### PR TITLE
Updated RBFFDWeightsCache to accept a rbf function.

### DIFF
--- a/include/ADS/RBFFDWeightsCache.h
+++ b/include/ADS/RBFFDWeightsCache.h
@@ -151,11 +151,11 @@ private:
 };
 
 /*!
- * \brief Class RBFFDWeightsCache is a concrete LaplaceOperator which implements
- * a globally second-order accurate cell-centered finite difference
- * discretization of a scalar elliptic operator of the form \f$ L = C I + \nabla
- * \cdot D \nabla\f$.
- */
+ * \brief Class RBFFDWeightsCache is a class that caches finite difference weights for general operators. This class
+ * requires a fe_mesh_partitioner and a level set function to determine which cells need finite difference weights.
+ * Three functions must be registered. The first is the RBF evaluated at a point r. The other two are the operator
+ * applied to the RBF evaluated at the point and a function that takes input a vector of inputs and returns the
+ * Vandermonde matrix of the linear operator applied to the monomials.*/
 class RBFFDWeightsCache
 {
 public:
@@ -190,9 +190,13 @@ public:
     const std::vector<UPoint>& getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const UPoint& pt);
     bool isRBFFDBasePoint(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> ptach, const UPoint& pt);
 
-    void registerPolyFcn(std::function<IBTK::MatrixXd(const std::vector<IBTK::VectorNd>&, int)> fcn)
+    void registerPolyFcn(std::function<IBTK::MatrixXd(const std::vector<IBTK::VectorNd>&, int)> poly_fcn,
+                         std::function<double(double)> rbf_fcn,
+                         std::function<double(double)> Lrbf_fcn)
     {
-        d_poly_fcn = fcn;
+        d_poly_fcn = poly_fcn;
+        d_rbf_fcn = rbf_fcn;
+        d_Lrbf_fcn = Lrbf_fcn;
     }
 
     void clearCache();
@@ -259,6 +263,7 @@ private:
     WeightVecMap d_pt_weight_vec;
 
     std::function<IBTK::MatrixXd(const std::vector<IBTK::VectorNd>&, int)> d_poly_fcn;
+    std::function<double(double)> d_rbf_fcn, d_Lrbf_fcn;
 
     bool d_weights_found = false;
 };

--- a/src/RBFFDWeightsCache.cpp
+++ b/src/RBFFDWeightsCache.cpp
@@ -305,13 +305,6 @@ RBFFDWeightsCache::findRBFFDWeights()
 {
     sortLagDOFsToCells();
     d_pt_weight_vec.clear();
-    auto rbf = [](const double r) -> double { return r * r * r * r * r + 2.0e-10; };
-#if (NDIM == 2)
-    auto lap_rbf = [](const double r) -> double { return 25.0 * r * r * r; };
-#endif
-#if (NDIM == 3)
-    auto lap_rbf = [](const double r) -> double { return 30.0 * r * r * r; };
-#endif
     Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(d_hierarchy->getFinestLevelNumber());
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
@@ -350,10 +343,10 @@ RBFFDWeightsCache::findRBFFDWeights()
                 {
                     VectorNd ptj = pt_vec[j].getVec();
                     for (int d = 0; d < NDIM; ++d) ptj[d] = ptj[d] / dx[d];
-                    A(i, j) = rbf((pti - ptj).norm());
+                    A(i, j) = d_rbf_fcn((pti - ptj).norm());
                 }
                 // Determine rhs
-                U(i) = lap_rbf((pt0 - pti).norm());
+                U(i) = d_Lrbf_fcn((pt0 - pti).norm());
             }
             // Add quadratic polynomials
             std::vector<VectorNd> zeros = { VectorNd::Zero() };

--- a/tests/operators/rbf_fd_weights.cpp
+++ b/tests/operators/rbf_fd_weights.cpp
@@ -276,8 +276,15 @@ main(int argc, char* argv[])
         auto poly_fcn = [](const std::vector<VectorNd>& pt_vec, int poly_degree) -> MatrixXd {
             return PolynomialBasis::laplacianMonomials(pt_vec, poly_degree);
         };
+        auto rbf_fcn = [](const double r) -> double { return r * r * r * r * r; };
+#if (NDIM == 2)
+        auto Lrbf_fcn = [](const double r) -> double { return 25.0 * r * r * r * r; };
+#endif
+#if (NDIM == 3)
+        auto Lrbf_fcn = [](const double r) -> double { return 30.0 * r * r * r * r; };
+#endif
         bool check_background_grid = input_db->getBool("CHECK_BACKGROUND_GRID_ONLY");
-        weights_op->registerPolyFcn(poly_fcn);
+        weights_op->registerPolyFcn(poly_fcn, rbf_fcn, Lrbf_fcn);
         weights_op->setLS(ls_idx);
         weights_op->findRBFFDWeights();
         {


### PR DESCRIPTION
Now three functions must be registered with RBFFDWeightsCache:

1. the RBF evaluated at a general point
2. the linear operator applied to the RBF evaluated at a general point
3. the linear operator applied to the monomials evaluated at a vector of points, generating a Vandermonde matrix.