### PR TITLE
Added a base class that caches FD weights, but does no computations.

### DIFF
--- a/include/ADS/FDWeightsCache.h
+++ b/include/ADS/FDWeightsCache.h
@@ -1,0 +1,346 @@
+/////////////////////////////// INCLUDE GUARD ////////////////////////////////
+
+#ifndef included_ADS_FDWeightsCache
+#define included_ADS_FDWeightsCache
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include <ibtk/config.h>
+
+#include "ADS/FEMeshPartitioner.h"
+
+#include "ibtk/HierarchyGhostCellInterpolation.h"
+#include "ibtk/LaplaceOperator.h"
+#include "ibtk/ibtk_utilities.h"
+
+#include "Box.h"
+#include "CartesianPatchGeometry.h"
+#include "IntVector.h"
+#include "PatchHierarchy.h"
+#include "SAMRAIVectorReal.h"
+#include "VariableFillPattern.h"
+#include "tbox/Pointer.h"
+
+#include "libmesh/boundary_mesh.h"
+#include "libmesh/dof_map.h"
+#include "libmesh/node.h"
+
+#include <string>
+#include <vector>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+namespace ADS
+{
+/*!
+ * Struct FDCachedPoint generalizes the notion of a degree of freedom. It is either a SAMRAI index, a libMesh Node, or a
+ * boundary Node. This allows for efficient caching of points, and quick lookups of individual points.
+ */
+struct FDCachedPoint
+{
+public:
+    /*!
+     * \brief Constructor that makes a SAMRAI point.
+     */
+    FDCachedPoint(const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch,
+                  const SAMRAI::pdat::CellIndex<NDIM>& idx)
+        : d_idx(idx)
+    {
+        SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
+        const double* const dx = pgeom->getDx();
+        const double* const xlow = pgeom->getXLower();
+        const SAMRAI::hier::Index<NDIM>& idx_low = patch->getBox().lower();
+        const SAMRAI::hier::Index<NDIM>& idx_up = patch->getBox().upper();
+        for (unsigned int d = 0; d < NDIM; ++d)
+            d_pt[d] = xlow[d] + dx[d] * (static_cast<double>(d_idx(d) - idx_low(d)) + 0.5);
+        for (unsigned int d = 0; d < (NDIM - 1); ++d) d_max_idx[d] = idx_up[d] - idx_low[d] + 1;
+    }
+
+    /*!
+     * \brief Constructor that makes either a libmesh or boundary point.
+     */
+    FDCachedPoint(const IBTK::VectorNd& pt, libMesh::Node* node, bool bdry_pt)
+        : d_pt(pt), d_node(node), d_bdry_pt(bdry_pt)
+    {
+        // intentionally blank
+    }
+
+    /*!
+     * \brief Constructor that leaves the object in an uninitialized state.
+     *
+     * \note This is used for compatibility with STL containers.
+     */
+    FDCachedPoint() : d_empty(true)
+    {
+        // intentionally blank
+    }
+
+    /*!
+     * \brief Constructor that takes in a point. Leaves in an uninitialized state, but able to compare distances.
+     *
+     * \note This is used for creation of KD-trees.
+     */
+    FDCachedPoint(const std::vector<double>& pt) : d_empty(true)
+    {
+        for (unsigned int d = 0; d < NDIM; ++d) d_pt[d] = pt[d];
+    }
+
+    /*!
+     * \brief Compute the distance between a point and the cached point.
+     */
+    double dist(const IBTK::VectorNd& x) const
+    {
+        return (d_pt - x).norm();
+    }
+
+    /*!
+     * \brief Compute the distance between another cached point and this point.
+     */
+    double dist(const FDCachedPoint& pt) const
+    {
+        return (d_pt - pt.getVec()).norm();
+    }
+
+    /*!
+     * \brief Return a copy of the ith point of the point.
+     */
+    double operator()(const size_t i) const
+    {
+        return d_pt(i);
+    }
+
+    /*!
+     * \brief Return a copy of the ith point of the point.
+     */
+    double operator[](const size_t i) const
+    {
+        return d_pt[i];
+    }
+
+    /*!
+     * \brief Print out the information of this point.
+     */
+    friend std::ostream& operator<<(std::ostream& out, const FDCachedPoint& pt)
+    {
+        out << "   location: " << pt.d_pt.transpose() << "\n";
+        out << "   is located on boundary: " << pt.d_bdry_pt << "\n";
+        if (pt.isNode())
+            out << "   node id: " << pt.d_node->id();
+        else if (!pt.isEmpty())
+            out << "   idx:     " << pt.d_idx;
+        else
+            out << "   pt is neither node nor index";
+        return out;
+    }
+
+    /*!
+     * \brief Comparison operator. Used for compatibility with STL containers.
+     */
+    friend bool operator==(const FDCachedPoint& lhs, const FDCachedPoint& rhs)
+    {
+        if (lhs.isNode() && rhs.isNode())
+        {
+            return (lhs.d_bdry_pt == rhs.d_bdry_pt) && (lhs.d_node == rhs.d_node);
+        }
+        else if (lhs.isIdx() && rhs.isIdx())
+        {
+            return lhs.d_idx == rhs.d_idx;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    /*!
+     * \brief Comparison operator. Used for compatibility with STL containers.
+     *
+     * The order of indexes is as follows:
+     * SAMRAI < libMesh < bdry < empty
+     */
+    friend bool operator<(const FDCachedPoint& lhs, const FDCachedPoint& rhs)
+    {
+        if (lhs.isIdx())
+        {
+            if (!rhs.isIdx()) return true;
+#if NDIM == 2
+            int l_idx = lhs.d_idx(0) + lhs.d_idx(1) * lhs.d_max_idx[0];
+            int r_idx = rhs.d_idx(0) + rhs.d_idx(1) * rhs.d_max_idx[0];
+#endif
+#if NDIM == 3
+            int l_idx =
+                lhs.d_idx(0) + lhs.d_idx(1) * lhs.d_max_idx[0] + lhs.d_idx(2) * lhs.d_max_idx[0] * lhs.d_max_idx[1];
+            int r_idx =
+                rhs.d_idx(0) + rhs.d_idx(1) * rhs.d_max_idx[0] + rhs.d_idx(2) * rhs.d_max_idx[0] * rhs.d_max_idx[1];
+#endif
+            return l_idx < r_idx;
+        }
+        else if (lhs.isNode())
+        {
+            if (rhs.isEmpty()) return true;
+            if (rhs.isIdx()) return false;
+            if (rhs.isBdry()) return true;
+            return lhs.d_node->id() < rhs.d_node->id();
+        }
+        else if (lhs.isBdry())
+        {
+            if (rhs.isEmpty()) return true;
+            if (!rhs.isBdry()) return false;
+            return lhs.d_node->id() < rhs.d_node->id();
+        }
+        return false;
+    }
+
+    /*!
+     * \brief Is this point actually initialized?
+     */
+    bool isEmpty() const
+    {
+        return d_empty;
+    }
+
+    /*!
+     * \brief Is this point a libMesh node?
+     */
+    bool isNode() const
+    {
+        return !d_bdry_pt && d_node != nullptr;
+    }
+
+    /*!
+     * \brief Is this point a SAMRAI point?
+     */
+    bool isIdx() const
+    {
+        return !isNode() && !isEmpty();
+    }
+
+    /*!
+     * \brief Is this point a boundary node?
+     */
+    bool isBdry() const
+    {
+        return d_bdry_pt;
+    }
+
+    /*!
+     * \brief Get the node pointer.
+     */
+    const libMesh::Node* const getNode() const
+    {
+        if (d_bdry_pt || !isNode()) TBOX_ERROR("Not at a node\n");
+        return d_node;
+    }
+
+    /*!
+     * \brief Get the SAMRAI index
+     */
+    const SAMRAI::pdat::CellIndex<NDIM>& getIndex() const
+    {
+        if (isNode()) TBOX_ERROR("At at node\n");
+        if (d_empty) TBOX_ERROR("Not a point\n");
+        return d_idx;
+    }
+
+    /*!
+     * \brief Get the physical location of the point.
+     */
+    const IBTK::VectorNd& getVec() const
+    {
+        return d_pt;
+    }
+
+private:
+    IBTK::VectorNd d_pt;
+    libMesh::Node* d_node = nullptr;
+    SAMRAI::pdat::CellIndex<NDIM> d_idx;
+    std::array<int, NDIM - 1> d_max_idx;
+    bool d_empty = false;
+    bool d_bdry_pt = false;
+};
+
+/*!
+ * \brief Class FDWeightsCache is a class that caches finite difference weights for general operators. This class
+ * requires that finite difference weights be registered. No calculations are done by this class.
+ */
+class FDWeightsCache
+{
+public:
+    /*!
+     * \brief Constructor
+     */
+    FDWeightsCache(std::string object_name);
+
+    /*!
+     * \brief Destructor.
+     */
+    virtual ~FDWeightsCache();
+
+    virtual void cachePoint(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
+                            const FDCachedPoint& pt,
+                            const std::vector<FDCachedPoint>& fd_pts,
+                            const std::vector<double>& fd_weights);
+
+    const std::map<FDCachedPoint, std::vector<double>>&
+    getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch);
+    const std::map<FDCachedPoint, std::vector<FDCachedPoint>>&
+    getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch);
+    const std::set<FDCachedPoint>& getRBFFDBasePoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch);
+
+    const std::vector<double>& getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
+                                               const FDCachedPoint& pt);
+    const std::vector<FDCachedPoint>& getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
+                                                     const FDCachedPoint& pt);
+    bool isRBFFDBasePoint(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDCachedPoint& pt);
+
+    virtual void clearCache();
+
+    /*!
+     * Debugging functions
+     */
+    virtual void printPtMap(std::ostream& os, SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy);
+
+protected:
+    std::string d_object_name;
+
+    // Weight and point information
+    using PtVecMap = std::map<SAMRAI::hier::Patch<NDIM>*, std::set<FDCachedPoint>>;
+    using PtPairVecMap = std::map<SAMRAI::hier::Patch<NDIM>*, std::map<FDCachedPoint, std::vector<FDCachedPoint>>>;
+    using WeightVecMap = std::map<SAMRAI::hier::Patch<NDIM>*, std::map<FDCachedPoint, std::vector<double>>>;
+    PtVecMap d_base_pt_set;
+    PtPairVecMap d_pair_pt_map;
+    WeightVecMap d_pt_weight_map;
+
+private:
+    /*!
+     * \brief Default constructor.
+     *
+     * \note This constructor is not implemented and should not be used.
+     */
+    FDWeightsCache() = delete;
+
+    /*!
+     * \brief Copy constructor.
+     *
+     * \note This constructor is not implemented and should not be used.
+     *
+     * \param from The value to copy to this object.
+     */
+    FDWeightsCache(const FDWeightsCache& from) = delete;
+
+    /*!
+     * \brief Assignment operator.
+     *
+     * \note This operator is not implemented and should not be used.
+     *
+     * \param that The value to assign to this object.
+     *
+     * \return A reference to this object.
+     */
+    FDWeightsCache& operator=(const FDWeightsCache& that) = delete;
+};
+} // namespace ADS
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif //#ifndef included_ADS_FDWeightsCache

--- a/include/ADS/RBFLaplaceOperator.h
+++ b/include/ADS/RBFLaplaceOperator.h
@@ -161,8 +161,8 @@ private:
 
     void applyToLagDOFs(int x_idx, int y_idx);
 
-    double getSolVal(const UPoint& pt, const SAMRAI::pdat::CellData<NDIM, double>& Q_data, Vec& vec) const;
-    void setSolVal(double q, const UPoint& pt, SAMRAI::pdat::CellData<NDIM, double>& Q_data, Vec& vec) const;
+    double getSolVal(const FDCachedPoint& pt, const SAMRAI::pdat::CellData<NDIM, double>& Q_data, Vec& vec) const;
+    void setSolVal(double q, const FDCachedPoint& pt, SAMRAI::pdat::CellData<NDIM, double>& Q_data, Vec& vec) const;
 
     // Operator parameters.
     int d_ncomp = 0;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ SET(CXX_SRC
     AdvectiveReconstructionOperator.cpp
     CutCellMeshMapping.cpp
     CutCellVolumeMeshMapping.cpp
+    FDWeightsCache.cpp
     FEMeshPartitioner.cpp
     GeneralBoundaryMeshMapping.cpp
     GhostPoints.cpp

--- a/src/FDWeightsCache.cpp
+++ b/src/FDWeightsCache.cpp
@@ -1,0 +1,152 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2021 - 2021 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include "ADS/FDWeightsCache.h"
+#include "ADS/KDTree.h"
+#include "ADS/PolynomialBasis.h"
+#include "ADS/app_namespaces.h" // IWYU pragma: keep
+#include "ADS/ls_functions.h"
+#include "ADS/reconstructions.h"
+
+#include "ibtk/CellNoCornersFillPattern.h"
+#include "ibtk/HierarchyMathOps.h"
+#include "ibtk/IBTK_CHKERRQ.h"
+#include "ibtk/IndexUtilities.h"
+#include "ibtk/ibtk_utilities.h"
+
+#include "CellVariable.h"
+#include "MultiblockDataTranslator.h"
+#include "PatchHierarchy.h"
+#include "PoissonSpecifications.h"
+#include "SAMRAIVectorReal.h"
+#include "VariableFillPattern.h"
+#include "tbox/Timer.h"
+
+#include <Eigen/Dense>
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+/////////////////////////////// NAMESPACE ////////////////////////////////////
+
+namespace ADS
+{
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+
+FDWeightsCache::FDWeightsCache(std::string object_name) : d_object_name(std::move(object_name))
+{
+    // intentionally blank
+    return;
+}
+
+FDWeightsCache::~FDWeightsCache()
+{
+    clearCache();
+    return;
+}
+
+void
+FDWeightsCache::clearCache()
+{
+    d_base_pt_set.clear();
+    d_pair_pt_map.clear();
+    d_pt_weight_map.clear();
+}
+
+void
+FDWeightsCache::cachePoint(Pointer<Patch<NDIM>> patch,
+                           const FDCachedPoint& pt,
+                           const std::vector<FDCachedPoint>& fd_pts,
+                           const std::vector<double>& fd_weights)
+{
+    // Cache the point. Replace it if it already exists
+    std::set<FDCachedPoint>& base_pt_set = d_base_pt_set[patch.getPointer()];
+    auto it = base_pt_set.find(pt);
+    if (it != base_pt_set.end()) base_pt_set.erase(it);
+    base_pt_set.insert(pt);
+    d_pair_pt_map[patch.getPointer()][pt] = fd_pts;
+    d_pt_weight_map[patch.getPointer()][pt] = fd_weights;
+}
+
+const std::map<FDCachedPoint, std::vector<double>>&
+FDWeightsCache::getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch)
+{
+    return d_pt_weight_map[patch.getPointer()];
+}
+
+const std::map<FDCachedPoint, std::vector<FDCachedPoint>>&
+FDWeightsCache::getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch)
+{
+    return d_pair_pt_map[patch.getPointer()];
+}
+
+const std::set<FDCachedPoint>&
+FDWeightsCache::getRBFFDBasePoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch)
+{
+    return d_base_pt_set[patch.getPointer()];
+}
+
+const std::vector<double>&
+FDWeightsCache::getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDCachedPoint& pt)
+{
+#if !defined(NDEBUG)
+    if (!isRBFFDBasePoint(patch, pt)) TBOX_ERROR("pt " << pt << " is not a base point on this patch");
+#endif
+    return d_pt_weight_map[patch.getPointer()][pt];
+}
+
+const std::vector<FDCachedPoint>&
+FDWeightsCache::getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDCachedPoint& pt)
+{
+#if !defined(NDEBUG)
+    if (!isRBFFDBasePoint(patch, pt)) TBOX_ERROR("pt " << pt << " is not a base point on this patch");
+#endif
+    return d_pair_pt_map[patch.getPointer()][pt];
+}
+
+bool
+FDWeightsCache::isRBFFDBasePoint(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDCachedPoint& pt)
+{
+    return d_base_pt_set[patch.getPointer()].find(pt) != d_base_pt_set[patch.getPointer()].end();
+}
+
+void
+FDWeightsCache::printPtMap(std::ostream& os, Pointer<PatchHierarchy<NDIM>> hierarchy)
+{
+    const int ln = hierarchy->getFinestLevelNumber();
+    Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+    unsigned int patch_num = 0;
+    for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++patch_num)
+    {
+        Pointer<Patch<NDIM>> patch = level->getPatch(p());
+        os << "On patch number: " << patch_num << "\n";
+        os << "There are " << d_base_pt_set[patch.getPointer()].size() << " key-value pairs present\n";
+        for (const auto& pt : d_base_pt_set[patch.getPointer()])
+        {
+            const std::vector<FDCachedPoint>& pt_vec = d_pair_pt_map[patch.getPointer()][pt];
+            os << "  Looking at point:\n" << pt << "\n";
+            os << "  Has points: \n";
+            for (const auto& pt_from_vec : pt_vec) os << pt_from_vec << "\n";
+        }
+        os << "\n";
+    }
+}
+//////////////////////////////////////////////////////////////////////////////
+
+} // namespace ADS
+
+//////////////////////////////////////////////////////////////////////////////

--- a/tests/operators/rbf_fd_weights.cpp
+++ b/tests/operators/rbf_fd_weights.cpp
@@ -294,13 +294,13 @@ main(int argc, char* argv[])
             for (PatchLevel<NDIM>::Iterator p(level); p; p++)
             {
                 Pointer<Patch<NDIM>> patch = level->getPatch(p());
-                const std::vector<UPoint>& pts = weights_op->getRBFFDBasePoints(patch);
+                const std::set<FDCachedPoint>& pts = weights_op->getRBFFDBasePoints(patch);
                 for (const auto& pt : pts)
                 {
                     if (pt.isNode()) continue;
                     plog << "On point: " << pt << "\n";
                     const std::vector<double>& weights = weights_op->getRBFFDWeights(patch, pt);
-                    const std::vector<UPoint>& other_pts = weights_op->getRBFFDPoints(patch, pt);
+                    const std::vector<FDCachedPoint>& other_pts = weights_op->getRBFFDPoints(patch, pt);
                     bool print_these = true;
                     if (check_background_grid)
                     {

--- a/tests/operators/rbf_fd_weights_2d.output
+++ b/tests/operators/rbf_fd_weights_2d.output
@@ -1,3168 +1,4224 @@
 On point:    location: -1.875 -1.875
+   is located on boundary: 0
    idx:     (0,0)
 pt[0]:    location: -1.875 -1.875
+   is located on boundary: 0
    idx:     (0,0)
 With weight: -64
 pt[1]:    location: -1.875 -2.125
+   is located on boundary: 0
    idx:     (0,-1)
 With weight: 16
 pt[2]:    location: -2.125 -1.875
+   is located on boundary: 0
    idx:     (-1,0)
 With weight: 16
 pt[3]:    location: -1.625 -1.875
+   is located on boundary: 0
    idx:     (1,0)
 With weight: 16
 pt[4]:    location: -1.875 -1.625
+   is located on boundary: 0
    idx:     (0,1)
 With weight: 16
 
 On point:    location: -1.625 -1.875
+   is located on boundary: 0
    idx:     (1,0)
 pt[0]:    location: -1.625 -1.875
+   is located on boundary: 0
    idx:     (1,0)
 With weight: -64
 pt[1]:    location: -1.625 -2.125
+   is located on boundary: 0
    idx:     (1,-1)
 With weight: 16
 pt[2]:    location: -1.875 -1.875
+   is located on boundary: 0
    idx:     (0,0)
 With weight: 16
 pt[3]:    location: -1.375 -1.875
+   is located on boundary: 0
    idx:     (2,0)
 With weight: 16
 pt[4]:    location: -1.625 -1.625
+   is located on boundary: 0
    idx:     (1,1)
 With weight: 16
 
 On point:    location: -1.375 -1.875
+   is located on boundary: 0
    idx:     (2,0)
 pt[0]:    location: -1.375 -1.875
+   is located on boundary: 0
    idx:     (2,0)
 With weight: -64
 pt[1]:    location: -1.375 -2.125
+   is located on boundary: 0
    idx:     (2,-1)
 With weight: 16
 pt[2]:    location: -1.625 -1.875
+   is located on boundary: 0
    idx:     (1,0)
 With weight: 16
 pt[3]:    location: -1.125 -1.875
+   is located on boundary: 0
    idx:     (3,0)
 With weight: 16
 pt[4]:    location: -1.375 -1.625
+   is located on boundary: 0
    idx:     (2,1)
 With weight: 16
 
 On point:    location: -1.125 -1.875
+   is located on boundary: 0
    idx:     (3,0)
 pt[0]:    location: -1.125 -1.875
+   is located on boundary: 0
    idx:     (3,0)
 With weight: -64
 pt[1]:    location: -1.125 -2.125
+   is located on boundary: 0
    idx:     (3,-1)
 With weight: 16
 pt[2]:    location: -1.375 -1.875
+   is located on boundary: 0
    idx:     (2,0)
 With weight: 16
 pt[3]:    location: -0.875 -1.875
+   is located on boundary: 0
    idx:     (4,0)
 With weight: 16
 pt[4]:    location: -1.125 -1.625
+   is located on boundary: 0
    idx:     (3,1)
 With weight: 16
 
 On point:    location: -0.875 -1.875
+   is located on boundary: 0
    idx:     (4,0)
 pt[0]:    location: -0.875 -1.875
+   is located on boundary: 0
    idx:     (4,0)
 With weight: -64
 pt[1]:    location: -0.875 -2.125
+   is located on boundary: 0
    idx:     (4,-1)
 With weight: 16
 pt[2]:    location: -1.125 -1.875
+   is located on boundary: 0
    idx:     (3,0)
 With weight: 16
 pt[3]:    location: -0.625 -1.875
+   is located on boundary: 0
    idx:     (5,0)
 With weight: 16
 pt[4]:    location: -0.875 -1.625
+   is located on boundary: 0
    idx:     (4,1)
 With weight: 16
 
 On point:    location: -0.625 -1.875
+   is located on boundary: 0
    idx:     (5,0)
 pt[0]:    location: -0.625 -1.875
+   is located on boundary: 0
    idx:     (5,0)
 With weight: -64
 pt[1]:    location: -0.625 -2.125
+   is located on boundary: 0
    idx:     (5,-1)
 With weight: 16
 pt[2]:    location: -0.875 -1.875
+   is located on boundary: 0
    idx:     (4,0)
 With weight: 16
 pt[3]:    location: -0.375 -1.875
+   is located on boundary: 0
    idx:     (6,0)
 With weight: 16
 pt[4]:    location: -0.625 -1.625
+   is located on boundary: 0
    idx:     (5,1)
 With weight: 16
 
 On point:    location: -0.375 -1.875
+   is located on boundary: 0
    idx:     (6,0)
 pt[0]:    location: -0.375 -1.875
+   is located on boundary: 0
    idx:     (6,0)
 With weight: -64
 pt[1]:    location: -0.375 -2.125
+   is located on boundary: 0
    idx:     (6,-1)
 With weight: 16
 pt[2]:    location: -0.625 -1.875
+   is located on boundary: 0
    idx:     (5,0)
 With weight: 16
 pt[3]:    location: -0.125 -1.875
+   is located on boundary: 0
    idx:     (7,0)
 With weight: 16
 pt[4]:    location: -0.375 -1.625
+   is located on boundary: 0
    idx:     (6,1)
 With weight: 16
 
 On point:    location: -0.125 -1.875
+   is located on boundary: 0
    idx:     (7,0)
 pt[0]:    location: -0.125 -1.875
+   is located on boundary: 0
    idx:     (7,0)
 With weight: -64
 pt[1]:    location: -0.125 -2.125
+   is located on boundary: 0
    idx:     (7,-1)
 With weight: 16
 pt[2]:    location: -0.375 -1.875
+   is located on boundary: 0
    idx:     (6,0)
 With weight: 16
 pt[3]:    location:  0.125 -1.875
+   is located on boundary: 0
    idx:     (8,0)
 With weight: 16
 pt[4]:    location: -0.125 -1.625
+   is located on boundary: 0
    idx:     (7,1)
 With weight: 16
 
 On point:    location:  0.125 -1.875
+   is located on boundary: 0
    idx:     (8,0)
 pt[0]:    location:  0.125 -1.875
+   is located on boundary: 0
    idx:     (8,0)
 With weight: -64
 pt[1]:    location:  0.125 -2.125
+   is located on boundary: 0
    idx:     (8,-1)
 With weight: 16
 pt[2]:    location: -0.125 -1.875
+   is located on boundary: 0
    idx:     (7,0)
 With weight: 16
 pt[3]:    location:  0.375 -1.875
+   is located on boundary: 0
    idx:     (9,0)
 With weight: 16
 pt[4]:    location:  0.125 -1.625
+   is located on boundary: 0
    idx:     (8,1)
 With weight: 16
 
 On point:    location:  0.375 -1.875
+   is located on boundary: 0
    idx:     (9,0)
 pt[0]:    location:  0.375 -1.875
+   is located on boundary: 0
    idx:     (9,0)
 With weight: -64
 pt[1]:    location:  0.375 -2.125
+   is located on boundary: 0
    idx:     (9,-1)
 With weight: 16
 pt[2]:    location:  0.125 -1.875
+   is located on boundary: 0
    idx:     (8,0)
 With weight: 16
 pt[3]:    location:  0.625 -1.875
+   is located on boundary: 0
    idx:     (10,0)
 With weight: 16
 pt[4]:    location:  0.375 -1.625
+   is located on boundary: 0
    idx:     (9,1)
 With weight: 16
 
 On point:    location:  0.625 -1.875
+   is located on boundary: 0
    idx:     (10,0)
 pt[0]:    location:  0.625 -1.875
+   is located on boundary: 0
    idx:     (10,0)
 With weight: -64
 pt[1]:    location:  0.625 -2.125
+   is located on boundary: 0
    idx:     (10,-1)
 With weight: 16
 pt[2]:    location:  0.375 -1.875
+   is located on boundary: 0
    idx:     (9,0)
 With weight: 16
 pt[3]:    location:  0.875 -1.875
+   is located on boundary: 0
    idx:     (11,0)
 With weight: 16
 pt[4]:    location:  0.625 -1.625
+   is located on boundary: 0
    idx:     (10,1)
 With weight: 16
 
 On point:    location:  0.875 -1.875
+   is located on boundary: 0
    idx:     (11,0)
 pt[0]:    location:  0.875 -1.875
+   is located on boundary: 0
    idx:     (11,0)
 With weight: -64
 pt[1]:    location:  0.875 -2.125
+   is located on boundary: 0
    idx:     (11,-1)
 With weight: 16
 pt[2]:    location:  0.625 -1.875
+   is located on boundary: 0
    idx:     (10,0)
 With weight: 16
 pt[3]:    location:  1.125 -1.875
+   is located on boundary: 0
    idx:     (12,0)
 With weight: 16
 pt[4]:    location:  0.875 -1.625
+   is located on boundary: 0
    idx:     (11,1)
 With weight: 16
 
 On point:    location:  1.125 -1.875
+   is located on boundary: 0
    idx:     (12,0)
 pt[0]:    location:  1.125 -1.875
+   is located on boundary: 0
    idx:     (12,0)
 With weight: -64
 pt[1]:    location:  1.125 -2.125
+   is located on boundary: 0
    idx:     (12,-1)
 With weight: 16
 pt[2]:    location:  0.875 -1.875
+   is located on boundary: 0
    idx:     (11,0)
 With weight: 16
 pt[3]:    location:  1.375 -1.875
+   is located on boundary: 0
    idx:     (13,0)
 With weight: 16
 pt[4]:    location:  1.125 -1.625
+   is located on boundary: 0
    idx:     (12,1)
 With weight: 16
 
 On point:    location:  1.375 -1.875
+   is located on boundary: 0
    idx:     (13,0)
 pt[0]:    location:  1.375 -1.875
+   is located on boundary: 0
    idx:     (13,0)
 With weight: -64
 pt[1]:    location:  1.375 -2.125
+   is located on boundary: 0
    idx:     (13,-1)
 With weight: 16
 pt[2]:    location:  1.125 -1.875
+   is located on boundary: 0
    idx:     (12,0)
 With weight: 16
 pt[3]:    location:  1.625 -1.875
+   is located on boundary: 0
    idx:     (14,0)
 With weight: 16
 pt[4]:    location:  1.375 -1.625
+   is located on boundary: 0
    idx:     (13,1)
 With weight: 16
 
 On point:    location:  1.625 -1.875
+   is located on boundary: 0
    idx:     (14,0)
 pt[0]:    location:  1.625 -1.875
+   is located on boundary: 0
    idx:     (14,0)
 With weight: -64
 pt[1]:    location:  1.625 -2.125
+   is located on boundary: 0
    idx:     (14,-1)
 With weight: 16
 pt[2]:    location:  1.375 -1.875
+   is located on boundary: 0
    idx:     (13,0)
 With weight: 16
 pt[3]:    location:  1.875 -1.875
+   is located on boundary: 0
    idx:     (15,0)
 With weight: 16
 pt[4]:    location:  1.625 -1.625
+   is located on boundary: 0
    idx:     (14,1)
 With weight: 16
 
 On point:    location:  1.875 -1.875
+   is located on boundary: 0
    idx:     (15,0)
 pt[0]:    location:  1.875 -1.875
+   is located on boundary: 0
    idx:     (15,0)
 With weight: -64
 pt[1]:    location:  1.875 -2.125
+   is located on boundary: 0
    idx:     (15,-1)
 With weight: 16
 pt[2]:    location:  1.625 -1.875
+   is located on boundary: 0
    idx:     (14,0)
 With weight: 16
 pt[3]:    location:  2.125 -1.875
+   is located on boundary: 0
    idx:     (16,0)
 With weight: 16
 pt[4]:    location:  1.875 -1.625
+   is located on boundary: 0
    idx:     (15,1)
 With weight: 16
 
 On point:    location: -1.875 -1.625
+   is located on boundary: 0
    idx:     (0,1)
 pt[0]:    location: -1.875 -1.625
+   is located on boundary: 0
    idx:     (0,1)
 With weight: -64
 pt[1]:    location: -1.875 -1.875
+   is located on boundary: 0
    idx:     (0,0)
 With weight: 16
 pt[2]:    location: -2.125 -1.625
+   is located on boundary: 0
    idx:     (-1,1)
 With weight: 16
 pt[3]:    location: -1.625 -1.625
+   is located on boundary: 0
    idx:     (1,1)
 With weight: 16
 pt[4]:    location: -1.875 -1.375
+   is located on boundary: 0
    idx:     (0,2)
 With weight: 16
 
 On point:    location: -1.625 -1.625
+   is located on boundary: 0
    idx:     (1,1)
 pt[0]:    location: -1.625 -1.625
+   is located on boundary: 0
    idx:     (1,1)
 With weight: -64
 pt[1]:    location: -1.625 -1.875
+   is located on boundary: 0
    idx:     (1,0)
 With weight: 16
 pt[2]:    location: -1.875 -1.625
+   is located on boundary: 0
    idx:     (0,1)
 With weight: 16
 pt[3]:    location: -1.375 -1.625
+   is located on boundary: 0
    idx:     (2,1)
 With weight: 16
 pt[4]:    location: -1.625 -1.375
+   is located on boundary: 0
    idx:     (1,2)
 With weight: 16
 
 On point:    location: -1.375 -1.625
+   is located on boundary: 0
    idx:     (2,1)
 pt[0]:    location: -1.375 -1.625
+   is located on boundary: 0
    idx:     (2,1)
 With weight: -64
 pt[1]:    location: -1.375 -1.875
+   is located on boundary: 0
    idx:     (2,0)
 With weight: 16
 pt[2]:    location: -1.625 -1.625
+   is located on boundary: 0
    idx:     (1,1)
 With weight: 16
 pt[3]:    location: -1.125 -1.625
+   is located on boundary: 0
    idx:     (3,1)
 With weight: 16
 pt[4]:    location: -1.375 -1.375
+   is located on boundary: 0
    idx:     (2,2)
 With weight: 16
 
 On point:    location: -1.125 -1.625
+   is located on boundary: 0
    idx:     (3,1)
 pt[0]:    location: -1.125 -1.625
+   is located on boundary: 0
    idx:     (3,1)
 With weight: -64
 pt[1]:    location: -1.125 -1.875
+   is located on boundary: 0
    idx:     (3,0)
 With weight: 16
 pt[2]:    location: -1.375 -1.625
+   is located on boundary: 0
    idx:     (2,1)
 With weight: 16
 pt[3]:    location: -0.875 -1.625
+   is located on boundary: 0
    idx:     (4,1)
 With weight: 16
 pt[4]:    location: -1.125 -1.375
+   is located on boundary: 0
    idx:     (3,2)
 With weight: 16
 
 On point:    location: -0.875 -1.625
+   is located on boundary: 0
    idx:     (4,1)
 pt[0]:    location: -0.875 -1.625
+   is located on boundary: 0
    idx:     (4,1)
 With weight: -64
 pt[1]:    location: -0.875 -1.875
+   is located on boundary: 0
    idx:     (4,0)
 With weight: 16
 pt[2]:    location: -1.125 -1.625
+   is located on boundary: 0
    idx:     (3,1)
 With weight: 16
 pt[3]:    location: -0.625 -1.625
+   is located on boundary: 0
    idx:     (5,1)
 With weight: 16
 pt[4]:    location: -0.875 -1.375
+   is located on boundary: 0
    idx:     (4,2)
 With weight: 16
 
 On point:    location: -0.625 -1.625
+   is located on boundary: 0
    idx:     (5,1)
 pt[0]:    location: -0.625 -1.625
+   is located on boundary: 0
    idx:     (5,1)
 With weight: -64
 pt[1]:    location: -0.625 -1.875
+   is located on boundary: 0
    idx:     (5,0)
 With weight: 16
 pt[2]:    location: -0.875 -1.625
+   is located on boundary: 0
    idx:     (4,1)
 With weight: 16
 pt[3]:    location: -0.375 -1.625
+   is located on boundary: 0
    idx:     (6,1)
 With weight: 16
 pt[4]:    location: -0.625 -1.375
+   is located on boundary: 0
    idx:     (5,2)
 With weight: 16
 
 On point:    location: -0.375 -1.625
+   is located on boundary: 0
    idx:     (6,1)
 pt[0]:    location: -0.375 -1.625
+   is located on boundary: 0
    idx:     (6,1)
 With weight: -64
 pt[1]:    location: -0.375 -1.875
+   is located on boundary: 0
    idx:     (6,0)
 With weight: 16
 pt[2]:    location: -0.625 -1.625
+   is located on boundary: 0
    idx:     (5,1)
 With weight: 16
 pt[3]:    location: -0.125 -1.625
+   is located on boundary: 0
    idx:     (7,1)
 With weight: 16
 pt[4]:    location: -0.375 -1.375
+   is located on boundary: 0
    idx:     (6,2)
 With weight: 16
 
 On point:    location: -0.125 -1.625
+   is located on boundary: 0
    idx:     (7,1)
 pt[0]:    location: -0.125 -1.625
+   is located on boundary: 0
    idx:     (7,1)
 With weight: -64
 pt[1]:    location: -0.125 -1.875
+   is located on boundary: 0
    idx:     (7,0)
 With weight: 16
 pt[2]:    location: -0.375 -1.625
+   is located on boundary: 0
    idx:     (6,1)
 With weight: 16
 pt[3]:    location:  0.125 -1.625
+   is located on boundary: 0
    idx:     (8,1)
 With weight: 16
 pt[4]:    location: -0.125 -1.375
+   is located on boundary: 0
    idx:     (7,2)
 With weight: 16
 
 On point:    location:  0.125 -1.625
+   is located on boundary: 0
    idx:     (8,1)
 pt[0]:    location:  0.125 -1.625
+   is located on boundary: 0
    idx:     (8,1)
 With weight: -64
 pt[1]:    location:  0.125 -1.875
+   is located on boundary: 0
    idx:     (8,0)
 With weight: 16
 pt[2]:    location: -0.125 -1.625
+   is located on boundary: 0
    idx:     (7,1)
 With weight: 16
 pt[3]:    location:  0.375 -1.625
+   is located on boundary: 0
    idx:     (9,1)
 With weight: 16
 pt[4]:    location:  0.125 -1.375
+   is located on boundary: 0
    idx:     (8,2)
 With weight: 16
 
 On point:    location:  0.375 -1.625
+   is located on boundary: 0
    idx:     (9,1)
 pt[0]:    location:  0.375 -1.625
+   is located on boundary: 0
    idx:     (9,1)
 With weight: -64
 pt[1]:    location:  0.375 -1.875
+   is located on boundary: 0
    idx:     (9,0)
 With weight: 16
 pt[2]:    location:  0.125 -1.625
+   is located on boundary: 0
    idx:     (8,1)
 With weight: 16
 pt[3]:    location:  0.625 -1.625
+   is located on boundary: 0
    idx:     (10,1)
 With weight: 16
 pt[4]:    location:  0.375 -1.375
+   is located on boundary: 0
    idx:     (9,2)
 With weight: 16
 
 On point:    location:  0.625 -1.625
+   is located on boundary: 0
    idx:     (10,1)
 pt[0]:    location:  0.625 -1.625
+   is located on boundary: 0
    idx:     (10,1)
 With weight: -64
 pt[1]:    location:  0.625 -1.875
+   is located on boundary: 0
    idx:     (10,0)
 With weight: 16
 pt[2]:    location:  0.375 -1.625
+   is located on boundary: 0
    idx:     (9,1)
 With weight: 16
 pt[3]:    location:  0.875 -1.625
+   is located on boundary: 0
    idx:     (11,1)
 With weight: 16
 pt[4]:    location:  0.625 -1.375
+   is located on boundary: 0
    idx:     (10,2)
 With weight: 16
 
 On point:    location:  0.875 -1.625
+   is located on boundary: 0
    idx:     (11,1)
 pt[0]:    location:  0.875 -1.625
+   is located on boundary: 0
    idx:     (11,1)
 With weight: -64
 pt[1]:    location:  0.875 -1.875
+   is located on boundary: 0
    idx:     (11,0)
 With weight: 16
 pt[2]:    location:  0.625 -1.625
+   is located on boundary: 0
    idx:     (10,1)
 With weight: 16
 pt[3]:    location:  1.125 -1.625
+   is located on boundary: 0
    idx:     (12,1)
 With weight: 16
 pt[4]:    location:  0.875 -1.375
+   is located on boundary: 0
    idx:     (11,2)
 With weight: 16
 
 On point:    location:  1.125 -1.625
+   is located on boundary: 0
    idx:     (12,1)
 pt[0]:    location:  1.125 -1.625
+   is located on boundary: 0
    idx:     (12,1)
 With weight: -64
 pt[1]:    location:  1.125 -1.875
+   is located on boundary: 0
    idx:     (12,0)
 With weight: 16
 pt[2]:    location:  0.875 -1.625
+   is located on boundary: 0
    idx:     (11,1)
 With weight: 16
 pt[3]:    location:  1.375 -1.625
+   is located on boundary: 0
    idx:     (13,1)
 With weight: 16
 pt[4]:    location:  1.125 -1.375
+   is located on boundary: 0
    idx:     (12,2)
 With weight: 16
 
 On point:    location:  1.375 -1.625
+   is located on boundary: 0
    idx:     (13,1)
 pt[0]:    location:  1.375 -1.625
+   is located on boundary: 0
    idx:     (13,1)
 With weight: -64
 pt[1]:    location:  1.375 -1.875
+   is located on boundary: 0
    idx:     (13,0)
 With weight: 16
 pt[2]:    location:  1.125 -1.625
+   is located on boundary: 0
    idx:     (12,1)
 With weight: 16
 pt[3]:    location:  1.625 -1.625
+   is located on boundary: 0
    idx:     (14,1)
 With weight: 16
 pt[4]:    location:  1.375 -1.375
+   is located on boundary: 0
    idx:     (13,2)
 With weight: 16
 
 On point:    location:  1.625 -1.625
+   is located on boundary: 0
    idx:     (14,1)
 pt[0]:    location:  1.625 -1.625
+   is located on boundary: 0
    idx:     (14,1)
 With weight: -64
 pt[1]:    location:  1.625 -1.875
+   is located on boundary: 0
    idx:     (14,0)
 With weight: 16
 pt[2]:    location:  1.375 -1.625
+   is located on boundary: 0
    idx:     (13,1)
 With weight: 16
 pt[3]:    location:  1.875 -1.625
+   is located on boundary: 0
    idx:     (15,1)
 With weight: 16
 pt[4]:    location:  1.625 -1.375
+   is located on boundary: 0
    idx:     (14,2)
 With weight: 16
 
 On point:    location:  1.875 -1.625
+   is located on boundary: 0
    idx:     (15,1)
 pt[0]:    location:  1.875 -1.625
+   is located on boundary: 0
    idx:     (15,1)
 With weight: -64
 pt[1]:    location:  1.875 -1.875
+   is located on boundary: 0
    idx:     (15,0)
 With weight: 16
 pt[2]:    location:  1.625 -1.625
+   is located on boundary: 0
    idx:     (14,1)
 With weight: 16
 pt[3]:    location:  2.125 -1.625
+   is located on boundary: 0
    idx:     (16,1)
 With weight: 16
 pt[4]:    location:  1.875 -1.375
+   is located on boundary: 0
    idx:     (15,2)
 With weight: 16
 
 On point:    location: -1.875 -1.375
+   is located on boundary: 0
    idx:     (0,2)
 pt[0]:    location: -1.875 -1.375
+   is located on boundary: 0
    idx:     (0,2)
 With weight: -64
 pt[1]:    location: -1.875 -1.625
+   is located on boundary: 0
    idx:     (0,1)
 With weight: 16
 pt[2]:    location: -2.125 -1.375
+   is located on boundary: 0
    idx:     (-1,2)
 With weight: 16
 pt[3]:    location: -1.625 -1.375
+   is located on boundary: 0
    idx:     (1,2)
 With weight: 16
 pt[4]:    location: -1.875 -1.125
+   is located on boundary: 0
    idx:     (0,3)
 With weight: 16
 
 On point:    location: -1.625 -1.375
+   is located on boundary: 0
    idx:     (1,2)
 pt[0]:    location: -1.625 -1.375
+   is located on boundary: 0
    idx:     (1,2)
 With weight: -64
 pt[1]:    location: -1.625 -1.625
+   is located on boundary: 0
    idx:     (1,1)
 With weight: 16
 pt[2]:    location: -1.875 -1.375
+   is located on boundary: 0
    idx:     (0,2)
 With weight: 16
 pt[3]:    location: -1.375 -1.375
+   is located on boundary: 0
    idx:     (2,2)
 With weight: 16
 pt[4]:    location: -1.625 -1.125
+   is located on boundary: 0
    idx:     (1,3)
 With weight: 16
 
 On point:    location: -1.375 -1.375
+   is located on boundary: 0
    idx:     (2,2)
 pt[0]:    location: -1.375 -1.375
+   is located on boundary: 0
    idx:     (2,2)
 With weight: -64
 pt[1]:    location: -1.375 -1.625
+   is located on boundary: 0
    idx:     (2,1)
 With weight: 16
 pt[2]:    location: -1.625 -1.375
+   is located on boundary: 0
    idx:     (1,2)
 With weight: 16
 pt[3]:    location: -1.125 -1.375
+   is located on boundary: 0
    idx:     (3,2)
 With weight: 16
 pt[4]:    location: -1.375 -1.125
+   is located on boundary: 0
    idx:     (2,3)
 With weight: 16
 
 On point:    location: -1.125 -1.375
+   is located on boundary: 0
    idx:     (3,2)
 pt[0]:    location: -1.125 -1.375
+   is located on boundary: 0
    idx:     (3,2)
 With weight: -64
 pt[1]:    location: -1.125 -1.625
+   is located on boundary: 0
    idx:     (3,1)
 With weight: 16
 pt[2]:    location: -1.375 -1.375
+   is located on boundary: 0
    idx:     (2,2)
 With weight: 16
 pt[3]:    location: -0.875 -1.375
+   is located on boundary: 0
    idx:     (4,2)
 With weight: 16
 pt[4]:    location: -1.125 -1.125
+   is located on boundary: 0
    idx:     (3,3)
 With weight: 16
 
 On point:    location: -0.875 -1.375
+   is located on boundary: 0
    idx:     (4,2)
 pt[0]:    location: -0.875 -1.375
+   is located on boundary: 0
    idx:     (4,2)
 With weight: -64
 pt[1]:    location: -0.875 -1.625
+   is located on boundary: 0
    idx:     (4,1)
 With weight: 16
 pt[2]:    location: -1.125 -1.375
+   is located on boundary: 0
    idx:     (3,2)
 With weight: 16
 pt[3]:    location: -0.625 -1.375
+   is located on boundary: 0
    idx:     (5,2)
 With weight: 16
 pt[4]:    location: -0.875 -1.125
+   is located on boundary: 0
    idx:     (4,3)
 With weight: 16
 
 On point:    location: -0.625 -1.375
+   is located on boundary: 0
    idx:     (5,2)
 pt[0]:    location: -0.625 -1.375
+   is located on boundary: 0
    idx:     (5,2)
 With weight: -64
 pt[1]:    location: -0.625 -1.625
+   is located on boundary: 0
    idx:     (5,1)
 With weight: 16
 pt[2]:    location: -0.875 -1.375
+   is located on boundary: 0
    idx:     (4,2)
 With weight: 16
 pt[3]:    location: -0.375 -1.375
+   is located on boundary: 0
    idx:     (6,2)
 With weight: 16
 pt[4]:    location: -0.625 -1.125
+   is located on boundary: 0
    idx:     (5,3)
 With weight: 16
 
 On point:    location: -0.375 -1.375
+   is located on boundary: 0
    idx:     (6,2)
 pt[0]:    location: -0.375 -1.375
+   is located on boundary: 0
    idx:     (6,2)
 With weight: -42.6667
 pt[1]:    location: -0.375 -1.625
+   is located on boundary: 0
    idx:     (6,1)
 With weight: 10.6667
 pt[2]:    location: -0.625 -1.375
+   is located on boundary: 0
    idx:     (5,2)
 With weight: 16
 pt[3]:    location: -0.125 -1.375
+   is located on boundary: 0
    idx:     (7,2)
 With weight: 16
 pt[4]:    location: -0.625 -1.625
+   is located on boundary: 0
    idx:     (5,1)
-With weight: -7.22782e-15
+With weight: -2.03742e-15
 
 On point:    location: -0.125 -1.375
+   is located on boundary: 0
    idx:     (7,2)
 pt[0]:    location: -0.125 -1.375
+   is located on boundary: 0
    idx:     (7,2)
 With weight: -42.6667
 pt[1]:    location: -0.125 -1.625
+   is located on boundary: 0
    idx:     (7,1)
 With weight: 10.6667
 pt[2]:    location: -0.375 -1.375
+   is located on boundary: 0
    idx:     (6,2)
 With weight: 16
 pt[3]:    location:  0.125 -1.375
+   is located on boundary: 0
    idx:     (8,2)
 With weight: 16
 pt[4]:    location: -0.375 -1.625
+   is located on boundary: 0
    idx:     (6,1)
-With weight: -7.22782e-15
+With weight: -2.03742e-15
 
 On point:    location:  0.125 -1.375
+   is located on boundary: 0
    idx:     (8,2)
 pt[0]:    location:  0.125 -1.375
+   is located on boundary: 0
    idx:     (8,2)
 With weight: -42.6667
 pt[1]:    location:  0.125 -1.625
+   is located on boundary: 0
    idx:     (8,1)
 With weight: 10.6667
 pt[2]:    location: -0.125 -1.375
+   is located on boundary: 0
    idx:     (7,2)
 With weight: 16
 pt[3]:    location:  0.375 -1.375
+   is located on boundary: 0
    idx:     (9,2)
 With weight: 16
 pt[4]:    location: -0.125 -1.625
+   is located on boundary: 0
    idx:     (7,1)
-With weight: -7.22782e-15
+With weight: -2.03742e-15
 
 On point:    location:  0.375 -1.375
+   is located on boundary: 0
    idx:     (9,2)
 pt[0]:    location:  0.375 -1.375
+   is located on boundary: 0
    idx:     (9,2)
 With weight: -42.6667
 pt[1]:    location:  0.375 -1.625
+   is located on boundary: 0
    idx:     (9,1)
 With weight: 10.6667
 pt[2]:    location:  0.125 -1.375
+   is located on boundary: 0
    idx:     (8,2)
 With weight: 16
 pt[3]:    location:  0.625 -1.375
+   is located on boundary: 0
    idx:     (10,2)
 With weight: 16
 pt[4]:    location:  0.125 -1.625
+   is located on boundary: 0
    idx:     (8,1)
-With weight: -7.22782e-15
+With weight: -2.03742e-15
 
 On point:    location:  0.625 -1.375
+   is located on boundary: 0
    idx:     (10,2)
 pt[0]:    location:  0.625 -1.375
+   is located on boundary: 0
    idx:     (10,2)
 With weight: -64
 pt[1]:    location:  0.625 -1.625
+   is located on boundary: 0
    idx:     (10,1)
 With weight: 16
 pt[2]:    location:  0.375 -1.375
+   is located on boundary: 0
    idx:     (9,2)
 With weight: 16
 pt[3]:    location:  0.875 -1.375
+   is located on boundary: 0
    idx:     (11,2)
 With weight: 16
 pt[4]:    location:  0.625 -1.125
+   is located on boundary: 0
    idx:     (10,3)
 With weight: 16
 
 On point:    location:  0.875 -1.375
+   is located on boundary: 0
    idx:     (11,2)
 pt[0]:    location:  0.875 -1.375
+   is located on boundary: 0
    idx:     (11,2)
 With weight: -64
 pt[1]:    location:  0.875 -1.625
+   is located on boundary: 0
    idx:     (11,1)
 With weight: 16
 pt[2]:    location:  0.625 -1.375
+   is located on boundary: 0
    idx:     (10,2)
 With weight: 16
 pt[3]:    location:  1.125 -1.375
+   is located on boundary: 0
    idx:     (12,2)
 With weight: 16
 pt[4]:    location:  0.875 -1.125
+   is located on boundary: 0
    idx:     (11,3)
 With weight: 16
 
 On point:    location:  1.125 -1.375
+   is located on boundary: 0
    idx:     (12,2)
 pt[0]:    location:  1.125 -1.375
+   is located on boundary: 0
    idx:     (12,2)
 With weight: -64
 pt[1]:    location:  1.125 -1.625
+   is located on boundary: 0
    idx:     (12,1)
 With weight: 16
 pt[2]:    location:  0.875 -1.375
+   is located on boundary: 0
    idx:     (11,2)
 With weight: 16
 pt[3]:    location:  1.375 -1.375
+   is located on boundary: 0
    idx:     (13,2)
 With weight: 16
 pt[4]:    location:  1.125 -1.125
+   is located on boundary: 0
    idx:     (12,3)
 With weight: 16
 
 On point:    location:  1.375 -1.375
+   is located on boundary: 0
    idx:     (13,2)
 pt[0]:    location:  1.375 -1.375
+   is located on boundary: 0
    idx:     (13,2)
 With weight: -64
 pt[1]:    location:  1.375 -1.625
+   is located on boundary: 0
    idx:     (13,1)
 With weight: 16
 pt[2]:    location:  1.125 -1.375
+   is located on boundary: 0
    idx:     (12,2)
 With weight: 16
 pt[3]:    location:  1.625 -1.375
+   is located on boundary: 0
    idx:     (14,2)
 With weight: 16
 pt[4]:    location:  1.375 -1.125
+   is located on boundary: 0
    idx:     (13,3)
 With weight: 16
 
 On point:    location:  1.625 -1.375
+   is located on boundary: 0
    idx:     (14,2)
 pt[0]:    location:  1.625 -1.375
+   is located on boundary: 0
    idx:     (14,2)
 With weight: -64
 pt[1]:    location:  1.625 -1.625
+   is located on boundary: 0
    idx:     (14,1)
 With weight: 16
 pt[2]:    location:  1.375 -1.375
+   is located on boundary: 0
    idx:     (13,2)
 With weight: 16
 pt[3]:    location:  1.875 -1.375
+   is located on boundary: 0
    idx:     (15,2)
 With weight: 16
 pt[4]:    location:  1.625 -1.125
+   is located on boundary: 0
    idx:     (14,3)
 With weight: 16
 
 On point:    location:  1.875 -1.375
+   is located on boundary: 0
    idx:     (15,2)
 pt[0]:    location:  1.875 -1.375
+   is located on boundary: 0
    idx:     (15,2)
 With weight: -64
 pt[1]:    location:  1.875 -1.625
+   is located on boundary: 0
    idx:     (15,1)
 With weight: 16
 pt[2]:    location:  1.625 -1.375
+   is located on boundary: 0
    idx:     (14,2)
 With weight: 16
 pt[3]:    location:  2.125 -1.375
+   is located on boundary: 0
    idx:     (16,2)
 With weight: 16
 pt[4]:    location:  1.875 -1.125
+   is located on boundary: 0
    idx:     (15,3)
 With weight: 16
 
 On point:    location: -1.875 -1.125
+   is located on boundary: 0
    idx:     (0,3)
 pt[0]:    location: -1.875 -1.125
+   is located on boundary: 0
    idx:     (0,3)
 With weight: -64
 pt[1]:    location: -1.875 -1.375
+   is located on boundary: 0
    idx:     (0,2)
 With weight: 16
 pt[2]:    location: -2.125 -1.125
+   is located on boundary: 0
    idx:     (-1,3)
 With weight: 16
 pt[3]:    location: -1.625 -1.125
+   is located on boundary: 0
    idx:     (1,3)
 With weight: 16
 pt[4]:    location: -1.875 -0.875
+   is located on boundary: 0
    idx:     (0,4)
 With weight: 16
 
 On point:    location: -1.625 -1.125
+   is located on boundary: 0
    idx:     (1,3)
 pt[0]:    location: -1.625 -1.125
+   is located on boundary: 0
    idx:     (1,3)
 With weight: -64
 pt[1]:    location: -1.625 -1.375
+   is located on boundary: 0
    idx:     (1,2)
 With weight: 16
 pt[2]:    location: -1.875 -1.125
+   is located on boundary: 0
    idx:     (0,3)
 With weight: 16
 pt[3]:    location: -1.375 -1.125
+   is located on boundary: 0
    idx:     (2,3)
 With weight: 16
 pt[4]:    location: -1.625 -0.875
+   is located on boundary: 0
    idx:     (1,4)
 With weight: 16
 
 On point:    location: -1.375 -1.125
+   is located on boundary: 0
    idx:     (2,3)
 pt[0]:    location: -1.375 -1.125
+   is located on boundary: 0
    idx:     (2,3)
 With weight: -64
 pt[1]:    location: -1.375 -1.375
+   is located on boundary: 0
    idx:     (2,2)
 With weight: 16
 pt[2]:    location: -1.625 -1.125
+   is located on boundary: 0
    idx:     (1,3)
 With weight: 16
 pt[3]:    location: -1.125 -1.125
+   is located on boundary: 0
    idx:     (3,3)
 With weight: 16
 pt[4]:    location: -1.375 -0.875
+   is located on boundary: 0
    idx:     (2,4)
 With weight: 16
 
 On point:    location: -1.125 -1.125
+   is located on boundary: 0
    idx:     (3,3)
 pt[0]:    location: -1.125 -1.125
+   is located on boundary: 0
    idx:     (3,3)
 With weight: -64
 pt[1]:    location: -1.125 -1.375
+   is located on boundary: 0
    idx:     (3,2)
 With weight: 16
 pt[2]:    location: -1.375 -1.125
+   is located on boundary: 0
    idx:     (2,3)
 With weight: 16
 pt[3]:    location: -0.875 -1.125
+   is located on boundary: 0
    idx:     (4,3)
 With weight: 16
 pt[4]:    location: -1.125 -0.875
+   is located on boundary: 0
    idx:     (3,4)
 With weight: 16
 
 On point:    location: -0.875 -1.125
+   is located on boundary: 0
    idx:     (4,3)
 pt[0]:    location: -0.875 -1.125
+   is located on boundary: 0
    idx:     (4,3)
 With weight: -45.1765
 pt[1]:    location: -0.875 -1.375
+   is located on boundary: 0
    idx:     (4,2)
 With weight: 13.1765
 pt[2]:    location: -1.125 -1.125
+   is located on boundary: 0
    idx:     (3,3)
 With weight: 8.47059
 pt[3]:    location: -0.625 -1.125
+   is located on boundary: 0
    idx:     (5,3)
 With weight: 16
 pt[4]:    location: -1.125 -0.875
+   is located on boundary: 0
    idx:     (3,4)
 With weight: 7.52941
 
 On point:    location: -0.625 -1.125
+   is located on boundary: 0
    idx:     (5,3)
 pt[0]:    location: -0.625 -1.125
+   is located on boundary: 0
    idx:     (5,3)
 With weight: -21.3333
 pt[1]:    location: -0.625 -1.375
+   is located on boundary: 0
    idx:     (5,2)
-With weight: -1.79207e-15
+With weight: 1.2191e-15
 pt[2]:    location: -0.875 -1.125
+   is located on boundary: 0
    idx:     (4,3)
 With weight: 10.6667
 pt[3]:    location: -0.875 -1.375
+   is located on boundary: 0
    idx:     (4,2)
 With weight: 2.66667
 pt[4]:    location: -0.375 -1.375
+   is located on boundary: 0
    idx:     (6,2)
 With weight: 8
 
 On point:    location:  0.625 -1.125
+   is located on boundary: 0
    idx:     (10,3)
 pt[0]:    location:  0.625 -1.125
+   is located on boundary: 0
    idx:     (10,3)
 With weight: -21.3333
 pt[1]:    location:  0.625 -1.375
+   is located on boundary: 0
    idx:     (10,2)
-With weight: -9.79547e-16
+With weight: 2.81359e-15
 pt[2]:    location:  0.875 -1.125
+   is located on boundary: 0
    idx:     (11,3)
 With weight: 10.6667
 pt[3]:    location:  0.375 -1.375
+   is located on boundary: 0
    idx:     (9,2)
 With weight: 8
 pt[4]:    location:  0.875 -1.375
+   is located on boundary: 0
    idx:     (11,2)
 With weight: 2.66667
 
 On point:    location:  0.875 -1.125
+   is located on boundary: 0
    idx:     (11,3)
 pt[0]:    location:  0.875 -1.125
+   is located on boundary: 0
    idx:     (11,3)
 With weight: -42.6667
 pt[1]:    location:  0.875 -1.375
+   is located on boundary: 0
    idx:     (11,2)
 With weight: 10.6667
 pt[2]:    location:  0.625 -1.125
+   is located on boundary: 0
    idx:     (10,3)
 With weight: 16
 pt[3]:    location:  1.125 -1.125
+   is located on boundary: 0
    idx:     (12,3)
 With weight: 16
 pt[4]:    location:  0.625 -1.375
+   is located on boundary: 0
    idx:     (10,2)
-With weight: -7.22782e-15
+With weight: -2.03742e-15
 
 On point:    location:  1.125 -1.125
+   is located on boundary: 0
    idx:     (12,3)
 pt[0]:    location:  1.125 -1.125
+   is located on boundary: 0
    idx:     (12,3)
 With weight: -64
 pt[1]:    location:  1.125 -1.375
+   is located on boundary: 0
    idx:     (12,2)
 With weight: 16
 pt[2]:    location:  0.875 -1.125
+   is located on boundary: 0
    idx:     (11,3)
 With weight: 16
 pt[3]:    location:  1.375 -1.125
+   is located on boundary: 0
    idx:     (13,3)
 With weight: 16
 pt[4]:    location:  1.125 -0.875
+   is located on boundary: 0
    idx:     (12,4)
 With weight: 16
 
 On point:    location:  1.375 -1.125
+   is located on boundary: 0
    idx:     (13,3)
 pt[0]:    location:  1.375 -1.125
+   is located on boundary: 0
    idx:     (13,3)
 With weight: -64
 pt[1]:    location:  1.375 -1.375
+   is located on boundary: 0
    idx:     (13,2)
 With weight: 16
 pt[2]:    location:  1.125 -1.125
+   is located on boundary: 0
    idx:     (12,3)
 With weight: 16
 pt[3]:    location:  1.625 -1.125
+   is located on boundary: 0
    idx:     (14,3)
 With weight: 16
 pt[4]:    location:  1.375 -0.875
+   is located on boundary: 0
    idx:     (13,4)
 With weight: 16
 
 On point:    location:  1.625 -1.125
+   is located on boundary: 0
    idx:     (14,3)
 pt[0]:    location:  1.625 -1.125
+   is located on boundary: 0
    idx:     (14,3)
 With weight: -64
 pt[1]:    location:  1.625 -1.375
+   is located on boundary: 0
    idx:     (14,2)
 With weight: 16
 pt[2]:    location:  1.375 -1.125
+   is located on boundary: 0
    idx:     (13,3)
 With weight: 16
 pt[3]:    location:  1.875 -1.125
+   is located on boundary: 0
    idx:     (15,3)
 With weight: 16
 pt[4]:    location:  1.625 -0.875
+   is located on boundary: 0
    idx:     (14,4)
 With weight: 16
 
 On point:    location:  1.875 -1.125
+   is located on boundary: 0
    idx:     (15,3)
 pt[0]:    location:  1.875 -1.125
+   is located on boundary: 0
    idx:     (15,3)
 With weight: -64
 pt[1]:    location:  1.875 -1.375
+   is located on boundary: 0
    idx:     (15,2)
 With weight: 16
 pt[2]:    location:  1.625 -1.125
+   is located on boundary: 0
    idx:     (14,3)
 With weight: 16
 pt[3]:    location:  2.125 -1.125
+   is located on boundary: 0
    idx:     (16,3)
 With weight: 16
 pt[4]:    location:  1.875 -0.875
+   is located on boundary: 0
    idx:     (15,4)
 With weight: 16
 
 On point:    location: -1.875 -0.875
+   is located on boundary: 0
    idx:     (0,4)
 pt[0]:    location: -1.875 -0.875
+   is located on boundary: 0
    idx:     (0,4)
 With weight: -64
 pt[1]:    location: -1.875 -1.125
+   is located on boundary: 0
    idx:     (0,3)
 With weight: 16
 pt[2]:    location: -2.125 -0.875
+   is located on boundary: 0
    idx:     (-1,4)
 With weight: 16
 pt[3]:    location: -1.625 -0.875
+   is located on boundary: 0
    idx:     (1,4)
 With weight: 16
 pt[4]:    location: -1.875 -0.625
+   is located on boundary: 0
    idx:     (0,5)
 With weight: 16
 
 On point:    location: -1.625 -0.875
+   is located on boundary: 0
    idx:     (1,4)
 pt[0]:    location: -1.625 -0.875
+   is located on boundary: 0
    idx:     (1,4)
 With weight: -64
 pt[1]:    location: -1.625 -1.125
+   is located on boundary: 0
    idx:     (1,3)
 With weight: 16
 pt[2]:    location: -1.875 -0.875
+   is located on boundary: 0
    idx:     (0,4)
 With weight: 16
 pt[3]:    location: -1.375 -0.875
+   is located on boundary: 0
    idx:     (2,4)
 With weight: 16
 pt[4]:    location: -1.625 -0.625
+   is located on boundary: 0
    idx:     (1,5)
 With weight: 16
 
 On point:    location: -1.375 -0.875
+   is located on boundary: 0
    idx:     (2,4)
 pt[0]:    location: -1.375 -0.875
+   is located on boundary: 0
    idx:     (2,4)
 With weight: -64
 pt[1]:    location: -1.375 -1.125
+   is located on boundary: 0
    idx:     (2,3)
 With weight: 16
 pt[2]:    location: -1.625 -0.875
+   is located on boundary: 0
    idx:     (1,4)
 With weight: 16
 pt[3]:    location: -1.125 -0.875
+   is located on boundary: 0
    idx:     (3,4)
 With weight: 16
 pt[4]:    location: -1.375 -0.625
+   is located on boundary: 0
    idx:     (2,5)
 With weight: 16
 
 On point:    location: -1.125 -0.875
+   is located on boundary: 0
    idx:     (3,4)
 pt[0]:    location: -1.125 -0.875
+   is located on boundary: 0
    idx:     (3,4)
 With weight: -42.6667
 pt[1]:    location: -1.125 -1.125
+   is located on boundary: 0
    idx:     (3,3)
 With weight: 16
 pt[2]:    location: -1.375 -0.875
+   is located on boundary: 0
    idx:     (2,4)
 With weight: 10.6667
 pt[3]:    location: -1.125 -0.625
+   is located on boundary: 0
    idx:     (3,5)
 With weight: 16
 pt[4]:    location: -1.375 -1.125
+   is located on boundary: 0
    idx:     (2,3)
-With weight: 1.8598e-15
+With weight: -3.3629e-16
 
 On point:    location:  1.125 -0.875
+   is located on boundary: 0
    idx:     (12,4)
 pt[0]:    location:  1.125 -0.875
+   is located on boundary: 0
    idx:     (12,4)
 With weight: -45.1765
 pt[1]:    location:  1.125 -1.125
+   is located on boundary: 0
    idx:     (12,3)
 With weight: 8.47059
 pt[2]:    location:  1.375 -0.875
+   is located on boundary: 0
    idx:     (13,4)
 With weight: 13.1765
 pt[3]:    location:  1.125 -0.625
+   is located on boundary: 0
    idx:     (12,5)
 With weight: 16
 pt[4]:    location:  0.875 -1.125
+   is located on boundary: 0
    idx:     (11,3)
 With weight: 7.52941
 
 On point:    location:  1.375 -0.875
+   is located on boundary: 0
    idx:     (13,4)
 pt[0]:    location:  1.375 -0.875
+   is located on boundary: 0
    idx:     (13,4)
 With weight: -64
 pt[1]:    location:  1.375 -1.125
+   is located on boundary: 0
    idx:     (13,3)
 With weight: 16
 pt[2]:    location:  1.125 -0.875
+   is located on boundary: 0
    idx:     (12,4)
 With weight: 16
 pt[3]:    location:  1.625 -0.875
+   is located on boundary: 0
    idx:     (14,4)
 With weight: 16
 pt[4]:    location:  1.375 -0.625
+   is located on boundary: 0
    idx:     (13,5)
 With weight: 16
 
 On point:    location:  1.625 -0.875
+   is located on boundary: 0
    idx:     (14,4)
 pt[0]:    location:  1.625 -0.875
+   is located on boundary: 0
    idx:     (14,4)
 With weight: -64
 pt[1]:    location:  1.625 -1.125
+   is located on boundary: 0
    idx:     (14,3)
 With weight: 16
 pt[2]:    location:  1.375 -0.875
+   is located on boundary: 0
    idx:     (13,4)
 With weight: 16
 pt[3]:    location:  1.875 -0.875
+   is located on boundary: 0
    idx:     (15,4)
 With weight: 16
 pt[4]:    location:  1.625 -0.625
+   is located on boundary: 0
    idx:     (14,5)
 With weight: 16
 
 On point:    location:  1.875 -0.875
+   is located on boundary: 0
    idx:     (15,4)
 pt[0]:    location:  1.875 -0.875
+   is located on boundary: 0
    idx:     (15,4)
 With weight: -64
 pt[1]:    location:  1.875 -1.125
+   is located on boundary: 0
    idx:     (15,3)
 With weight: 16
 pt[2]:    location:  1.625 -0.875
+   is located on boundary: 0
    idx:     (14,4)
 With weight: 16
 pt[3]:    location:  2.125 -0.875
+   is located on boundary: 0
    idx:     (16,4)
 With weight: 16
 pt[4]:    location:  1.875 -0.625
+   is located on boundary: 0
    idx:     (15,5)
 With weight: 16
 
 On point:    location: -1.875 -0.625
+   is located on boundary: 0
    idx:     (0,5)
 pt[0]:    location: -1.875 -0.625
+   is located on boundary: 0
    idx:     (0,5)
 With weight: -64
 pt[1]:    location: -1.875 -0.875
+   is located on boundary: 0
    idx:     (0,4)
 With weight: 16
 pt[2]:    location: -2.125 -0.625
+   is located on boundary: 0
    idx:     (-1,5)
 With weight: 16
 pt[3]:    location: -1.625 -0.625
+   is located on boundary: 0
    idx:     (1,5)
 With weight: 16
 pt[4]:    location: -1.875 -0.375
+   is located on boundary: 0
    idx:     (0,6)
 With weight: 16
 
 On point:    location: -1.625 -0.625
+   is located on boundary: 0
    idx:     (1,5)
 pt[0]:    location: -1.625 -0.625
+   is located on boundary: 0
    idx:     (1,5)
 With weight: -64
 pt[1]:    location: -1.625 -0.875
+   is located on boundary: 0
    idx:     (1,4)
 With weight: 16
 pt[2]:    location: -1.875 -0.625
+   is located on boundary: 0
    idx:     (0,5)
 With weight: 16
 pt[3]:    location: -1.375 -0.625
+   is located on boundary: 0
    idx:     (2,5)
 With weight: 16
 pt[4]:    location: -1.625 -0.375
+   is located on boundary: 0
    idx:     (1,6)
 With weight: 16
 
 On point:    location: -1.375 -0.625
+   is located on boundary: 0
    idx:     (2,5)
 pt[0]:    location: -1.375 -0.625
+   is located on boundary: 0
    idx:     (2,5)
 With weight: -64
 pt[1]:    location: -1.375 -0.875
+   is located on boundary: 0
    idx:     (2,4)
 With weight: 16
 pt[2]:    location: -1.625 -0.625
+   is located on boundary: 0
    idx:     (1,5)
 With weight: 16
 pt[3]:    location: -1.125 -0.625
+   is located on boundary: 0
    idx:     (3,5)
 With weight: 16
 pt[4]:    location: -1.375 -0.375
+   is located on boundary: 0
    idx:     (2,6)
 With weight: 16
 
 On point:    location: -1.125 -0.625
+   is located on boundary: 0
    idx:     (3,5)
 pt[0]:    location: -1.125 -0.625
+   is located on boundary: 0
    idx:     (3,5)
 With weight: -21.3333
 pt[1]:    location: -1.125 -0.875
+   is located on boundary: 0
    idx:     (3,4)
 With weight: 10.6667
 pt[2]:    location: -1.375 -0.625
+   is located on boundary: 0
    idx:     (2,5)
-With weight: -1.64197e-15
+With weight: -1.22853e-15
 pt[3]:    location: -1.375 -0.875
+   is located on boundary: 0
    idx:     (2,4)
 With weight: 2.66667
 pt[4]:    location: -1.375 -0.375
+   is located on boundary: 0
    idx:     (2,6)
 With weight: 8
 
 On point:    location:  1.125 -0.625
+   is located on boundary: 0
    idx:     (12,5)
 pt[0]:    location:  1.125 -0.625
+   is located on boundary: 0
    idx:     (12,5)
 With weight: -21.3333
 pt[1]:    location:  1.125 -0.875
+   is located on boundary: 0
    idx:     (12,4)
 With weight: 10.6667
 pt[2]:    location:  1.375 -0.625
+   is located on boundary: 0
    idx:     (13,5)
-With weight: -1.64197e-15
+With weight: -1.22853e-15
 pt[3]:    location:  1.375 -0.875
+   is located on boundary: 0
    idx:     (13,4)
 With weight: 2.66667
 pt[4]:    location:  1.375 -0.375
+   is located on boundary: 0
    idx:     (13,6)
 With weight: 8
 
 On point:    location:  1.375 -0.625
+   is located on boundary: 0
    idx:     (13,5)
 pt[0]:    location:  1.375 -0.625
+   is located on boundary: 0
    idx:     (13,5)
 With weight: -64
 pt[1]:    location:  1.375 -0.875
+   is located on boundary: 0
    idx:     (13,4)
 With weight: 16
 pt[2]:    location:  1.125 -0.625
+   is located on boundary: 0
    idx:     (12,5)
 With weight: 16
 pt[3]:    location:  1.625 -0.625
+   is located on boundary: 0
    idx:     (14,5)
 With weight: 16
 pt[4]:    location:  1.375 -0.375
+   is located on boundary: 0
    idx:     (13,6)
 With weight: 16
 
 On point:    location:  1.625 -0.625
+   is located on boundary: 0
    idx:     (14,5)
 pt[0]:    location:  1.625 -0.625
+   is located on boundary: 0
    idx:     (14,5)
 With weight: -64
 pt[1]:    location:  1.625 -0.875
+   is located on boundary: 0
    idx:     (14,4)
 With weight: 16
 pt[2]:    location:  1.375 -0.625
+   is located on boundary: 0
    idx:     (13,5)
 With weight: 16
 pt[3]:    location:  1.875 -0.625
+   is located on boundary: 0
    idx:     (15,5)
 With weight: 16
 pt[4]:    location:  1.625 -0.375
+   is located on boundary: 0
    idx:     (14,6)
 With weight: 16
 
 On point:    location:  1.875 -0.625
+   is located on boundary: 0
    idx:     (15,5)
 pt[0]:    location:  1.875 -0.625
+   is located on boundary: 0
    idx:     (15,5)
 With weight: -64
 pt[1]:    location:  1.875 -0.875
+   is located on boundary: 0
    idx:     (15,4)
 With weight: 16
 pt[2]:    location:  1.625 -0.625
+   is located on boundary: 0
    idx:     (14,5)
 With weight: 16
 pt[3]:    location:  2.125 -0.625
+   is located on boundary: 0
    idx:     (16,5)
 With weight: 16
 pt[4]:    location:  1.875 -0.375
+   is located on boundary: 0
    idx:     (15,6)
 With weight: 16
 
 On point:    location: -1.875 -0.375
+   is located on boundary: 0
    idx:     (0,6)
 pt[0]:    location: -1.875 -0.375
+   is located on boundary: 0
    idx:     (0,6)
 With weight: -64
 pt[1]:    location: -1.875 -0.625
+   is located on boundary: 0
    idx:     (0,5)
 With weight: 16
 pt[2]:    location: -2.125 -0.375
+   is located on boundary: 0
    idx:     (-1,6)
 With weight: 16
 pt[3]:    location: -1.625 -0.375
+   is located on boundary: 0
    idx:     (1,6)
 With weight: 16
 pt[4]:    location: -1.875 -0.125
+   is located on boundary: 0
    idx:     (0,7)
 With weight: 16
 
 On point:    location: -1.625 -0.375
+   is located on boundary: 0
    idx:     (1,6)
 pt[0]:    location: -1.625 -0.375
+   is located on boundary: 0
    idx:     (1,6)
 With weight: -64
 pt[1]:    location: -1.625 -0.625
+   is located on boundary: 0
    idx:     (1,5)
 With weight: 16
 pt[2]:    location: -1.875 -0.375
+   is located on boundary: 0
    idx:     (0,6)
 With weight: 16
 pt[3]:    location: -1.375 -0.375
+   is located on boundary: 0
    idx:     (2,6)
 With weight: 16
 pt[4]:    location: -1.625 -0.125
+   is located on boundary: 0
    idx:     (1,7)
 With weight: 16
 
 On point:    location: -1.375 -0.375
+   is located on boundary: 0
    idx:     (2,6)
 pt[0]:    location: -1.375 -0.375
+   is located on boundary: 0
    idx:     (2,6)
 With weight: -42.6667
 pt[1]:    location: -1.375 -0.625
+   is located on boundary: 0
    idx:     (2,5)
 With weight: 16
 pt[2]:    location: -1.625 -0.375
+   is located on boundary: 0
    idx:     (1,6)
 With weight: 10.6667
 pt[3]:    location: -1.375 -0.125
+   is located on boundary: 0
    idx:     (2,7)
 With weight: 16
 pt[4]:    location: -1.625 -0.625
+   is located on boundary: 0
    idx:     (1,5)
-With weight: 1.8598e-15
+With weight: -3.3629e-16
 
 On point:    location:  1.375 -0.375
+   is located on boundary: 0
    idx:     (13,6)
 pt[0]:    location:  1.375 -0.375
+   is located on boundary: 0
    idx:     (13,6)
 With weight: -45.1765
 pt[1]:    location:  1.375 -0.625
+   is located on boundary: 0
    idx:     (13,5)
 With weight: 8.47059
 pt[2]:    location:  1.625 -0.375
+   is located on boundary: 0
    idx:     (14,6)
 With weight: 13.1765
 pt[3]:    location:  1.375 -0.125
+   is located on boundary: 0
    idx:     (13,7)
 With weight: 16
 pt[4]:    location:  1.125 -0.625
+   is located on boundary: 0
    idx:     (12,5)
 With weight: 7.52941
 
 On point:    location:  1.625 -0.375
+   is located on boundary: 0
    idx:     (14,6)
 pt[0]:    location:  1.625 -0.375
+   is located on boundary: 0
    idx:     (14,6)
 With weight: -64
 pt[1]:    location:  1.625 -0.625
+   is located on boundary: 0
    idx:     (14,5)
 With weight: 16
 pt[2]:    location:  1.375 -0.375
+   is located on boundary: 0
    idx:     (13,6)
 With weight: 16
 pt[3]:    location:  1.875 -0.375
+   is located on boundary: 0
    idx:     (15,6)
 With weight: 16
 pt[4]:    location:  1.625 -0.125
+   is located on boundary: 0
    idx:     (14,7)
 With weight: 16
 
 On point:    location:  1.875 -0.375
+   is located on boundary: 0
    idx:     (15,6)
 pt[0]:    location:  1.875 -0.375
+   is located on boundary: 0
    idx:     (15,6)
 With weight: -64
 pt[1]:    location:  1.875 -0.625
+   is located on boundary: 0
    idx:     (15,5)
 With weight: 16
 pt[2]:    location:  1.625 -0.375
+   is located on boundary: 0
    idx:     (14,6)
 With weight: 16
 pt[3]:    location:  2.125 -0.375
+   is located on boundary: 0
    idx:     (16,6)
 With weight: 16
 pt[4]:    location:  1.875 -0.125
+   is located on boundary: 0
    idx:     (15,7)
 With weight: 16
 
 On point:    location: -1.875 -0.125
+   is located on boundary: 0
    idx:     (0,7)
 pt[0]:    location: -1.875 -0.125
+   is located on boundary: 0
    idx:     (0,7)
 With weight: -64
 pt[1]:    location: -1.875 -0.375
+   is located on boundary: 0
    idx:     (0,6)
 With weight: 16
 pt[2]:    location: -2.125 -0.125
+   is located on boundary: 0
    idx:     (-1,7)
 With weight: 16
 pt[3]:    location: -1.625 -0.125
+   is located on boundary: 0
    idx:     (1,7)
 With weight: 16
 pt[4]:    location: -1.875  0.125
+   is located on boundary: 0
    idx:     (0,8)
 With weight: 16
 
 On point:    location: -1.625 -0.125
+   is located on boundary: 0
    idx:     (1,7)
 pt[0]:    location: -1.625 -0.125
+   is located on boundary: 0
    idx:     (1,7)
 With weight: -64
 pt[1]:    location: -1.625 -0.375
+   is located on boundary: 0
    idx:     (1,6)
 With weight: 16
 pt[2]:    location: -1.875 -0.125
+   is located on boundary: 0
    idx:     (0,7)
 With weight: 16
 pt[3]:    location: -1.375 -0.125
+   is located on boundary: 0
    idx:     (2,7)
 With weight: 16
 pt[4]:    location: -1.625  0.125
+   is located on boundary: 0
    idx:     (1,8)
 With weight: 16
 
 On point:    location: -1.375 -0.125
+   is located on boundary: 0
    idx:     (2,7)
 pt[0]:    location: -1.375 -0.125
+   is located on boundary: 0
    idx:     (2,7)
 With weight: -42.6667
 pt[1]:    location: -1.375 -0.375
+   is located on boundary: 0
    idx:     (2,6)
 With weight: 16
 pt[2]:    location: -1.625 -0.125
+   is located on boundary: 0
    idx:     (1,7)
 With weight: 10.6667
 pt[3]:    location: -1.375  0.125
+   is located on boundary: 0
    idx:     (2,8)
 With weight: 16
 pt[4]:    location: -1.625 -0.375
+   is located on boundary: 0
    idx:     (1,6)
-With weight: 1.8598e-15
+With weight: -3.3629e-16
 
 On point:    location:  1.375 -0.125
+   is located on boundary: 0
    idx:     (13,7)
 pt[0]:    location:  1.375 -0.125
+   is located on boundary: 0
    idx:     (13,7)
 With weight: -42.6667
 pt[1]:    location:  1.375 -0.375
+   is located on boundary: 0
    idx:     (13,6)
 With weight: 16
 pt[2]:    location:  1.625 -0.125
+   is located on boundary: 0
    idx:     (14,7)
 With weight: 10.6667
 pt[3]:    location: 1.375 0.125
+   is located on boundary: 0
    idx:     (13,8)
 With weight: 16
 pt[4]:    location:  1.625 -0.375
+   is located on boundary: 0
    idx:     (14,6)
-With weight: 1.8598e-15
+With weight: -3.3629e-16
 
 On point:    location:  1.625 -0.125
+   is located on boundary: 0
    idx:     (14,7)
 pt[0]:    location:  1.625 -0.125
+   is located on boundary: 0
    idx:     (14,7)
 With weight: -64
 pt[1]:    location:  1.625 -0.375
+   is located on boundary: 0
    idx:     (14,6)
 With weight: 16
 pt[2]:    location:  1.375 -0.125
+   is located on boundary: 0
    idx:     (13,7)
 With weight: 16
 pt[3]:    location:  1.875 -0.125
+   is located on boundary: 0
    idx:     (15,7)
 With weight: 16
 pt[4]:    location: 1.625 0.125
+   is located on boundary: 0
    idx:     (14,8)
 With weight: 16
 
 On point:    location:  1.875 -0.125
+   is located on boundary: 0
    idx:     (15,7)
 pt[0]:    location:  1.875 -0.125
+   is located on boundary: 0
    idx:     (15,7)
 With weight: -64
 pt[1]:    location:  1.875 -0.375
+   is located on boundary: 0
    idx:     (15,6)
 With weight: 16
 pt[2]:    location:  1.625 -0.125
+   is located on boundary: 0
    idx:     (14,7)
 With weight: 16
 pt[3]:    location:  2.125 -0.125
+   is located on boundary: 0
    idx:     (16,7)
 With weight: 16
 pt[4]:    location: 1.875 0.125
+   is located on boundary: 0
    idx:     (15,8)
 With weight: 16
 
 On point:    location: -1.875  0.125
+   is located on boundary: 0
    idx:     (0,8)
 pt[0]:    location: -1.875  0.125
+   is located on boundary: 0
    idx:     (0,8)
 With weight: -64
 pt[1]:    location: -1.875 -0.125
+   is located on boundary: 0
    idx:     (0,7)
 With weight: 16
 pt[2]:    location: -2.125  0.125
+   is located on boundary: 0
    idx:     (-1,8)
 With weight: 16
 pt[3]:    location: -1.625  0.125
+   is located on boundary: 0
    idx:     (1,8)
 With weight: 16
 pt[4]:    location: -1.875  0.375
+   is located on boundary: 0
    idx:     (0,9)
 With weight: 16
 
 On point:    location: -1.625  0.125
+   is located on boundary: 0
    idx:     (1,8)
 pt[0]:    location: -1.625  0.125
+   is located on boundary: 0
    idx:     (1,8)
 With weight: -64
 pt[1]:    location: -1.625 -0.125
+   is located on boundary: 0
    idx:     (1,7)
 With weight: 16
 pt[2]:    location: -1.875  0.125
+   is located on boundary: 0
    idx:     (0,8)
 With weight: 16
 pt[3]:    location: -1.375  0.125
+   is located on boundary: 0
    idx:     (2,8)
 With weight: 16
 pt[4]:    location: -1.625  0.375
+   is located on boundary: 0
    idx:     (1,9)
 With weight: 16
 
 On point:    location: -1.375  0.125
+   is located on boundary: 0
    idx:     (2,8)
 pt[0]:    location: -1.375  0.125
+   is located on boundary: 0
    idx:     (2,8)
 With weight: -42.6667
 pt[1]:    location: -1.375 -0.125
+   is located on boundary: 0
    idx:     (2,7)
 With weight: 16
 pt[2]:    location: -1.625  0.125
+   is located on boundary: 0
    idx:     (1,8)
 With weight: 10.6667
 pt[3]:    location: -1.375  0.375
+   is located on boundary: 0
    idx:     (2,9)
 With weight: 16
 pt[4]:    location: -1.625 -0.125
+   is located on boundary: 0
    idx:     (1,7)
-With weight: 1.8598e-15
+With weight: -3.3629e-16
 
 On point:    location: 1.375 0.125
+   is located on boundary: 0
    idx:     (13,8)
 pt[0]:    location: 1.375 0.125
+   is located on boundary: 0
    idx:     (13,8)
 With weight: -42.6667
 pt[1]:    location:  1.375 -0.125
+   is located on boundary: 0
    idx:     (13,7)
 With weight: 16
 pt[2]:    location: 1.625 0.125
+   is located on boundary: 0
    idx:     (14,8)
 With weight: 10.6667
 pt[3]:    location: 1.375 0.375
+   is located on boundary: 0
    idx:     (13,9)
 With weight: 16
 pt[4]:    location: 1.625 0.375
+   is located on boundary: 0
    idx:     (14,9)
-With weight: -3.43048e-15
+With weight: -1.44512e-15
 
 On point:    location: 1.625 0.125
+   is located on boundary: 0
    idx:     (14,8)
 pt[0]:    location: 1.625 0.125
+   is located on boundary: 0
    idx:     (14,8)
 With weight: -64
 pt[1]:    location:  1.625 -0.125
+   is located on boundary: 0
    idx:     (14,7)
 With weight: 16
 pt[2]:    location: 1.375 0.125
+   is located on boundary: 0
    idx:     (13,8)
 With weight: 16
 pt[3]:    location: 1.875 0.125
+   is located on boundary: 0
    idx:     (15,8)
 With weight: 16
 pt[4]:    location: 1.625 0.375
+   is located on boundary: 0
    idx:     (14,9)
 With weight: 16
 
 On point:    location: 1.875 0.125
+   is located on boundary: 0
    idx:     (15,8)
 pt[0]:    location: 1.875 0.125
+   is located on boundary: 0
    idx:     (15,8)
 With weight: -64
 pt[1]:    location:  1.875 -0.125
+   is located on boundary: 0
    idx:     (15,7)
 With weight: 16
 pt[2]:    location: 1.625 0.125
+   is located on boundary: 0
    idx:     (14,8)
 With weight: 16
 pt[3]:    location: 2.125 0.125
+   is located on boundary: 0
    idx:     (16,8)
 With weight: 16
 pt[4]:    location: 1.875 0.375
+   is located on boundary: 0
    idx:     (15,9)
 With weight: 16
 
 On point:    location: -1.875  0.375
+   is located on boundary: 0
    idx:     (0,9)
 pt[0]:    location: -1.875  0.375
+   is located on boundary: 0
    idx:     (0,9)
 With weight: -64
 pt[1]:    location: -1.875  0.125
+   is located on boundary: 0
    idx:     (0,8)
 With weight: 16
 pt[2]:    location: -2.125  0.375
+   is located on boundary: 0
    idx:     (-1,9)
 With weight: 16
 pt[3]:    location: -1.625  0.375
+   is located on boundary: 0
    idx:     (1,9)
 With weight: 16
 pt[4]:    location: -1.875  0.625
+   is located on boundary: 0
    idx:     (0,10)
 With weight: 16
 
 On point:    location: -1.625  0.375
+   is located on boundary: 0
    idx:     (1,9)
 pt[0]:    location: -1.625  0.375
+   is located on boundary: 0
    idx:     (1,9)
 With weight: -64
 pt[1]:    location: -1.625  0.125
+   is located on boundary: 0
    idx:     (1,8)
 With weight: 16
 pt[2]:    location: -1.875  0.375
+   is located on boundary: 0
    idx:     (0,9)
 With weight: 16
 pt[3]:    location: -1.375  0.375
+   is located on boundary: 0
    idx:     (2,9)
 With weight: 16
 pt[4]:    location: -1.625  0.625
+   is located on boundary: 0
    idx:     (1,10)
 With weight: 16
 
 On point:    location: -1.375  0.375
+   is located on boundary: 0
    idx:     (2,9)
 pt[0]:    location: -1.375  0.375
+   is located on boundary: 0
    idx:     (2,9)
 With weight: -42.6667
 pt[1]:    location: -1.375  0.125
+   is located on boundary: 0
    idx:     (2,8)
 With weight: 16
 pt[2]:    location: -1.625  0.375
+   is located on boundary: 0
    idx:     (1,9)
 With weight: 10.6667
 pt[3]:    location: -1.375  0.625
+   is located on boundary: 0
    idx:     (2,10)
 With weight: 16
 pt[4]:    location: -1.625  0.625
+   is located on boundary: 0
    idx:     (1,10)
-With weight: -3.43048e-15
+With weight: -1.44512e-15
 
 On point:    location: 1.375 0.375
+   is located on boundary: 0
    idx:     (13,9)
 pt[0]:    location: 1.375 0.375
+   is located on boundary: 0
    idx:     (13,9)
 With weight: -42.6667
 pt[1]:    location: 1.375 0.125
+   is located on boundary: 0
    idx:     (13,8)
 With weight: 16
 pt[2]:    location: 1.625 0.375
+   is located on boundary: 0
    idx:     (14,9)
 With weight: 10.6667
 pt[3]:    location: 1.375 0.625
+   is located on boundary: 0
    idx:     (13,10)
 With weight: 16
 pt[4]:    location: 1.625 0.125
+   is located on boundary: 0
    idx:     (14,8)
-With weight: 1.8598e-15
+With weight: -3.3629e-16
 
 On point:    location: 1.625 0.375
+   is located on boundary: 0
    idx:     (14,9)
 pt[0]:    location: 1.625 0.375
+   is located on boundary: 0
    idx:     (14,9)
 With weight: -64
 pt[1]:    location: 1.625 0.125
+   is located on boundary: 0
    idx:     (14,8)
 With weight: 16
 pt[2]:    location: 1.375 0.375
+   is located on boundary: 0
    idx:     (13,9)
 With weight: 16
 pt[3]:    location: 1.875 0.375
+   is located on boundary: 0
    idx:     (15,9)
 With weight: 16
 pt[4]:    location: 1.625 0.625
+   is located on boundary: 0
    idx:     (14,10)
 With weight: 16
 
 On point:    location: 1.875 0.375
+   is located on boundary: 0
    idx:     (15,9)
 pt[0]:    location: 1.875 0.375
+   is located on boundary: 0
    idx:     (15,9)
 With weight: -64
 pt[1]:    location: 1.875 0.125
+   is located on boundary: 0
    idx:     (15,8)
 With weight: 16
 pt[2]:    location: 1.625 0.375
+   is located on boundary: 0
    idx:     (14,9)
 With weight: 16
 pt[3]:    location: 2.125 0.375
+   is located on boundary: 0
    idx:     (16,9)
 With weight: 16
 pt[4]:    location: 1.875 0.625
+   is located on boundary: 0
    idx:     (15,10)
 With weight: 16
 
 On point:    location: -1.875  0.625
+   is located on boundary: 0
    idx:     (0,10)
 pt[0]:    location: -1.875  0.625
+   is located on boundary: 0
    idx:     (0,10)
 With weight: -64
 pt[1]:    location: -1.875  0.375
+   is located on boundary: 0
    idx:     (0,9)
 With weight: 16
 pt[2]:    location: -2.125  0.625
+   is located on boundary: 0
    idx:     (-1,10)
 With weight: 16
 pt[3]:    location: -1.625  0.625
+   is located on boundary: 0
    idx:     (1,10)
 With weight: 16
 pt[4]:    location: -1.875  0.875
+   is located on boundary: 0
    idx:     (0,11)
 With weight: 16
 
 On point:    location: -1.625  0.625
+   is located on boundary: 0
    idx:     (1,10)
 pt[0]:    location: -1.625  0.625
+   is located on boundary: 0
    idx:     (1,10)
 With weight: -64
 pt[1]:    location: -1.625  0.375
+   is located on boundary: 0
    idx:     (1,9)
 With weight: 16
 pt[2]:    location: -1.875  0.625
+   is located on boundary: 0
    idx:     (0,10)
 With weight: 16
 pt[3]:    location: -1.375  0.625
+   is located on boundary: 0
    idx:     (2,10)
 With weight: 16
 pt[4]:    location: -1.625  0.875
+   is located on boundary: 0
    idx:     (1,11)
 With weight: 16
 
 On point:    location: -1.375  0.625
+   is located on boundary: 0
    idx:     (2,10)
 pt[0]:    location: -1.375  0.625
+   is located on boundary: 0
    idx:     (2,10)
 With weight: -64
 pt[1]:    location: -1.375  0.375
+   is located on boundary: 0
    idx:     (2,9)
 With weight: 16
 pt[2]:    location: -1.625  0.625
+   is located on boundary: 0
    idx:     (1,10)
 With weight: 16
 pt[3]:    location: -1.125  0.625
+   is located on boundary: 0
    idx:     (3,10)
 With weight: 16
 pt[4]:    location: -1.375  0.875
+   is located on boundary: 0
    idx:     (2,11)
 With weight: 16
 
 On point:    location: -1.125  0.625
+   is located on boundary: 0
    idx:     (3,10)
 pt[0]:    location: -1.125  0.625
+   is located on boundary: 0
    idx:     (3,10)
 With weight: -21.3333
 pt[1]:    location: -1.375  0.625
+   is located on boundary: 0
    idx:     (2,10)
-With weight: -3.12538e-15
+With weight: -2.90863e-16
 pt[2]:    location: -1.125  0.875
+   is located on boundary: 0
    idx:     (3,11)
 With weight: 10.6667
 pt[3]:    location: -1.375  0.375
+   is located on boundary: 0
    idx:     (2,9)
 With weight: 8
 pt[4]:    location: -1.375  0.875
+   is located on boundary: 0
    idx:     (2,11)
 With weight: 2.66667
 
 On point:    location: 1.125 0.625
+   is located on boundary: 0
    idx:     (12,10)
 pt[0]:    location: 1.125 0.625
+   is located on boundary: 0
    idx:     (12,10)
 With weight: -21.3333
 pt[1]:    location: 1.375 0.625
+   is located on boundary: 0
    idx:     (13,10)
-With weight: -3.12538e-15
+With weight: -2.90863e-16
 pt[2]:    location: 1.125 0.875
+   is located on boundary: 0
    idx:     (12,11)
 With weight: 10.6667
 pt[3]:    location: 1.375 0.375
+   is located on boundary: 0
    idx:     (13,9)
 With weight: 8
 pt[4]:    location: 1.375 0.875
+   is located on boundary: 0
    idx:     (13,11)
 With weight: 2.66667
 
 On point:    location: 1.375 0.625
+   is located on boundary: 0
    idx:     (13,10)
 pt[0]:    location: 1.375 0.625
+   is located on boundary: 0
    idx:     (13,10)
 With weight: -64
 pt[1]:    location: 1.375 0.375
+   is located on boundary: 0
    idx:     (13,9)
 With weight: 16
 pt[2]:    location: 1.125 0.625
+   is located on boundary: 0
    idx:     (12,10)
 With weight: 16
 pt[3]:    location: 1.625 0.625
+   is located on boundary: 0
    idx:     (14,10)
 With weight: 16
 pt[4]:    location: 1.375 0.875
+   is located on boundary: 0
    idx:     (13,11)
 With weight: 16
 
 On point:    location: 1.625 0.625
+   is located on boundary: 0
    idx:     (14,10)
 pt[0]:    location: 1.625 0.625
+   is located on boundary: 0
    idx:     (14,10)
 With weight: -64
 pt[1]:    location: 1.625 0.375
+   is located on boundary: 0
    idx:     (14,9)
 With weight: 16
 pt[2]:    location: 1.375 0.625
+   is located on boundary: 0
    idx:     (13,10)
 With weight: 16
 pt[3]:    location: 1.875 0.625
+   is located on boundary: 0
    idx:     (15,10)
 With weight: 16
 pt[4]:    location: 1.625 0.875
+   is located on boundary: 0
    idx:     (14,11)
 With weight: 16
 
 On point:    location: 1.875 0.625
+   is located on boundary: 0
    idx:     (15,10)
 pt[0]:    location: 1.875 0.625
+   is located on boundary: 0
    idx:     (15,10)
 With weight: -64
 pt[1]:    location: 1.875 0.375
+   is located on boundary: 0
    idx:     (15,9)
 With weight: 16
 pt[2]:    location: 1.625 0.625
+   is located on boundary: 0
    idx:     (14,10)
 With weight: 16
 pt[3]:    location: 2.125 0.625
+   is located on boundary: 0
    idx:     (16,10)
 With weight: 16
 pt[4]:    location: 1.875 0.875
+   is located on boundary: 0
    idx:     (15,11)
 With weight: 16
 
 On point:    location: -1.875  0.875
+   is located on boundary: 0
    idx:     (0,11)
 pt[0]:    location: -1.875  0.875
+   is located on boundary: 0
    idx:     (0,11)
 With weight: -64
 pt[1]:    location: -1.875  0.625
+   is located on boundary: 0
    idx:     (0,10)
 With weight: 16
 pt[2]:    location: -2.125  0.875
+   is located on boundary: 0
    idx:     (-1,11)
 With weight: 16
 pt[3]:    location: -1.625  0.875
+   is located on boundary: 0
    idx:     (1,11)
 With weight: 16
 pt[4]:    location: -1.875  1.125
+   is located on boundary: 0
    idx:     (0,12)
 With weight: 16
 
 On point:    location: -1.625  0.875
+   is located on boundary: 0
    idx:     (1,11)
 pt[0]:    location: -1.625  0.875
+   is located on boundary: 0
    idx:     (1,11)
 With weight: -64
 pt[1]:    location: -1.625  0.625
+   is located on boundary: 0
    idx:     (1,10)
 With weight: 16
 pt[2]:    location: -1.875  0.875
+   is located on boundary: 0
    idx:     (0,11)
 With weight: 16
 pt[3]:    location: -1.375  0.875
+   is located on boundary: 0
    idx:     (2,11)
 With weight: 16
 pt[4]:    location: -1.625  1.125
+   is located on boundary: 0
    idx:     (1,12)
 With weight: 16
 
 On point:    location: -1.375  0.875
+   is located on boundary: 0
    idx:     (2,11)
 pt[0]:    location: -1.375  0.875
+   is located on boundary: 0
    idx:     (2,11)
 With weight: -64
 pt[1]:    location: -1.375  0.625
+   is located on boundary: 0
    idx:     (2,10)
 With weight: 16
 pt[2]:    location: -1.625  0.875
+   is located on boundary: 0
    idx:     (1,11)
 With weight: 16
 pt[3]:    location: -1.125  0.875
+   is located on boundary: 0
    idx:     (3,11)
 With weight: 16
 pt[4]:    location: -1.375  1.125
+   is located on boundary: 0
    idx:     (2,12)
 With weight: 16
 
 On point:    location: -1.125  0.875
+   is located on boundary: 0
    idx:     (3,11)
 pt[0]:    location: -1.125  0.875
+   is located on boundary: 0
    idx:     (3,11)
 With weight: -42.6667
 pt[1]:    location: -1.125  0.625
+   is located on boundary: 0
    idx:     (3,10)
 With weight: 16
 pt[2]:    location: -1.375  0.875
+   is located on boundary: 0
    idx:     (2,11)
 With weight: 10.6667
 pt[3]:    location: -1.125  1.125
+   is located on boundary: 0
    idx:     (3,12)
 With weight: 16
 pt[4]:    location: -1.375  0.625
+   is located on boundary: 0
    idx:     (2,10)
-With weight: 1.8598e-15
+With weight: -3.3629e-16
 
 On point:    location: 1.125 0.875
+   is located on boundary: 0
    idx:     (12,11)
 pt[0]:    location: 1.125 0.875
+   is located on boundary: 0
    idx:     (12,11)
 With weight: -42.6667
 pt[1]:    location: 1.125 0.625
+   is located on boundary: 0
    idx:     (12,10)
 With weight: 16
 pt[2]:    location: 1.375 0.875
+   is located on boundary: 0
    idx:     (13,11)
 With weight: 10.6667
 pt[3]:    location: 1.125 1.125
+   is located on boundary: 0
    idx:     (12,12)
 With weight: 16
 pt[4]:    location: 1.375 0.625
+   is located on boundary: 0
    idx:     (13,10)
-With weight: 1.8598e-15
+With weight: -3.3629e-16
 
 On point:    location: 1.375 0.875
+   is located on boundary: 0
    idx:     (13,11)
 pt[0]:    location: 1.375 0.875
+   is located on boundary: 0
    idx:     (13,11)
 With weight: -64
 pt[1]:    location: 1.375 0.625
+   is located on boundary: 0
    idx:     (13,10)
 With weight: 16
 pt[2]:    location: 1.125 0.875
+   is located on boundary: 0
    idx:     (12,11)
 With weight: 16
 pt[3]:    location: 1.625 0.875
+   is located on boundary: 0
    idx:     (14,11)
 With weight: 16
 pt[4]:    location: 1.375 1.125
+   is located on boundary: 0
    idx:     (13,12)
 With weight: 16
 
 On point:    location: 1.625 0.875
+   is located on boundary: 0
    idx:     (14,11)
 pt[0]:    location: 1.625 0.875
+   is located on boundary: 0
    idx:     (14,11)
 With weight: -64
 pt[1]:    location: 1.625 0.625
+   is located on boundary: 0
    idx:     (14,10)
 With weight: 16
 pt[2]:    location: 1.375 0.875
+   is located on boundary: 0
    idx:     (13,11)
 With weight: 16
 pt[3]:    location: 1.875 0.875
+   is located on boundary: 0
    idx:     (15,11)
 With weight: 16
 pt[4]:    location: 1.625 1.125
+   is located on boundary: 0
    idx:     (14,12)
 With weight: 16
 
 On point:    location: 1.875 0.875
+   is located on boundary: 0
    idx:     (15,11)
 pt[0]:    location: 1.875 0.875
+   is located on boundary: 0
    idx:     (15,11)
 With weight: -64
 pt[1]:    location: 1.875 0.625
+   is located on boundary: 0
    idx:     (15,10)
 With weight: 16
 pt[2]:    location: 1.625 0.875
+   is located on boundary: 0
    idx:     (14,11)
 With weight: 16
 pt[3]:    location: 2.125 0.875
+   is located on boundary: 0
    idx:     (16,11)
 With weight: 16
 pt[4]:    location: 1.875 1.125
+   is located on boundary: 0
    idx:     (15,12)
 With weight: 16
 
 On point:    location: -1.875  1.125
+   is located on boundary: 0
    idx:     (0,12)
 pt[0]:    location: -1.875  1.125
+   is located on boundary: 0
    idx:     (0,12)
 With weight: -64
 pt[1]:    location: -1.875  0.875
+   is located on boundary: 0
    idx:     (0,11)
 With weight: 16
 pt[2]:    location: -2.125  1.125
+   is located on boundary: 0
    idx:     (-1,12)
 With weight: 16
 pt[3]:    location: -1.625  1.125
+   is located on boundary: 0
    idx:     (1,12)
 With weight: 16
 pt[4]:    location: -1.875  1.375
+   is located on boundary: 0
    idx:     (0,13)
 With weight: 16
 
 On point:    location: -1.625  1.125
+   is located on boundary: 0
    idx:     (1,12)
 pt[0]:    location: -1.625  1.125
+   is located on boundary: 0
    idx:     (1,12)
 With weight: -64
 pt[1]:    location: -1.625  0.875
+   is located on boundary: 0
    idx:     (1,11)
 With weight: 16
 pt[2]:    location: -1.875  1.125
+   is located on boundary: 0
    idx:     (0,12)
 With weight: 16
 pt[3]:    location: -1.375  1.125
+   is located on boundary: 0
    idx:     (2,12)
 With weight: 16
 pt[4]:    location: -1.625  1.375
+   is located on boundary: 0
    idx:     (1,13)
 With weight: 16
 
 On point:    location: -1.375  1.125
+   is located on boundary: 0
    idx:     (2,12)
 pt[0]:    location: -1.375  1.125
+   is located on boundary: 0
    idx:     (2,12)
 With weight: -64
 pt[1]:    location: -1.375  0.875
+   is located on boundary: 0
    idx:     (2,11)
 With weight: 16
 pt[2]:    location: -1.625  1.125
+   is located on boundary: 0
    idx:     (1,12)
 With weight: 16
 pt[3]:    location: -1.125  1.125
+   is located on boundary: 0
    idx:     (3,12)
 With weight: 16
 pt[4]:    location: -1.375  1.375
+   is located on boundary: 0
    idx:     (2,13)
 With weight: 16
 
 On point:    location: -1.125  1.125
+   is located on boundary: 0
    idx:     (3,12)
 pt[0]:    location: -1.125  1.125
+   is located on boundary: 0
    idx:     (3,12)
 With weight: -64
 pt[1]:    location: -1.125  0.875
+   is located on boundary: 0
    idx:     (3,11)
 With weight: 16
 pt[2]:    location: -1.375  1.125
+   is located on boundary: 0
    idx:     (2,12)
 With weight: 16
 pt[3]:    location: -0.875  1.125
+   is located on boundary: 0
    idx:     (4,12)
 With weight: 16
 pt[4]:    location: -1.125  1.375
+   is located on boundary: 0
    idx:     (3,13)
 With weight: 16
 
 On point:    location: -0.875  1.125
+   is located on boundary: 0
    idx:     (4,12)
 pt[0]:    location: -0.875  1.125
+   is located on boundary: 0
    idx:     (4,12)
 With weight: -45.1765
 pt[1]:    location: -1.125  1.125
+   is located on boundary: 0
    idx:     (3,12)
 With weight: 8.47059
 pt[2]:    location: -0.625  1.125
+   is located on boundary: 0
    idx:     (5,12)
 With weight: 16
 pt[3]:    location: -0.875  1.375
+   is located on boundary: 0
    idx:     (4,13)
 With weight: 13.1765
 pt[4]:    location: -1.125  0.875
+   is located on boundary: 0
    idx:     (3,11)
 With weight: 7.52941
 
 On point:    location: -0.625  1.125
+   is located on boundary: 0
    idx:     (5,12)
 pt[0]:    location: -0.625  1.125
+   is located on boundary: 0
    idx:     (5,12)
 With weight: -21.3333
 pt[1]:    location: -0.875  1.125
+   is located on boundary: 0
    idx:     (4,12)
 With weight: 10.6667
 pt[2]:    location: -0.625  1.375
+   is located on boundary: 0
    idx:     (5,13)
-With weight: -4.5252e-16
+With weight: 5.00358e-15
 pt[3]:    location: -0.875  1.375
+   is located on boundary: 0
    idx:     (4,13)
 With weight: 2.66667
 pt[4]:    location: -0.375  1.375
+   is located on boundary: 0
    idx:     (6,13)
 With weight: 8
 
 On point:    location: 0.625 1.125
+   is located on boundary: 0
    idx:     (10,12)
 pt[0]:    location: 0.625 1.125
+   is located on boundary: 0
    idx:     (10,12)
 With weight: -21.3333
 pt[1]:    location: 0.875 1.125
+   is located on boundary: 0
    idx:     (11,12)
 With weight: 10.6667
 pt[2]:    location: 0.625 1.375
+   is located on boundary: 0
    idx:     (10,13)
-With weight: 1.43884e-16
+With weight: 1.19902e-15
 pt[3]:    location: 0.375 1.375
+   is located on boundary: 0
    idx:     (9,13)
 With weight: 8
 pt[4]:    location: 0.875 1.375
+   is located on boundary: 0
    idx:     (11,13)
 With weight: 2.66667
 
 On point:    location: 0.875 1.125
+   is located on boundary: 0
    idx:     (11,12)
 pt[0]:    location: 0.875 1.125
+   is located on boundary: 0
    idx:     (11,12)
 With weight: -45.1765
 pt[1]:    location: 0.625 1.125
+   is located on boundary: 0
    idx:     (10,12)
 With weight: 16
 pt[2]:    location: 1.125 1.125
+   is located on boundary: 0
    idx:     (12,12)
 With weight: 8.47059
 pt[3]:    location: 0.875 1.375
+   is located on boundary: 0
    idx:     (11,13)
 With weight: 13.1765
 pt[4]:    location: 1.125 0.875
+   is located on boundary: 0
    idx:     (12,11)
 With weight: 7.52941
 
 On point:    location: 1.125 1.125
+   is located on boundary: 0
    idx:     (12,12)
 pt[0]:    location: 1.125 1.125
+   is located on boundary: 0
    idx:     (12,12)
 With weight: -64
 pt[1]:    location: 1.125 0.875
+   is located on boundary: 0
    idx:     (12,11)
 With weight: 16
 pt[2]:    location: 0.875 1.125
+   is located on boundary: 0
    idx:     (11,12)
 With weight: 16
 pt[3]:    location: 1.375 1.125
+   is located on boundary: 0
    idx:     (13,12)
 With weight: 16
 pt[4]:    location: 1.125 1.375
+   is located on boundary: 0
    idx:     (12,13)
 With weight: 16
 
 On point:    location: 1.375 1.125
+   is located on boundary: 0
    idx:     (13,12)
 pt[0]:    location: 1.375 1.125
+   is located on boundary: 0
    idx:     (13,12)
 With weight: -64
 pt[1]:    location: 1.375 0.875
+   is located on boundary: 0
    idx:     (13,11)
 With weight: 16
 pt[2]:    location: 1.125 1.125
+   is located on boundary: 0
    idx:     (12,12)
 With weight: 16
 pt[3]:    location: 1.625 1.125
+   is located on boundary: 0
    idx:     (14,12)
 With weight: 16
 pt[4]:    location: 1.375 1.375
+   is located on boundary: 0
    idx:     (13,13)
 With weight: 16
 
 On point:    location: 1.625 1.125
+   is located on boundary: 0
    idx:     (14,12)
 pt[0]:    location: 1.625 1.125
+   is located on boundary: 0
    idx:     (14,12)
 With weight: -64
 pt[1]:    location: 1.625 0.875
+   is located on boundary: 0
    idx:     (14,11)
 With weight: 16
 pt[2]:    location: 1.375 1.125
+   is located on boundary: 0
    idx:     (13,12)
 With weight: 16
 pt[3]:    location: 1.875 1.125
+   is located on boundary: 0
    idx:     (15,12)
 With weight: 16
 pt[4]:    location: 1.625 1.375
+   is located on boundary: 0
    idx:     (14,13)
 With weight: 16
 
 On point:    location: 1.875 1.125
+   is located on boundary: 0
    idx:     (15,12)
 pt[0]:    location: 1.875 1.125
+   is located on boundary: 0
    idx:     (15,12)
 With weight: -64
 pt[1]:    location: 1.875 0.875
+   is located on boundary: 0
    idx:     (15,11)
 With weight: 16
 pt[2]:    location: 1.625 1.125
+   is located on boundary: 0
    idx:     (14,12)
 With weight: 16
 pt[3]:    location: 2.125 1.125
+   is located on boundary: 0
    idx:     (16,12)
 With weight: 16
 pt[4]:    location: 1.875 1.375
+   is located on boundary: 0
    idx:     (15,13)
 With weight: 16
 
 On point:    location: -1.875  1.375
+   is located on boundary: 0
    idx:     (0,13)
 pt[0]:    location: -1.875  1.375
+   is located on boundary: 0
    idx:     (0,13)
 With weight: -64
 pt[1]:    location: -1.875  1.125
+   is located on boundary: 0
    idx:     (0,12)
 With weight: 16
 pt[2]:    location: -2.125  1.375
+   is located on boundary: 0
    idx:     (-1,13)
 With weight: 16
 pt[3]:    location: -1.625  1.375
+   is located on boundary: 0
    idx:     (1,13)
 With weight: 16
 pt[4]:    location: -1.875  1.625
+   is located on boundary: 0
    idx:     (0,14)
 With weight: 16
 
 On point:    location: -1.625  1.375
+   is located on boundary: 0
    idx:     (1,13)
 pt[0]:    location: -1.625  1.375
+   is located on boundary: 0
    idx:     (1,13)
 With weight: -64
 pt[1]:    location: -1.625  1.125
+   is located on boundary: 0
    idx:     (1,12)
 With weight: 16
 pt[2]:    location: -1.875  1.375
+   is located on boundary: 0
    idx:     (0,13)
 With weight: 16
 pt[3]:    location: -1.375  1.375
+   is located on boundary: 0
    idx:     (2,13)
 With weight: 16
 pt[4]:    location: -1.625  1.625
+   is located on boundary: 0
    idx:     (1,14)
 With weight: 16
 
 On point:    location: -1.375  1.375
+   is located on boundary: 0
    idx:     (2,13)
 pt[0]:    location: -1.375  1.375
+   is located on boundary: 0
    idx:     (2,13)
 With weight: -64
 pt[1]:    location: -1.375  1.125
+   is located on boundary: 0
    idx:     (2,12)
 With weight: 16
 pt[2]:    location: -1.625  1.375
+   is located on boundary: 0
    idx:     (1,13)
 With weight: 16
 pt[3]:    location: -1.125  1.375
+   is located on boundary: 0
    idx:     (3,13)
 With weight: 16
 pt[4]:    location: -1.375  1.625
+   is located on boundary: 0
    idx:     (2,14)
 With weight: 16
 
 On point:    location: -1.125  1.375
+   is located on boundary: 0
    idx:     (3,13)
 pt[0]:    location: -1.125  1.375
+   is located on boundary: 0
    idx:     (3,13)
 With weight: -64
 pt[1]:    location: -1.125  1.125
+   is located on boundary: 0
    idx:     (3,12)
 With weight: 16
 pt[2]:    location: -1.375  1.375
+   is located on boundary: 0
    idx:     (2,13)
 With weight: 16
 pt[3]:    location: -0.875  1.375
+   is located on boundary: 0
    idx:     (4,13)
 With weight: 16
 pt[4]:    location: -1.125  1.625
+   is located on boundary: 0
    idx:     (3,14)
 With weight: 16
 
 On point:    location: -0.875  1.375
+   is located on boundary: 0
    idx:     (4,13)
 pt[0]:    location: -0.875  1.375
+   is located on boundary: 0
    idx:     (4,13)
 With weight: -64
 pt[1]:    location: -0.875  1.125
+   is located on boundary: 0
    idx:     (4,12)
 With weight: 16
 pt[2]:    location: -1.125  1.375
+   is located on boundary: 0
    idx:     (3,13)
 With weight: 16
 pt[3]:    location: -0.625  1.375
+   is located on boundary: 0
    idx:     (5,13)
 With weight: 16
 pt[4]:    location: -0.875  1.625
+   is located on boundary: 0
    idx:     (4,14)
 With weight: 16
 
 On point:    location: -0.625  1.375
+   is located on boundary: 0
    idx:     (5,13)
 pt[0]:    location: -0.625  1.375
+   is located on boundary: 0
    idx:     (5,13)
 With weight: -64
 pt[1]:    location: -0.625  1.125
+   is located on boundary: 0
    idx:     (5,12)
 With weight: 16
 pt[2]:    location: -0.875  1.375
+   is located on boundary: 0
    idx:     (4,13)
 With weight: 16
 pt[3]:    location: -0.375  1.375
+   is located on boundary: 0
    idx:     (6,13)
 With weight: 16
 pt[4]:    location: -0.625  1.625
+   is located on boundary: 0
    idx:     (5,14)
 With weight: 16
 
 On point:    location: -0.375  1.375
+   is located on boundary: 0
    idx:     (6,13)
 pt[0]:    location: -0.375  1.375
+   is located on boundary: 0
    idx:     (6,13)
 With weight: -45.1765
 pt[1]:    location: -0.625  1.375
+   is located on boundary: 0
    idx:     (5,13)
 With weight: 8.47059
 pt[2]:    location: -0.125  1.375
+   is located on boundary: 0
    idx:     (7,13)
 With weight: 16
 pt[3]:    location: -0.375  1.625
+   is located on boundary: 0
    idx:     (6,14)
 With weight: 13.1765
 pt[4]:    location: -0.625  1.125
+   is located on boundary: 0
    idx:     (5,12)
 With weight: 7.52941
 
 On point:    location: -0.125  1.375
+   is located on boundary: 0
    idx:     (7,13)
 pt[0]:    location: -0.125  1.375
+   is located on boundary: 0
    idx:     (7,13)
 With weight: -42.6667
 pt[1]:    location: -0.375  1.375
+   is located on boundary: 0
    idx:     (6,13)
 With weight: 16
 pt[2]:    location: 0.125 1.375
+   is located on boundary: 0
    idx:     (8,13)
 With weight: 16
 pt[3]:    location: -0.125  1.625
+   is located on boundary: 0
    idx:     (7,14)
 With weight: 10.6667
 pt[4]:    location: -0.375  1.625
+   is located on boundary: 0
    idx:     (6,14)
-With weight: -6.55255e-16
+With weight: -2.03635e-15
 
 On point:    location: 0.125 1.375
+   is located on boundary: 0
    idx:     (8,13)
 pt[0]:    location: 0.125 1.375
+   is located on boundary: 0
    idx:     (8,13)
 With weight: -42.6667
 pt[1]:    location: -0.125  1.375
+   is located on boundary: 0
    idx:     (7,13)
 With weight: 16
 pt[2]:    location: 0.375 1.375
+   is located on boundary: 0
    idx:     (9,13)
 With weight: 16
 pt[3]:    location: 0.125 1.625
+   is located on boundary: 0
    idx:     (8,14)
 With weight: 10.6667
 pt[4]:    location: 0.375 1.625
+   is located on boundary: 0
    idx:     (9,14)
-With weight: -1.31992e-15
+With weight: 2.32318e-16
 
 On point:    location: 0.375 1.375
+   is located on boundary: 0
    idx:     (9,13)
 pt[0]:    location: 0.375 1.375
+   is located on boundary: 0
    idx:     (9,13)
 With weight: -45.1765
 pt[1]:    location: 0.125 1.375
+   is located on boundary: 0
    idx:     (8,13)
 With weight: 16
 pt[2]:    location: 0.625 1.375
+   is located on boundary: 0
    idx:     (10,13)
 With weight: 8.47059
 pt[3]:    location: 0.375 1.625
+   is located on boundary: 0
    idx:     (9,14)
 With weight: 13.1765
 pt[4]:    location: 0.625 1.125
+   is located on boundary: 0
    idx:     (10,12)
 With weight: 7.52941
 
 On point:    location: 0.625 1.375
+   is located on boundary: 0
    idx:     (10,13)
 pt[0]:    location: 0.625 1.375
+   is located on boundary: 0
    idx:     (10,13)
 With weight: -64
 pt[1]:    location: 0.625 1.125
+   is located on boundary: 0
    idx:     (10,12)
 With weight: 16
 pt[2]:    location: 0.375 1.375
+   is located on boundary: 0
    idx:     (9,13)
 With weight: 16
 pt[3]:    location: 0.875 1.375
+   is located on boundary: 0
    idx:     (11,13)
 With weight: 16
 pt[4]:    location: 0.625 1.625
+   is located on boundary: 0
    idx:     (10,14)
 With weight: 16
 
 On point:    location: 0.875 1.375
+   is located on boundary: 0
    idx:     (11,13)
 pt[0]:    location: 0.875 1.375
+   is located on boundary: 0
    idx:     (11,13)
 With weight: -64
 pt[1]:    location: 0.875 1.125
+   is located on boundary: 0
    idx:     (11,12)
 With weight: 16
 pt[2]:    location: 0.625 1.375
+   is located on boundary: 0
    idx:     (10,13)
 With weight: 16
 pt[3]:    location: 1.125 1.375
+   is located on boundary: 0
    idx:     (12,13)
 With weight: 16
 pt[4]:    location: 0.875 1.625
+   is located on boundary: 0
    idx:     (11,14)
 With weight: 16
 
 On point:    location: 1.125 1.375
+   is located on boundary: 0
    idx:     (12,13)
 pt[0]:    location: 1.125 1.375
+   is located on boundary: 0
    idx:     (12,13)
 With weight: -64
 pt[1]:    location: 1.125 1.125
+   is located on boundary: 0
    idx:     (12,12)
 With weight: 16
 pt[2]:    location: 0.875 1.375
+   is located on boundary: 0
    idx:     (11,13)
 With weight: 16
 pt[3]:    location: 1.375 1.375
+   is located on boundary: 0
    idx:     (13,13)
 With weight: 16
 pt[4]:    location: 1.125 1.625
+   is located on boundary: 0
    idx:     (12,14)
 With weight: 16
 
 On point:    location: 1.375 1.375
+   is located on boundary: 0
    idx:     (13,13)
 pt[0]:    location: 1.375 1.375
+   is located on boundary: 0
    idx:     (13,13)
 With weight: -64
 pt[1]:    location: 1.375 1.125
+   is located on boundary: 0
    idx:     (13,12)
 With weight: 16
 pt[2]:    location: 1.125 1.375
+   is located on boundary: 0
    idx:     (12,13)
 With weight: 16
 pt[3]:    location: 1.625 1.375
+   is located on boundary: 0
    idx:     (14,13)
 With weight: 16
 pt[4]:    location: 1.375 1.625
+   is located on boundary: 0
    idx:     (13,14)
 With weight: 16
 
 On point:    location: 1.625 1.375
+   is located on boundary: 0
    idx:     (14,13)
 pt[0]:    location: 1.625 1.375
+   is located on boundary: 0
    idx:     (14,13)
 With weight: -64
 pt[1]:    location: 1.625 1.125
+   is located on boundary: 0
    idx:     (14,12)
 With weight: 16
 pt[2]:    location: 1.375 1.375
+   is located on boundary: 0
    idx:     (13,13)
 With weight: 16
 pt[3]:    location: 1.875 1.375
+   is located on boundary: 0
    idx:     (15,13)
 With weight: 16
 pt[4]:    location: 1.625 1.625
+   is located on boundary: 0
    idx:     (14,14)
 With weight: 16
 
 On point:    location: 1.875 1.375
+   is located on boundary: 0
    idx:     (15,13)
 pt[0]:    location: 1.875 1.375
+   is located on boundary: 0
    idx:     (15,13)
 With weight: -64
 pt[1]:    location: 1.875 1.125
+   is located on boundary: 0
    idx:     (15,12)
 With weight: 16
 pt[2]:    location: 1.625 1.375
+   is located on boundary: 0
    idx:     (14,13)
 With weight: 16
 pt[3]:    location: 2.125 1.375
+   is located on boundary: 0
    idx:     (16,13)
 With weight: 16
 pt[4]:    location: 1.875 1.625
+   is located on boundary: 0
    idx:     (15,14)
 With weight: 16
 
 On point:    location: -1.875  1.625
+   is located on boundary: 0
    idx:     (0,14)
 pt[0]:    location: -1.875  1.625
+   is located on boundary: 0
    idx:     (0,14)
 With weight: -64
 pt[1]:    location: -1.875  1.375
+   is located on boundary: 0
    idx:     (0,13)
 With weight: 16
 pt[2]:    location: -2.125  1.625
+   is located on boundary: 0
    idx:     (-1,14)
 With weight: 16
 pt[3]:    location: -1.625  1.625
+   is located on boundary: 0
    idx:     (1,14)
 With weight: 16
 pt[4]:    location: -1.875  1.875
+   is located on boundary: 0
    idx:     (0,15)
 With weight: 16
 
 On point:    location: -1.625  1.625
+   is located on boundary: 0
    idx:     (1,14)
 pt[0]:    location: -1.625  1.625
+   is located on boundary: 0
    idx:     (1,14)
 With weight: -64
 pt[1]:    location: -1.625  1.375
+   is located on boundary: 0
    idx:     (1,13)
 With weight: 16
 pt[2]:    location: -1.875  1.625
+   is located on boundary: 0
    idx:     (0,14)
 With weight: 16
 pt[3]:    location: -1.375  1.625
+   is located on boundary: 0
    idx:     (2,14)
 With weight: 16
 pt[4]:    location: -1.625  1.875
+   is located on boundary: 0
    idx:     (1,15)
 With weight: 16
 
 On point:    location: -1.375  1.625
+   is located on boundary: 0
    idx:     (2,14)
 pt[0]:    location: -1.375  1.625
+   is located on boundary: 0
    idx:     (2,14)
 With weight: -64
 pt[1]:    location: -1.375  1.375
+   is located on boundary: 0
    idx:     (2,13)
 With weight: 16
 pt[2]:    location: -1.625  1.625
+   is located on boundary: 0
    idx:     (1,14)
 With weight: 16
 pt[3]:    location: -1.125  1.625
+   is located on boundary: 0
    idx:     (3,14)
 With weight: 16
 pt[4]:    location: -1.375  1.875
+   is located on boundary: 0
    idx:     (2,15)
 With weight: 16
 
 On point:    location: -1.125  1.625
+   is located on boundary: 0
    idx:     (3,14)
 pt[0]:    location: -1.125  1.625
+   is located on boundary: 0
    idx:     (3,14)
 With weight: -64
 pt[1]:    location: -1.125  1.375
+   is located on boundary: 0
    idx:     (3,13)
 With weight: 16
 pt[2]:    location: -1.375  1.625
+   is located on boundary: 0
    idx:     (2,14)
 With weight: 16
 pt[3]:    location: -0.875  1.625
+   is located on boundary: 0
    idx:     (4,14)
 With weight: 16
 pt[4]:    location: -1.125  1.875
+   is located on boundary: 0
    idx:     (3,15)
 With weight: 16
 
 On point:    location: -0.875  1.625
+   is located on boundary: 0
    idx:     (4,14)
 pt[0]:    location: -0.875  1.625
+   is located on boundary: 0
    idx:     (4,14)
 With weight: -64
 pt[1]:    location: -0.875  1.375
+   is located on boundary: 0
    idx:     (4,13)
 With weight: 16
 pt[2]:    location: -1.125  1.625
+   is located on boundary: 0
    idx:     (3,14)
 With weight: 16
 pt[3]:    location: -0.625  1.625
+   is located on boundary: 0
    idx:     (5,14)
 With weight: 16
 pt[4]:    location: -0.875  1.875
+   is located on boundary: 0
    idx:     (4,15)
 With weight: 16
 
 On point:    location: -0.625  1.625
+   is located on boundary: 0
    idx:     (5,14)
 pt[0]:    location: -0.625  1.625
+   is located on boundary: 0
    idx:     (5,14)
 With weight: -64
 pt[1]:    location: -0.625  1.375
+   is located on boundary: 0
    idx:     (5,13)
 With weight: 16
 pt[2]:    location: -0.875  1.625
+   is located on boundary: 0
    idx:     (4,14)
 With weight: 16
 pt[3]:    location: -0.375  1.625
+   is located on boundary: 0
    idx:     (6,14)
 With weight: 16
 pt[4]:    location: -0.625  1.875
+   is located on boundary: 0
    idx:     (5,15)
 With weight: 16
 
 On point:    location: -0.375  1.625
+   is located on boundary: 0
    idx:     (6,14)
 pt[0]:    location: -0.375  1.625
+   is located on boundary: 0
    idx:     (6,14)
 With weight: -64
 pt[1]:    location: -0.375  1.375
+   is located on boundary: 0
    idx:     (6,13)
 With weight: 16
 pt[2]:    location: -0.625  1.625
+   is located on boundary: 0
    idx:     (5,14)
 With weight: 16
 pt[3]:    location: -0.125  1.625
+   is located on boundary: 0
    idx:     (7,14)
 With weight: 16
 pt[4]:    location: -0.375  1.875
+   is located on boundary: 0
    idx:     (6,15)
 With weight: 16
 
 On point:    location: -0.125  1.625
+   is located on boundary: 0
    idx:     (7,14)
 pt[0]:    location: -0.125  1.625
+   is located on boundary: 0
    idx:     (7,14)
 With weight: -64
 pt[1]:    location: -0.125  1.375
+   is located on boundary: 0
    idx:     (7,13)
 With weight: 16
 pt[2]:    location: -0.375  1.625
+   is located on boundary: 0
    idx:     (6,14)
 With weight: 16
 pt[3]:    location: 0.125 1.625
+   is located on boundary: 0
    idx:     (8,14)
 With weight: 16
 pt[4]:    location: -0.125  1.875
+   is located on boundary: 0
    idx:     (7,15)
 With weight: 16
 
 On point:    location: 0.125 1.625
+   is located on boundary: 0
    idx:     (8,14)
 pt[0]:    location: 0.125 1.625
+   is located on boundary: 0
    idx:     (8,14)
 With weight: -64
 pt[1]:    location: 0.125 1.375
+   is located on boundary: 0
    idx:     (8,13)
 With weight: 16
 pt[2]:    location: -0.125  1.625
+   is located on boundary: 0
    idx:     (7,14)
 With weight: 16
 pt[3]:    location: 0.375 1.625
+   is located on boundary: 0
    idx:     (9,14)
 With weight: 16
 pt[4]:    location: 0.125 1.875
+   is located on boundary: 0
    idx:     (8,15)
 With weight: 16
 
 On point:    location: 0.375 1.625
+   is located on boundary: 0
    idx:     (9,14)
 pt[0]:    location: 0.375 1.625
+   is located on boundary: 0
    idx:     (9,14)
 With weight: -64
 pt[1]:    location: 0.375 1.375
+   is located on boundary: 0
    idx:     (9,13)
 With weight: 16
 pt[2]:    location: 0.125 1.625
+   is located on boundary: 0
    idx:     (8,14)
 With weight: 16
 pt[3]:    location: 0.625 1.625
+   is located on boundary: 0
    idx:     (10,14)
 With weight: 16
 pt[4]:    location: 0.375 1.875
+   is located on boundary: 0
    idx:     (9,15)
 With weight: 16
 
 On point:    location: 0.625 1.625
+   is located on boundary: 0
    idx:     (10,14)
 pt[0]:    location: 0.625 1.625
+   is located on boundary: 0
    idx:     (10,14)
 With weight: -64
 pt[1]:    location: 0.625 1.375
+   is located on boundary: 0
    idx:     (10,13)
 With weight: 16
 pt[2]:    location: 0.375 1.625
+   is located on boundary: 0
    idx:     (9,14)
 With weight: 16
 pt[3]:    location: 0.875 1.625
+   is located on boundary: 0
    idx:     (11,14)
 With weight: 16
 pt[4]:    location: 0.625 1.875
+   is located on boundary: 0
    idx:     (10,15)
 With weight: 16
 
 On point:    location: 0.875 1.625
+   is located on boundary: 0
    idx:     (11,14)
 pt[0]:    location: 0.875 1.625
+   is located on boundary: 0
    idx:     (11,14)
 With weight: -64
 pt[1]:    location: 0.875 1.375
+   is located on boundary: 0
    idx:     (11,13)
 With weight: 16
 pt[2]:    location: 0.625 1.625
+   is located on boundary: 0
    idx:     (10,14)
 With weight: 16
 pt[3]:    location: 1.125 1.625
+   is located on boundary: 0
    idx:     (12,14)
 With weight: 16
 pt[4]:    location: 0.875 1.875
+   is located on boundary: 0
    idx:     (11,15)
 With weight: 16
 
 On point:    location: 1.125 1.625
+   is located on boundary: 0
    idx:     (12,14)
 pt[0]:    location: 1.125 1.625
+   is located on boundary: 0
    idx:     (12,14)
 With weight: -64
 pt[1]:    location: 1.125 1.375
+   is located on boundary: 0
    idx:     (12,13)
 With weight: 16
 pt[2]:    location: 0.875 1.625
+   is located on boundary: 0
    idx:     (11,14)
 With weight: 16
 pt[3]:    location: 1.375 1.625
+   is located on boundary: 0
    idx:     (13,14)
 With weight: 16
 pt[4]:    location: 1.125 1.875
+   is located on boundary: 0
    idx:     (12,15)
 With weight: 16
 
 On point:    location: 1.375 1.625
+   is located on boundary: 0
    idx:     (13,14)
 pt[0]:    location: 1.375 1.625
+   is located on boundary: 0
    idx:     (13,14)
 With weight: -64
 pt[1]:    location: 1.375 1.375
+   is located on boundary: 0
    idx:     (13,13)
 With weight: 16
 pt[2]:    location: 1.125 1.625
+   is located on boundary: 0
    idx:     (12,14)
 With weight: 16
 pt[3]:    location: 1.625 1.625
+   is located on boundary: 0
    idx:     (14,14)
 With weight: 16
 pt[4]:    location: 1.375 1.875
+   is located on boundary: 0
    idx:     (13,15)
 With weight: 16
 
 On point:    location: 1.625 1.625
+   is located on boundary: 0
    idx:     (14,14)
 pt[0]:    location: 1.625 1.625
+   is located on boundary: 0
    idx:     (14,14)
 With weight: -64
 pt[1]:    location: 1.625 1.375
+   is located on boundary: 0
    idx:     (14,13)
 With weight: 16
 pt[2]:    location: 1.375 1.625
+   is located on boundary: 0
    idx:     (13,14)
 With weight: 16
 pt[3]:    location: 1.875 1.625
+   is located on boundary: 0
    idx:     (15,14)
 With weight: 16
 pt[4]:    location: 1.625 1.875
+   is located on boundary: 0
    idx:     (14,15)
 With weight: 16
 
 On point:    location: 1.875 1.625
+   is located on boundary: 0
    idx:     (15,14)
 pt[0]:    location: 1.875 1.625
+   is located on boundary: 0
    idx:     (15,14)
 With weight: -64
 pt[1]:    location: 1.875 1.375
+   is located on boundary: 0
    idx:     (15,13)
 With weight: 16
 pt[2]:    location: 1.625 1.625
+   is located on boundary: 0
    idx:     (14,14)
 With weight: 16
 pt[3]:    location: 2.125 1.625
+   is located on boundary: 0
    idx:     (16,14)
 With weight: 16
 pt[4]:    location: 1.875 1.875
+   is located on boundary: 0
    idx:     (15,15)
 With weight: 16
 
 On point:    location: -1.875  1.875
+   is located on boundary: 0
    idx:     (0,15)
 pt[0]:    location: -1.875  1.875
+   is located on boundary: 0
    idx:     (0,15)
 With weight: -64
 pt[1]:    location: -1.875  1.625
+   is located on boundary: 0
    idx:     (0,14)
 With weight: 16
 pt[2]:    location: -2.125  1.875
+   is located on boundary: 0
    idx:     (-1,15)
 With weight: 16
 pt[3]:    location: -1.625  1.875
+   is located on boundary: 0
    idx:     (1,15)
 With weight: 16
 pt[4]:    location: -1.875  2.125
+   is located on boundary: 0
    idx:     (0,16)
 With weight: 16
 
 On point:    location: -1.625  1.875
+   is located on boundary: 0
    idx:     (1,15)
 pt[0]:    location: -1.625  1.875
+   is located on boundary: 0
    idx:     (1,15)
 With weight: -64
 pt[1]:    location: -1.625  1.625
+   is located on boundary: 0
    idx:     (1,14)
 With weight: 16
 pt[2]:    location: -1.875  1.875
+   is located on boundary: 0
    idx:     (0,15)
 With weight: 16
 pt[3]:    location: -1.375  1.875
+   is located on boundary: 0
    idx:     (2,15)
 With weight: 16
 pt[4]:    location: -1.625  2.125
+   is located on boundary: 0
    idx:     (1,16)
 With weight: 16
 
 On point:    location: -1.375  1.875
+   is located on boundary: 0
    idx:     (2,15)
 pt[0]:    location: -1.375  1.875
+   is located on boundary: 0
    idx:     (2,15)
 With weight: -64
 pt[1]:    location: -1.375  1.625
+   is located on boundary: 0
    idx:     (2,14)
 With weight: 16
 pt[2]:    location: -1.625  1.875
+   is located on boundary: 0
    idx:     (1,15)
 With weight: 16
 pt[3]:    location: -1.125  1.875
+   is located on boundary: 0
    idx:     (3,15)
 With weight: 16
 pt[4]:    location: -1.375  2.125
+   is located on boundary: 0
    idx:     (2,16)
 With weight: 16
 
 On point:    location: -1.125  1.875
+   is located on boundary: 0
    idx:     (3,15)
 pt[0]:    location: -1.125  1.875
+   is located on boundary: 0
    idx:     (3,15)
 With weight: -64
 pt[1]:    location: -1.125  1.625
+   is located on boundary: 0
    idx:     (3,14)
 With weight: 16
 pt[2]:    location: -1.375  1.875
+   is located on boundary: 0
    idx:     (2,15)
 With weight: 16
 pt[3]:    location: -0.875  1.875
+   is located on boundary: 0
    idx:     (4,15)
 With weight: 16
 pt[4]:    location: -1.125  2.125
+   is located on boundary: 0
    idx:     (3,16)
 With weight: 16
 
 On point:    location: -0.875  1.875
+   is located on boundary: 0
    idx:     (4,15)
 pt[0]:    location: -0.875  1.875
+   is located on boundary: 0
    idx:     (4,15)
 With weight: -64
 pt[1]:    location: -0.875  1.625
+   is located on boundary: 0
    idx:     (4,14)
 With weight: 16
 pt[2]:    location: -1.125  1.875
+   is located on boundary: 0
    idx:     (3,15)
 With weight: 16
 pt[3]:    location: -0.625  1.875
+   is located on boundary: 0
    idx:     (5,15)
 With weight: 16
 pt[4]:    location: -0.875  2.125
+   is located on boundary: 0
    idx:     (4,16)
 With weight: 16
 
 On point:    location: -0.625  1.875
+   is located on boundary: 0
    idx:     (5,15)
 pt[0]:    location: -0.625  1.875
+   is located on boundary: 0
    idx:     (5,15)
 With weight: -64
 pt[1]:    location: -0.625  1.625
+   is located on boundary: 0
    idx:     (5,14)
 With weight: 16
 pt[2]:    location: -0.875  1.875
+   is located on boundary: 0
    idx:     (4,15)
 With weight: 16
 pt[3]:    location: -0.375  1.875
+   is located on boundary: 0
    idx:     (6,15)
 With weight: 16
 pt[4]:    location: -0.625  2.125
+   is located on boundary: 0
    idx:     (5,16)
 With weight: 16
 
 On point:    location: -0.375  1.875
+   is located on boundary: 0
    idx:     (6,15)
 pt[0]:    location: -0.375  1.875
+   is located on boundary: 0
    idx:     (6,15)
 With weight: -64
 pt[1]:    location: -0.375  1.625
+   is located on boundary: 0
    idx:     (6,14)
 With weight: 16
 pt[2]:    location: -0.625  1.875
+   is located on boundary: 0
    idx:     (5,15)
 With weight: 16
 pt[3]:    location: -0.125  1.875
+   is located on boundary: 0
    idx:     (7,15)
 With weight: 16
 pt[4]:    location: -0.375  2.125
+   is located on boundary: 0
    idx:     (6,16)
 With weight: 16
 
 On point:    location: -0.125  1.875
+   is located on boundary: 0
    idx:     (7,15)
 pt[0]:    location: -0.125  1.875
+   is located on boundary: 0
    idx:     (7,15)
 With weight: -64
 pt[1]:    location: -0.125  1.625
+   is located on boundary: 0
    idx:     (7,14)
 With weight: 16
 pt[2]:    location: -0.375  1.875
+   is located on boundary: 0
    idx:     (6,15)
 With weight: 16
 pt[3]:    location: 0.125 1.875
+   is located on boundary: 0
    idx:     (8,15)
 With weight: 16
 pt[4]:    location: -0.125  2.125
+   is located on boundary: 0
    idx:     (7,16)
 With weight: 16
 
 On point:    location: 0.125 1.875
+   is located on boundary: 0
    idx:     (8,15)
 pt[0]:    location: 0.125 1.875
+   is located on boundary: 0
    idx:     (8,15)
 With weight: -64
 pt[1]:    location: 0.125 1.625
+   is located on boundary: 0
    idx:     (8,14)
 With weight: 16
 pt[2]:    location: -0.125  1.875
+   is located on boundary: 0
    idx:     (7,15)
 With weight: 16
 pt[3]:    location: 0.375 1.875
+   is located on boundary: 0
    idx:     (9,15)
 With weight: 16
 pt[4]:    location: 0.125 2.125
+   is located on boundary: 0
    idx:     (8,16)
 With weight: 16
 
 On point:    location: 0.375 1.875
+   is located on boundary: 0
    idx:     (9,15)
 pt[0]:    location: 0.375 1.875
+   is located on boundary: 0
    idx:     (9,15)
 With weight: -64
 pt[1]:    location: 0.375 1.625
+   is located on boundary: 0
    idx:     (9,14)
 With weight: 16
 pt[2]:    location: 0.125 1.875
+   is located on boundary: 0
    idx:     (8,15)
 With weight: 16
 pt[3]:    location: 0.625 1.875
+   is located on boundary: 0
    idx:     (10,15)
 With weight: 16
 pt[4]:    location: 0.375 2.125
+   is located on boundary: 0
    idx:     (9,16)
 With weight: 16
 
 On point:    location: 0.625 1.875
+   is located on boundary: 0
    idx:     (10,15)
 pt[0]:    location: 0.625 1.875
+   is located on boundary: 0
    idx:     (10,15)
 With weight: -64
 pt[1]:    location: 0.625 1.625
+   is located on boundary: 0
    idx:     (10,14)
 With weight: 16
 pt[2]:    location: 0.375 1.875
+   is located on boundary: 0
    idx:     (9,15)
 With weight: 16
 pt[3]:    location: 0.875 1.875
+   is located on boundary: 0
    idx:     (11,15)
 With weight: 16
 pt[4]:    location: 0.625 2.125
+   is located on boundary: 0
    idx:     (10,16)
 With weight: 16
 
 On point:    location: 0.875 1.875
+   is located on boundary: 0
    idx:     (11,15)
 pt[0]:    location: 0.875 1.875
+   is located on boundary: 0
    idx:     (11,15)
 With weight: -64
 pt[1]:    location: 0.875 1.625
+   is located on boundary: 0
    idx:     (11,14)
 With weight: 16
 pt[2]:    location: 0.625 1.875
+   is located on boundary: 0
    idx:     (10,15)
 With weight: 16
 pt[3]:    location: 1.125 1.875
+   is located on boundary: 0
    idx:     (12,15)
 With weight: 16
 pt[4]:    location: 0.875 2.125
+   is located on boundary: 0
    idx:     (11,16)
 With weight: 16
 
 On point:    location: 1.125 1.875
+   is located on boundary: 0
    idx:     (12,15)
 pt[0]:    location: 1.125 1.875
+   is located on boundary: 0
    idx:     (12,15)
 With weight: -64
 pt[1]:    location: 1.125 1.625
+   is located on boundary: 0
    idx:     (12,14)
 With weight: 16
 pt[2]:    location: 0.875 1.875
+   is located on boundary: 0
    idx:     (11,15)
 With weight: 16
 pt[3]:    location: 1.375 1.875
+   is located on boundary: 0
    idx:     (13,15)
 With weight: 16
 pt[4]:    location: 1.125 2.125
+   is located on boundary: 0
    idx:     (12,16)
 With weight: 16
 
 On point:    location: 1.375 1.875
+   is located on boundary: 0
    idx:     (13,15)
 pt[0]:    location: 1.375 1.875
+   is located on boundary: 0
    idx:     (13,15)
 With weight: -64
 pt[1]:    location: 1.375 1.625
+   is located on boundary: 0
    idx:     (13,14)
 With weight: 16
 pt[2]:    location: 1.125 1.875
+   is located on boundary: 0
    idx:     (12,15)
 With weight: 16
 pt[3]:    location: 1.625 1.875
+   is located on boundary: 0
    idx:     (14,15)
 With weight: 16
 pt[4]:    location: 1.375 2.125
+   is located on boundary: 0
    idx:     (13,16)
 With weight: 16
 
 On point:    location: 1.625 1.875
+   is located on boundary: 0
    idx:     (14,15)
 pt[0]:    location: 1.625 1.875
+   is located on boundary: 0
    idx:     (14,15)
 With weight: -64
 pt[1]:    location: 1.625 1.625
+   is located on boundary: 0
    idx:     (14,14)
 With weight: 16
 pt[2]:    location: 1.375 1.875
+   is located on boundary: 0
    idx:     (13,15)
 With weight: 16
 pt[3]:    location: 1.875 1.875
+   is located on boundary: 0
    idx:     (15,15)
 With weight: 16
 pt[4]:    location: 1.625 2.125
+   is located on boundary: 0
    idx:     (14,16)
 With weight: 16
 
 On point:    location: 1.875 1.875
+   is located on boundary: 0
    idx:     (15,15)
 pt[0]:    location: 1.875 1.875
+   is located on boundary: 0
    idx:     (15,15)
 With weight: -64
 pt[1]:    location: 1.875 1.625
+   is located on boundary: 0
    idx:     (15,14)
 With weight: 16
 pt[2]:    location: 1.625 1.875
+   is located on boundary: 0
    idx:     (14,15)
 With weight: 16
 pt[3]:    location: 2.125 1.875
+   is located on boundary: 0
    idx:     (16,15)
 With weight: 16
 pt[4]:    location: 1.875 2.125
+   is located on boundary: 0
    idx:     (15,16)
 With weight: 16
 

--- a/tests/operators/rbf_fd_weights_3d.output
+++ b/tests/operators/rbf_fd_weights_3d.output
@@ -1,8448 +1,11264 @@
 On point:    location: -1.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (0,0,0)
 pt[0]:    location: -1.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (0,0,0)
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -2.25
+   is located on boundary: 0
    idx:     (0,0,-1)
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -1.75
+   is located on boundary: 0
    idx:     (0,-1,0)
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (-1,0,0)
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (1,0,0)
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (0,1,0)
 With weight: 4
 pt[6]:    location: -1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (0,0,1)
 With weight: 4
 
 On point:    location: -1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (1,0,0)
 pt[0]:    location: -1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (1,0,0)
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -2.25
+   is located on boundary: 0
    idx:     (1,0,-1)
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -1.75
+   is located on boundary: 0
    idx:     (1,-1,0)
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (0,0,0)
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (2,0,0)
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (1,1,0)
 With weight: 4
 pt[6]:    location: -1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (1,0,1)
 With weight: 4
 
 On point:    location: -0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (2,0,0)
 pt[0]:    location: -0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (2,0,0)
 With weight: -24
 pt[1]:    location: -0.75 -1.75 -2.25
+   is located on boundary: 0
    idx:     (2,0,-1)
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -1.75
+   is located on boundary: 0
    idx:     (2,-1,0)
 With weight: 4
 pt[3]:    location: -1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (1,0,0)
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (3,0,0)
 With weight: 4
 pt[5]:    location: -0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (2,1,0)
 With weight: 4
 pt[6]:    location: -0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (2,0,1)
 With weight: 4
 
 On point:    location: -0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (3,0,0)
 pt[0]:    location: -0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (3,0,0)
 With weight: -24
 pt[1]:    location: -0.25 -1.75 -2.25
+   is located on boundary: 0
    idx:     (3,0,-1)
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -1.75
+   is located on boundary: 0
    idx:     (3,-1,0)
 With weight: 4
 pt[3]:    location: -0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (2,0,0)
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (4,0,0)
 With weight: 4
 pt[5]:    location: -0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (3,1,0)
 With weight: 4
 pt[6]:    location: -0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (3,0,1)
 With weight: 4
 
 On point:    location:  0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (4,0,0)
 pt[0]:    location:  0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (4,0,0)
 With weight: -24
 pt[1]:    location:  0.25 -1.75 -2.25
+   is located on boundary: 0
    idx:     (4,0,-1)
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -1.75
+   is located on boundary: 0
    idx:     (4,-1,0)
 With weight: 4
 pt[3]:    location: -0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (3,0,0)
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (5,0,0)
 With weight: 4
 pt[5]:    location:  0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (4,1,0)
 With weight: 4
 pt[6]:    location:  0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (4,0,1)
 With weight: 4
 
 On point:    location:  0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (5,0,0)
 pt[0]:    location:  0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (5,0,0)
 With weight: -24
 pt[1]:    location:  0.75 -1.75 -2.25
+   is located on boundary: 0
    idx:     (5,0,-1)
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -1.75
+   is located on boundary: 0
    idx:     (5,-1,0)
 With weight: 4
 pt[3]:    location:  0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (4,0,0)
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (6,0,0)
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (5,1,0)
 With weight: 4
 pt[6]:    location:  0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (5,0,1)
 With weight: 4
 
 On point:    location:  1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (6,0,0)
 pt[0]:    location:  1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (6,0,0)
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -2.25
+   is located on boundary: 0
    idx:     (6,0,-1)
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -1.75
+   is located on boundary: 0
    idx:     (6,-1,0)
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (5,0,0)
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (7,0,0)
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (6,1,0)
 With weight: 4
 pt[6]:    location:  1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (6,0,1)
 With weight: 4
 
 On point:    location:  1.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (7,0,0)
 pt[0]:    location:  1.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (7,0,0)
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -2.25
+   is located on boundary: 0
    idx:     (7,0,-1)
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -1.75
+   is located on boundary: 0
    idx:     (7,-1,0)
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (6,0,0)
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (8,0,0)
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (7,1,0)
 With weight: 4
 pt[6]:    location:  1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (7,0,1)
 With weight: 4
 
 On point:    location: -1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (0,1,0)
 pt[0]:    location: -1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (0,1,0)
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -2.25
+   is located on boundary: 0
    idx:     (0,1,-1)
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (0,0,0)
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (-1,1,0)
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (1,1,0)
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (0,2,0)
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (0,1,1)
 With weight: 4
 
 On point:    location: -1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (1,1,0)
 pt[0]:    location: -1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (1,1,0)
 With weight: -24
 pt[1]:    location: -1.25 -1.25 -2.25
+   is located on boundary: 0
    idx:     (1,1,-1)
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (1,0,0)
 With weight: 4
 pt[3]:    location: -1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (0,1,0)
 With weight: 4
 pt[4]:    location: -0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (2,1,0)
 With weight: 4
 pt[5]:    location: -1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (1,2,0)
 With weight: 4
 pt[6]:    location: -1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (1,1,1)
 With weight: 4
 
 On point:    location: -0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (2,1,0)
 pt[0]:    location: -0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (2,1,0)
 With weight: -24
 pt[1]:    location: -0.75 -1.25 -2.25
+   is located on boundary: 0
    idx:     (2,1,-1)
 With weight: 4
 pt[2]:    location: -0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (2,0,0)
 With weight: 4
 pt[3]:    location: -1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (1,1,0)
 With weight: 4
 pt[4]:    location: -0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (3,1,0)
 With weight: 4
 pt[5]:    location: -0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (2,2,0)
 With weight: 4
 pt[6]:    location: -0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (2,1,1)
 With weight: 4
 
 On point:    location: -0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (3,1,0)
 pt[0]:    location: -0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (3,1,0)
 With weight: -24
 pt[1]:    location: -0.25 -1.25 -2.25
+   is located on boundary: 0
    idx:     (3,1,-1)
 With weight: 4
 pt[2]:    location: -0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (3,0,0)
 With weight: 4
 pt[3]:    location: -0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (2,1,0)
 With weight: 4
 pt[4]:    location:  0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (4,1,0)
 With weight: 4
 pt[5]:    location: -0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (3,2,0)
 With weight: 4
 pt[6]:    location: -0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (3,1,1)
 With weight: 4
 
 On point:    location:  0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (4,1,0)
 pt[0]:    location:  0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (4,1,0)
 With weight: -24
 pt[1]:    location:  0.25 -1.25 -2.25
+   is located on boundary: 0
    idx:     (4,1,-1)
 With weight: 4
 pt[2]:    location:  0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (4,0,0)
 With weight: 4
 pt[3]:    location: -0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (3,1,0)
 With weight: 4
 pt[4]:    location:  0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (5,1,0)
 With weight: 4
 pt[5]:    location:  0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (4,2,0)
 With weight: 4
 pt[6]:    location:  0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (4,1,1)
 With weight: 4
 
 On point:    location:  0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (5,1,0)
 pt[0]:    location:  0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (5,1,0)
 With weight: -24
 pt[1]:    location:  0.75 -1.25 -2.25
+   is located on boundary: 0
    idx:     (5,1,-1)
 With weight: 4
 pt[2]:    location:  0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (5,0,0)
 With weight: 4
 pt[3]:    location:  0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (4,1,0)
 With weight: 4
 pt[4]:    location:  1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (6,1,0)
 With weight: 4
 pt[5]:    location:  0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (5,2,0)
 With weight: 4
 pt[6]:    location:  0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (5,1,1)
 With weight: 4
 
 On point:    location:  1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (6,1,0)
 pt[0]:    location:  1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (6,1,0)
 With weight: -24
 pt[1]:    location:  1.25 -1.25 -2.25
+   is located on boundary: 0
    idx:     (6,1,-1)
 With weight: 4
 pt[2]:    location:  1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (6,0,0)
 With weight: 4
 pt[3]:    location:  0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (5,1,0)
 With weight: 4
 pt[4]:    location:  1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (7,1,0)
 With weight: 4
 pt[5]:    location:  1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (6,2,0)
 With weight: 4
 pt[6]:    location:  1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (6,1,1)
 With weight: 4
 
 On point:    location:  1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (7,1,0)
 pt[0]:    location:  1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (7,1,0)
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -2.25
+   is located on boundary: 0
    idx:     (7,1,-1)
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (7,0,0)
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (6,1,0)
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (8,1,0)
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (7,2,0)
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (7,1,1)
 With weight: 4
 
 On point:    location: -1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (0,2,0)
 pt[0]:    location: -1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (0,2,0)
 With weight: -24
 pt[1]:    location: -1.75 -0.75 -2.25
+   is located on boundary: 0
    idx:     (0,2,-1)
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (0,1,0)
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (-1,2,0)
 With weight: 4
 pt[4]:    location: -1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (1,2,0)
 With weight: 4
 pt[5]:    location: -1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (0,3,0)
 With weight: 4
 pt[6]:    location: -1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (0,2,1)
 With weight: 4
 
 On point:    location: -1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (1,2,0)
 pt[0]:    location: -1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (1,2,0)
 With weight: -24
 pt[1]:    location: -1.25 -0.75 -2.25
+   is located on boundary: 0
    idx:     (1,2,-1)
 With weight: 4
 pt[2]:    location: -1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (1,1,0)
 With weight: 4
 pt[3]:    location: -1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (0,2,0)
 With weight: 4
 pt[4]:    location: -0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (2,2,0)
 With weight: 4
 pt[5]:    location: -1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (1,3,0)
 With weight: 4
 pt[6]:    location: -1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (1,2,1)
 With weight: 4
 
 On point:    location: -0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (2,2,0)
 pt[0]:    location: -0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (2,2,0)
 With weight: -18.6667
 pt[1]:    location: -0.75 -0.75 -2.25
+   is located on boundary: 0
    idx:     (2,2,-1)
 With weight: 2.66667
 pt[2]:    location: -0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (2,1,0)
 With weight: 4
 pt[3]:    location: -1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (1,2,0)
 With weight: 4
 pt[4]:    location: -0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (3,2,0)
 With weight: 4
 pt[5]:    location: -0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (2,3,0)
 With weight: 4
 pt[6]:    location: -0.75 -1.25 -2.25
+   is located on boundary: 0
    idx:     (2,1,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location: -0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (3,2,0)
 pt[0]:    location: -0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (3,2,0)
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.75 -2.25
+   is located on boundary: 0
    idx:     (3,2,-1)
 With weight: 2.66667
 pt[2]:    location: -0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (3,1,0)
 With weight: 4
 pt[3]:    location: -0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (2,2,0)
 With weight: 4
 pt[4]:    location:  0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (4,2,0)
 With weight: 4
 pt[5]:    location: -0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (3,3,0)
 With weight: 4
 pt[6]:    location: -0.25 -1.25 -2.25
+   is located on boundary: 0
    idx:     (3,1,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location:  0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (4,2,0)
 pt[0]:    location:  0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (4,2,0)
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.75 -2.25
+   is located on boundary: 0
    idx:     (4,2,-1)
 With weight: 2.66667
 pt[2]:    location:  0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (4,1,0)
 With weight: 4
 pt[3]:    location: -0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (3,2,0)
 With weight: 4
 pt[4]:    location:  0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (5,2,0)
 With weight: 4
 pt[5]:    location:  0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (4,3,0)
 With weight: 4
 pt[6]:    location:  0.25 -1.25 -2.25
+   is located on boundary: 0
    idx:     (4,1,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location:  0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (5,2,0)
 pt[0]:    location:  0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (5,2,0)
 With weight: -18.6667
 pt[1]:    location:  0.75 -0.75 -2.25
+   is located on boundary: 0
    idx:     (5,2,-1)
 With weight: 2.66667
 pt[2]:    location:  0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (5,1,0)
 With weight: 4
 pt[3]:    location:  0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (4,2,0)
 With weight: 4
 pt[4]:    location:  1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (6,2,0)
 With weight: 4
 pt[5]:    location:  0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (5,3,0)
 With weight: 4
 pt[6]:    location:  0.75 -1.25 -2.25
+   is located on boundary: 0
    idx:     (5,1,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location:  1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (6,2,0)
 pt[0]:    location:  1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (6,2,0)
 With weight: -24
 pt[1]:    location:  1.25 -0.75 -2.25
+   is located on boundary: 0
    idx:     (6,2,-1)
 With weight: 4
 pt[2]:    location:  1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (6,1,0)
 With weight: 4
 pt[3]:    location:  0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (5,2,0)
 With weight: 4
 pt[4]:    location:  1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (7,2,0)
 With weight: 4
 pt[5]:    location:  1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (6,3,0)
 With weight: 4
 pt[6]:    location:  1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (6,2,1)
 With weight: 4
 
 On point:    location:  1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (7,2,0)
 pt[0]:    location:  1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (7,2,0)
 With weight: -24
 pt[1]:    location:  1.75 -0.75 -2.25
+   is located on boundary: 0
    idx:     (7,2,-1)
 With weight: 4
 pt[2]:    location:  1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (7,1,0)
 With weight: 4
 pt[3]:    location:  1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (6,2,0)
 With weight: 4
 pt[4]:    location:  2.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (8,2,0)
 With weight: 4
 pt[5]:    location:  1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (7,3,0)
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (7,2,1)
 With weight: 4
 
 On point:    location: -1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (0,3,0)
 pt[0]:    location: -1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (0,3,0)
 With weight: -24
 pt[1]:    location: -1.75 -0.25 -2.25
+   is located on boundary: 0
    idx:     (0,3,-1)
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (0,2,0)
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (-1,3,0)
 With weight: 4
 pt[4]:    location: -1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (1,3,0)
 With weight: 4
 pt[5]:    location: -1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (0,4,0)
 With weight: 4
 pt[6]:    location: -1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (0,3,1)
 With weight: 4
 
 On point:    location: -1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (1,3,0)
 pt[0]:    location: -1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (1,3,0)
 With weight: -24
 pt[1]:    location: -1.25 -0.25 -2.25
+   is located on boundary: 0
    idx:     (1,3,-1)
 With weight: 4
 pt[2]:    location: -1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (1,2,0)
 With weight: 4
 pt[3]:    location: -1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (0,3,0)
 With weight: 4
 pt[4]:    location: -0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (2,3,0)
 With weight: 4
 pt[5]:    location: -1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (1,4,0)
 With weight: 4
 pt[6]:    location: -1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (1,3,1)
 With weight: 4
 
 On point:    location: -0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (2,3,0)
 pt[0]:    location: -0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (2,3,0)
 With weight: -18.6667
 pt[1]:    location: -0.75 -0.25 -2.25
+   is located on boundary: 0
    idx:     (2,3,-1)
 With weight: 2.66667
 pt[2]:    location: -0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (2,2,0)
 With weight: 4
 pt[3]:    location: -1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (1,3,0)
 With weight: 4
 pt[4]:    location: -0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (3,3,0)
 With weight: 4
 pt[5]:    location: -0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (2,4,0)
 With weight: 4
 pt[6]:    location: -0.75 -0.75 -2.25
+   is located on boundary: 0
    idx:     (2,2,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location: -0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (3,3,0)
 pt[0]:    location: -0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (3,3,0)
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.25 -2.25
+   is located on boundary: 0
    idx:     (3,3,-1)
 With weight: 2.66667
 pt[2]:    location: -0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (3,2,0)
 With weight: 4
 pt[3]:    location: -0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (2,3,0)
 With weight: 4
 pt[4]:    location:  0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (4,3,0)
 With weight: 4
 pt[5]:    location: -0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (3,4,0)
 With weight: 4
 pt[6]:    location: -0.25 -0.75 -2.25
+   is located on boundary: 0
    idx:     (3,2,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location:  0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (4,3,0)
 pt[0]:    location:  0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (4,3,0)
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.25 -2.25
+   is located on boundary: 0
    idx:     (4,3,-1)
 With weight: 2.66667
 pt[2]:    location:  0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (4,2,0)
 With weight: 4
 pt[3]:    location: -0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (3,3,0)
 With weight: 4
 pt[4]:    location:  0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (5,3,0)
 With weight: 4
 pt[5]:    location:  0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (4,4,0)
 With weight: 4
 pt[6]:    location:  0.25 -0.75 -2.25
+   is located on boundary: 0
    idx:     (4,2,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location:  0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (5,3,0)
 pt[0]:    location:  0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (5,3,0)
 With weight: -18.6667
 pt[1]:    location:  0.75 -0.25 -2.25
+   is located on boundary: 0
    idx:     (5,3,-1)
 With weight: 2.66667
 pt[2]:    location:  0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (5,2,0)
 With weight: 4
 pt[3]:    location:  0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (4,3,0)
 With weight: 4
 pt[4]:    location:  1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (6,3,0)
 With weight: 4
 pt[5]:    location:  0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (5,4,0)
 With weight: 4
 pt[6]:    location:  0.75 -0.75 -2.25
+   is located on boundary: 0
    idx:     (5,2,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location:  1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (6,3,0)
 pt[0]:    location:  1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (6,3,0)
 With weight: -24
 pt[1]:    location:  1.25 -0.25 -2.25
+   is located on boundary: 0
    idx:     (6,3,-1)
 With weight: 4
 pt[2]:    location:  1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (6,2,0)
 With weight: 4
 pt[3]:    location:  0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (5,3,0)
 With weight: 4
 pt[4]:    location:  1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (7,3,0)
 With weight: 4
 pt[5]:    location:  1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (6,4,0)
 With weight: 4
 pt[6]:    location:  1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (6,3,1)
 With weight: 4
 
 On point:    location:  1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (7,3,0)
 pt[0]:    location:  1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (7,3,0)
 With weight: -24
 pt[1]:    location:  1.75 -0.25 -2.25
+   is located on boundary: 0
    idx:     (7,3,-1)
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (7,2,0)
 With weight: 4
 pt[3]:    location:  1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (6,3,0)
 With weight: 4
 pt[4]:    location:  2.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (8,3,0)
 With weight: 4
 pt[5]:    location:  1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (7,4,0)
 With weight: 4
 pt[6]:    location:  1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (7,3,1)
 With weight: 4
 
 On point:    location: -1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (0,4,0)
 pt[0]:    location: -1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (0,4,0)
 With weight: -24
 pt[1]:    location: -1.75  0.25 -2.25
+   is located on boundary: 0
    idx:     (0,4,-1)
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (0,3,0)
 With weight: 4
 pt[3]:    location: -2.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (-1,4,0)
 With weight: 4
 pt[4]:    location: -1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (1,4,0)
 With weight: 4
 pt[5]:    location: -1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (0,5,0)
 With weight: 4
 pt[6]:    location: -1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (0,4,1)
 With weight: 4
 
 On point:    location: -1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (1,4,0)
 pt[0]:    location: -1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (1,4,0)
 With weight: -24
 pt[1]:    location: -1.25  0.25 -2.25
+   is located on boundary: 0
    idx:     (1,4,-1)
 With weight: 4
 pt[2]:    location: -1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (1,3,0)
 With weight: 4
 pt[3]:    location: -1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (0,4,0)
 With weight: 4
 pt[4]:    location: -0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (2,4,0)
 With weight: 4
 pt[5]:    location: -1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (1,5,0)
 With weight: 4
 pt[6]:    location: -1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (1,4,1)
 With weight: 4
 
 On point:    location: -0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (2,4,0)
 pt[0]:    location: -0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (2,4,0)
 With weight: -18.6667
 pt[1]:    location: -0.75  0.25 -2.25
+   is located on boundary: 0
    idx:     (2,4,-1)
 With weight: 2.66667
 pt[2]:    location: -0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (2,3,0)
 With weight: 4
 pt[3]:    location: -1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (1,4,0)
 With weight: 4
 pt[4]:    location: -0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (3,4,0)
 With weight: 4
 pt[5]:    location: -0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (2,5,0)
 With weight: 4
 pt[6]:    location: -1.25  0.25 -2.25
+   is located on boundary: 0
    idx:     (1,4,-1)
-With weight: 1.51453e-15
+With weight: 1.82407e-15
 
 On point:    location: -0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (3,4,0)
 pt[0]:    location: -0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (3,4,0)
 With weight: -18.6667
 pt[1]:    location: -0.25  0.25 -2.25
+   is located on boundary: 0
    idx:     (3,4,-1)
 With weight: 2.66667
 pt[2]:    location: -0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (3,3,0)
 With weight: 4
 pt[3]:    location: -0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (2,4,0)
 With weight: 4
 pt[4]:    location:  0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (4,4,0)
 With weight: 4
 pt[5]:    location: -0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (3,5,0)
 With weight: 4
 pt[6]:    location: -0.75  0.25 -2.25
+   is located on boundary: 0
    idx:     (2,4,-1)
-With weight: 1.51453e-15
+With weight: 1.82407e-15
 
 On point:    location:  0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (4,4,0)
 pt[0]:    location:  0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (4,4,0)
 With weight: -18.6667
 pt[1]:    location:  0.25  0.25 -2.25
+   is located on boundary: 0
    idx:     (4,4,-1)
 With weight: 2.66667
 pt[2]:    location:  0.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (4,3,0)
 With weight: 4
 pt[3]:    location: -0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (3,4,0)
 With weight: 4
 pt[4]:    location:  0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (5,4,0)
 With weight: 4
 pt[5]:    location:  0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (4,5,0)
 With weight: 4
 pt[6]:    location:  0.75  0.25 -2.25
+   is located on boundary: 0
    idx:     (5,4,-1)
-With weight: -1.26528e-15
+With weight: -2.7135e-16
 
 On point:    location:  0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (5,4,0)
 pt[0]:    location:  0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (5,4,0)
 With weight: -18.6667
 pt[1]:    location:  0.75  0.25 -2.25
+   is located on boundary: 0
    idx:     (5,4,-1)
 With weight: 2.66667
 pt[2]:    location:  0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (5,3,0)
 With weight: 4
 pt[3]:    location:  0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (4,4,0)
 With weight: 4
 pt[4]:    location:  1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (6,4,0)
 With weight: 4
 pt[5]:    location:  0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (5,5,0)
 With weight: 4
 pt[6]:    location:  0.25  0.25 -2.25
+   is located on boundary: 0
    idx:     (4,4,-1)
-With weight: 1.51453e-15
+With weight: 1.82407e-15
 
 On point:    location:  1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (6,4,0)
 pt[0]:    location:  1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (6,4,0)
 With weight: -24
 pt[1]:    location:  1.25  0.25 -2.25
+   is located on boundary: 0
    idx:     (6,4,-1)
 With weight: 4
 pt[2]:    location:  1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (6,3,0)
 With weight: 4
 pt[3]:    location:  0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (5,4,0)
 With weight: 4
 pt[4]:    location:  1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (7,4,0)
 With weight: 4
 pt[5]:    location:  1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (6,5,0)
 With weight: 4
 pt[6]:    location:  1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (6,4,1)
 With weight: 4
 
 On point:    location:  1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (7,4,0)
 pt[0]:    location:  1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (7,4,0)
 With weight: -24
 pt[1]:    location:  1.75  0.25 -2.25
+   is located on boundary: 0
    idx:     (7,4,-1)
 With weight: 4
 pt[2]:    location:  1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (7,3,0)
 With weight: 4
 pt[3]:    location:  1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (6,4,0)
 With weight: 4
 pt[4]:    location:  2.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (8,4,0)
 With weight: 4
 pt[5]:    location:  1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (7,5,0)
 With weight: 4
 pt[6]:    location:  1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (7,4,1)
 With weight: 4
 
 On point:    location: -1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (0,5,0)
 pt[0]:    location: -1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (0,5,0)
 With weight: -24
 pt[1]:    location: -1.75  0.75 -2.25
+   is located on boundary: 0
    idx:     (0,5,-1)
 With weight: 4
 pt[2]:    location: -1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (0,4,0)
 With weight: 4
 pt[3]:    location: -2.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (-1,5,0)
 With weight: 4
 pt[4]:    location: -1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (1,5,0)
 With weight: 4
 pt[5]:    location: -1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (0,6,0)
 With weight: 4
 pt[6]:    location: -1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (0,5,1)
 With weight: 4
 
 On point:    location: -1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (1,5,0)
 pt[0]:    location: -1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (1,5,0)
 With weight: -24
 pt[1]:    location: -1.25  0.75 -2.25
+   is located on boundary: 0
    idx:     (1,5,-1)
 With weight: 4
 pt[2]:    location: -1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (1,4,0)
 With weight: 4
 pt[3]:    location: -1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (0,5,0)
 With weight: 4
 pt[4]:    location: -0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (2,5,0)
 With weight: 4
 pt[5]:    location: -1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (1,6,0)
 With weight: 4
 pt[6]:    location: -1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (1,5,1)
 With weight: 4
 
 On point:    location: -0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (2,5,0)
 pt[0]:    location: -0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (2,5,0)
 With weight: -18.6667
 pt[1]:    location: -0.75  0.75 -2.25
+   is located on boundary: 0
    idx:     (2,5,-1)
 With weight: 2.66667
 pt[2]:    location: -0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (2,4,0)
 With weight: 4
 pt[3]:    location: -1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (1,5,0)
 With weight: 4
 pt[4]:    location: -0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (3,5,0)
 With weight: 4
 pt[5]:    location: -0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (2,6,0)
 With weight: 4
 pt[6]:    location: -0.75  0.25 -2.25
+   is located on boundary: 0
    idx:     (2,4,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location: -0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (3,5,0)
 pt[0]:    location: -0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (3,5,0)
 With weight: -18.6667
 pt[1]:    location: -0.25  0.75 -2.25
+   is located on boundary: 0
    idx:     (3,5,-1)
 With weight: 2.66667
 pt[2]:    location: -0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (3,4,0)
 With weight: 4
 pt[3]:    location: -0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (2,5,0)
 With weight: 4
 pt[4]:    location:  0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (4,5,0)
 With weight: 4
 pt[5]:    location: -0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (3,6,0)
 With weight: 4
 pt[6]:    location: -0.25  0.25 -2.25
+   is located on boundary: 0
    idx:     (3,4,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location:  0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (4,5,0)
 pt[0]:    location:  0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (4,5,0)
 With weight: -18.6667
 pt[1]:    location:  0.25  0.75 -2.25
+   is located on boundary: 0
    idx:     (4,5,-1)
 With weight: 2.66667
 pt[2]:    location:  0.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (4,4,0)
 With weight: 4
 pt[3]:    location: -0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (3,5,0)
 With weight: 4
 pt[4]:    location:  0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (5,5,0)
 With weight: 4
 pt[5]:    location:  0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (4,6,0)
 With weight: 4
 pt[6]:    location:  0.25  0.25 -2.25
+   is located on boundary: 0
    idx:     (4,4,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location:  0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (5,5,0)
 pt[0]:    location:  0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (5,5,0)
 With weight: -18.6667
 pt[1]:    location:  0.75  0.75 -2.25
+   is located on boundary: 0
    idx:     (5,5,-1)
 With weight: 2.66667
 pt[2]:    location:  0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (5,4,0)
 With weight: 4
 pt[3]:    location:  0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (4,5,0)
 With weight: 4
 pt[4]:    location:  1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (6,5,0)
 With weight: 4
 pt[5]:    location:  0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (5,6,0)
 With weight: 4
 pt[6]:    location:  0.75  0.25 -2.25
+   is located on boundary: 0
    idx:     (5,4,-1)
-With weight: 1.56242e-16
+With weight: -5.7285e-16
 
 On point:    location:  1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (6,5,0)
 pt[0]:    location:  1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (6,5,0)
 With weight: -24
 pt[1]:    location:  1.25  0.75 -2.25
+   is located on boundary: 0
    idx:     (6,5,-1)
 With weight: 4
 pt[2]:    location:  1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (6,4,0)
 With weight: 4
 pt[3]:    location:  0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (5,5,0)
 With weight: 4
 pt[4]:    location:  1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (7,5,0)
 With weight: 4
 pt[5]:    location:  1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (6,6,0)
 With weight: 4
 pt[6]:    location:  1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (6,5,1)
 With weight: 4
 
 On point:    location:  1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (7,5,0)
 pt[0]:    location:  1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (7,5,0)
 With weight: -24
 pt[1]:    location:  1.75  0.75 -2.25
+   is located on boundary: 0
    idx:     (7,5,-1)
 With weight: 4
 pt[2]:    location:  1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (7,4,0)
 With weight: 4
 pt[3]:    location:  1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (6,5,0)
 With weight: 4
 pt[4]:    location:  2.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (8,5,0)
 With weight: 4
 pt[5]:    location:  1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (7,6,0)
 With weight: 4
 pt[6]:    location:  1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (7,5,1)
 With weight: 4
 
 On point:    location: -1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (0,6,0)
 pt[0]:    location: -1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (0,6,0)
 With weight: -24
 pt[1]:    location: -1.75  1.25 -2.25
+   is located on boundary: 0
    idx:     (0,6,-1)
 With weight: 4
 pt[2]:    location: -1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (0,5,0)
 With weight: 4
 pt[3]:    location: -2.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (-1,6,0)
 With weight: 4
 pt[4]:    location: -1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (1,6,0)
 With weight: 4
 pt[5]:    location: -1.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (0,7,0)
 With weight: 4
 pt[6]:    location: -1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (0,6,1)
 With weight: 4
 
 On point:    location: -1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (1,6,0)
 pt[0]:    location: -1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (1,6,0)
 With weight: -24
 pt[1]:    location: -1.25  1.25 -2.25
+   is located on boundary: 0
    idx:     (1,6,-1)
 With weight: 4
 pt[2]:    location: -1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (1,5,0)
 With weight: 4
 pt[3]:    location: -1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (0,6,0)
 With weight: 4
 pt[4]:    location: -0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (2,6,0)
 With weight: 4
 pt[5]:    location: -1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (1,7,0)
 With weight: 4
 pt[6]:    location: -1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (1,6,1)
 With weight: 4
 
 On point:    location: -0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (2,6,0)
 pt[0]:    location: -0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (2,6,0)
 With weight: -24
 pt[1]:    location: -0.75  1.25 -2.25
+   is located on boundary: 0
    idx:     (2,6,-1)
 With weight: 4
 pt[2]:    location: -0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (2,5,0)
 With weight: 4
 pt[3]:    location: -1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (1,6,0)
 With weight: 4
 pt[4]:    location: -0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (3,6,0)
 With weight: 4
 pt[5]:    location: -0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (2,7,0)
 With weight: 4
 pt[6]:    location: -0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (2,6,1)
 With weight: 4
 
 On point:    location: -0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (3,6,0)
 pt[0]:    location: -0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (3,6,0)
 With weight: -24
 pt[1]:    location: -0.25  1.25 -2.25
+   is located on boundary: 0
    idx:     (3,6,-1)
 With weight: 4
 pt[2]:    location: -0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (3,5,0)
 With weight: 4
 pt[3]:    location: -0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (2,6,0)
 With weight: 4
 pt[4]:    location:  0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (4,6,0)
 With weight: 4
 pt[5]:    location: -0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (3,7,0)
 With weight: 4
 pt[6]:    location: -0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (3,6,1)
 With weight: 4
 
 On point:    location:  0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (4,6,0)
 pt[0]:    location:  0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (4,6,0)
 With weight: -24
 pt[1]:    location:  0.25  1.25 -2.25
+   is located on boundary: 0
    idx:     (4,6,-1)
 With weight: 4
 pt[2]:    location:  0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (4,5,0)
 With weight: 4
 pt[3]:    location: -0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (3,6,0)
 With weight: 4
 pt[4]:    location:  0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (5,6,0)
 With weight: 4
 pt[5]:    location:  0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (4,7,0)
 With weight: 4
 pt[6]:    location:  0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (4,6,1)
 With weight: 4
 
 On point:    location:  0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (5,6,0)
 pt[0]:    location:  0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (5,6,0)
 With weight: -24
 pt[1]:    location:  0.75  1.25 -2.25
+   is located on boundary: 0
    idx:     (5,6,-1)
 With weight: 4
 pt[2]:    location:  0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (5,5,0)
 With weight: 4
 pt[3]:    location:  0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (4,6,0)
 With weight: 4
 pt[4]:    location:  1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (6,6,0)
 With weight: 4
 pt[5]:    location:  0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (5,7,0)
 With weight: 4
 pt[6]:    location:  0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (5,6,1)
 With weight: 4
 
 On point:    location:  1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (6,6,0)
 pt[0]:    location:  1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (6,6,0)
 With weight: -24
 pt[1]:    location:  1.25  1.25 -2.25
+   is located on boundary: 0
    idx:     (6,6,-1)
 With weight: 4
 pt[2]:    location:  1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (6,5,0)
 With weight: 4
 pt[3]:    location:  0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (5,6,0)
 With weight: 4
 pt[4]:    location:  1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (7,6,0)
 With weight: 4
 pt[5]:    location:  1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (6,7,0)
 With weight: 4
 pt[6]:    location:  1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (6,6,1)
 With weight: 4
 
 On point:    location:  1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (7,6,0)
 pt[0]:    location:  1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (7,6,0)
 With weight: -24
 pt[1]:    location:  1.75  1.25 -2.25
+   is located on boundary: 0
    idx:     (7,6,-1)
 With weight: 4
 pt[2]:    location:  1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (7,5,0)
 With weight: 4
 pt[3]:    location:  1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (6,6,0)
 With weight: 4
 pt[4]:    location:  2.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (8,6,0)
 With weight: 4
 pt[5]:    location:  1.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (7,7,0)
 With weight: 4
 pt[6]:    location:  1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (7,6,1)
 With weight: 4
 
 On point:    location: -1.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (0,7,0)
 pt[0]:    location: -1.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (0,7,0)
 With weight: -24
 pt[1]:    location: -1.75  1.75 -2.25
+   is located on boundary: 0
    idx:     (0,7,-1)
 With weight: 4
 pt[2]:    location: -1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (0,6,0)
 With weight: 4
 pt[3]:    location: -2.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (-1,7,0)
 With weight: 4
 pt[4]:    location: -1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (1,7,0)
 With weight: 4
 pt[5]:    location: -1.75  2.25 -1.75
+   is located on boundary: 0
    idx:     (0,8,0)
 With weight: 4
 pt[6]:    location: -1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (0,7,1)
 With weight: 4
 
 On point:    location: -1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (1,7,0)
 pt[0]:    location: -1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (1,7,0)
 With weight: -24
 pt[1]:    location: -1.25  1.75 -2.25
+   is located on boundary: 0
    idx:     (1,7,-1)
 With weight: 4
 pt[2]:    location: -1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (1,6,0)
 With weight: 4
 pt[3]:    location: -1.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (0,7,0)
 With weight: 4
 pt[4]:    location: -0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (2,7,0)
 With weight: 4
 pt[5]:    location: -1.25  2.25 -1.75
+   is located on boundary: 0
    idx:     (1,8,0)
 With weight: 4
 pt[6]:    location: -1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (1,7,1)
 With weight: 4
 
 On point:    location: -0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (2,7,0)
 pt[0]:    location: -0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (2,7,0)
 With weight: -24
 pt[1]:    location: -0.75  1.75 -2.25
+   is located on boundary: 0
    idx:     (2,7,-1)
 With weight: 4
 pt[2]:    location: -0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (2,6,0)
 With weight: 4
 pt[3]:    location: -1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (1,7,0)
 With weight: 4
 pt[4]:    location: -0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (3,7,0)
 With weight: 4
 pt[5]:    location: -0.75  2.25 -1.75
+   is located on boundary: 0
    idx:     (2,8,0)
 With weight: 4
 pt[6]:    location: -0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (2,7,1)
 With weight: 4
 
 On point:    location: -0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (3,7,0)
 pt[0]:    location: -0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (3,7,0)
 With weight: -24
 pt[1]:    location: -0.25  1.75 -2.25
+   is located on boundary: 0
    idx:     (3,7,-1)
 With weight: 4
 pt[2]:    location: -0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (3,6,0)
 With weight: 4
 pt[3]:    location: -0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (2,7,0)
 With weight: 4
 pt[4]:    location:  0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (4,7,0)
 With weight: 4
 pt[5]:    location: -0.25  2.25 -1.75
+   is located on boundary: 0
    idx:     (3,8,0)
 With weight: 4
 pt[6]:    location: -0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (3,7,1)
 With weight: 4
 
 On point:    location:  0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (4,7,0)
 pt[0]:    location:  0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (4,7,0)
 With weight: -24
 pt[1]:    location:  0.25  1.75 -2.25
+   is located on boundary: 0
    idx:     (4,7,-1)
 With weight: 4
 pt[2]:    location:  0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (4,6,0)
 With weight: 4
 pt[3]:    location: -0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (3,7,0)
 With weight: 4
 pt[4]:    location:  0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (5,7,0)
 With weight: 4
 pt[5]:    location:  0.25  2.25 -1.75
+   is located on boundary: 0
    idx:     (4,8,0)
 With weight: 4
 pt[6]:    location:  0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (4,7,1)
 With weight: 4
 
 On point:    location:  0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (5,7,0)
 pt[0]:    location:  0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (5,7,0)
 With weight: -24
 pt[1]:    location:  0.75  1.75 -2.25
+   is located on boundary: 0
    idx:     (5,7,-1)
 With weight: 4
 pt[2]:    location:  0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (5,6,0)
 With weight: 4
 pt[3]:    location:  0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (4,7,0)
 With weight: 4
 pt[4]:    location:  1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (6,7,0)
 With weight: 4
 pt[5]:    location:  0.75  2.25 -1.75
+   is located on boundary: 0
    idx:     (5,8,0)
 With weight: 4
 pt[6]:    location:  0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (5,7,1)
 With weight: 4
 
 On point:    location:  1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (6,7,0)
 pt[0]:    location:  1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (6,7,0)
 With weight: -24
 pt[1]:    location:  1.25  1.75 -2.25
+   is located on boundary: 0
    idx:     (6,7,-1)
 With weight: 4
 pt[2]:    location:  1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (6,6,0)
 With weight: 4
 pt[3]:    location:  0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (5,7,0)
 With weight: 4
 pt[4]:    location:  1.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (7,7,0)
 With weight: 4
 pt[5]:    location:  1.25  2.25 -1.75
+   is located on boundary: 0
    idx:     (6,8,0)
 With weight: 4
 pt[6]:    location:  1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (6,7,1)
 With weight: 4
 
 On point:    location:  1.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (7,7,0)
 pt[0]:    location:  1.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (7,7,0)
 With weight: -24
 pt[1]:    location:  1.75  1.75 -2.25
+   is located on boundary: 0
    idx:     (7,7,-1)
 With weight: 4
 pt[2]:    location:  1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (7,6,0)
 With weight: 4
 pt[3]:    location:  1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (6,7,0)
 With weight: 4
 pt[4]:    location:  2.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (8,7,0)
 With weight: 4
 pt[5]:    location:  1.75  2.25 -1.75
+   is located on boundary: 0
    idx:     (7,8,0)
 With weight: 4
 pt[6]:    location:  1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (7,7,1)
 With weight: 4
 
 On point:    location: -1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (0,0,1)
 pt[0]:    location: -1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (0,0,1)
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (0,0,0)
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -1.25
+   is located on boundary: 0
    idx:     (0,-1,1)
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (-1,0,1)
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (1,0,1)
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (0,1,1)
 With weight: 4
 pt[6]:    location: -1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (0,0,2)
 With weight: 4
 
 On point:    location: -1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (1,0,1)
 pt[0]:    location: -1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (1,0,1)
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (1,0,0)
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -1.25
+   is located on boundary: 0
    idx:     (1,-1,1)
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (0,0,1)
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (2,0,1)
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (1,1,1)
 With weight: 4
 pt[6]:    location: -1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (1,0,2)
 With weight: 4
 
 On point:    location: -0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (2,0,1)
 pt[0]:    location: -0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (2,0,1)
 With weight: -24
 pt[1]:    location: -0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (2,0,0)
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -1.25
+   is located on boundary: 0
    idx:     (2,-1,1)
 With weight: 4
 pt[3]:    location: -1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (1,0,1)
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (3,0,1)
 With weight: 4
 pt[5]:    location: -0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (2,1,1)
 With weight: 4
 pt[6]:    location: -0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (2,0,2)
 With weight: 4
 
 On point:    location: -0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (3,0,1)
 pt[0]:    location: -0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (3,0,1)
 With weight: -24
 pt[1]:    location: -0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (3,0,0)
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -1.25
+   is located on boundary: 0
    idx:     (3,-1,1)
 With weight: 4
 pt[3]:    location: -0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (2,0,1)
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (4,0,1)
 With weight: 4
 pt[5]:    location: -0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (3,1,1)
 With weight: 4
 pt[6]:    location: -0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (3,0,2)
 With weight: 4
 
 On point:    location:  0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (4,0,1)
 pt[0]:    location:  0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (4,0,1)
 With weight: -24
 pt[1]:    location:  0.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (4,0,0)
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -1.25
+   is located on boundary: 0
    idx:     (4,-1,1)
 With weight: 4
 pt[3]:    location: -0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (3,0,1)
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (5,0,1)
 With weight: 4
 pt[5]:    location:  0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (4,1,1)
 With weight: 4
 pt[6]:    location:  0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (4,0,2)
 With weight: 4
 
 On point:    location:  0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (5,0,1)
 pt[0]:    location:  0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (5,0,1)
 With weight: -24
 pt[1]:    location:  0.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (5,0,0)
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -1.25
+   is located on boundary: 0
    idx:     (5,-1,1)
 With weight: 4
 pt[3]:    location:  0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (4,0,1)
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (6,0,1)
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (5,1,1)
 With weight: 4
 pt[6]:    location:  0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (5,0,2)
 With weight: 4
 
 On point:    location:  1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (6,0,1)
 pt[0]:    location:  1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (6,0,1)
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -1.75
+   is located on boundary: 0
    idx:     (6,0,0)
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -1.25
+   is located on boundary: 0
    idx:     (6,-1,1)
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (5,0,1)
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (7,0,1)
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (6,1,1)
 With weight: 4
 pt[6]:    location:  1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (6,0,2)
 With weight: 4
 
 On point:    location:  1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (7,0,1)
 pt[0]:    location:  1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (7,0,1)
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -1.75
+   is located on boundary: 0
    idx:     (7,0,0)
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -1.25
+   is located on boundary: 0
    idx:     (7,-1,1)
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (6,0,1)
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (8,0,1)
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (7,1,1)
 With weight: 4
 pt[6]:    location:  1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (7,0,2)
 With weight: 4
 
 On point:    location: -1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (0,1,1)
 pt[0]:    location: -1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (0,1,1)
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (0,1,0)
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (0,0,1)
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (-1,1,1)
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (1,1,1)
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (0,2,1)
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (0,1,2)
 With weight: 4
 
 On point:    location: -1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (1,1,1)
 pt[0]:    location: -1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (1,1,1)
 With weight: -24
 pt[1]:    location: -1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (1,1,0)
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (1,0,1)
 With weight: 4
 pt[3]:    location: -1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (0,1,1)
 With weight: 4
 pt[4]:    location: -0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (2,1,1)
 With weight: 4
 pt[5]:    location: -1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (1,2,1)
 With weight: 4
 pt[6]:    location: -1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (1,1,2)
 With weight: 4
 
 On point:    location: -0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (2,1,1)
 pt[0]:    location: -0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (2,1,1)
 With weight: -13.9608
 pt[1]:    location: -0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (2,1,0)
 With weight: 0.784314
 pt[2]:    location: -0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (2,0,1)
 With weight: 3.29412
 pt[3]:    location: -1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (1,1,1)
 With weight: 4
 pt[4]:    location: -0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (3,1,1)
 With weight: 4
 pt[5]:    location: -0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (3,1,0)
-With weight: 1.06705e-16
+With weight: -1.78054e-15
 pt[6]:    location: -0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (2,2,0)
 With weight: 1.88235
 
 On point:    location: -0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (3,1,1)
 pt[0]:    location: -0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (3,1,1)
 With weight: -13.9608
 pt[1]:    location: -0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (3,1,0)
 With weight: 0.784314
 pt[2]:    location: -0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (3,0,1)
 With weight: 3.29412
 pt[3]:    location: -0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (2,1,1)
 With weight: 4
 pt[4]:    location:  0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (4,1,1)
 With weight: 4
 pt[5]:    location: -0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (2,1,0)
-With weight: -8.51718e-16
+With weight: -8.73475e-16
 pt[6]:    location: -0.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (3,2,0)
 With weight: 1.88235
 
 On point:    location:  0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (4,1,1)
 pt[0]:    location:  0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (4,1,1)
 With weight: -13.3333
 pt[1]:    location:  0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (4,1,0)
 With weight: 2.66667
 pt[2]:    location:  0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (4,0,1)
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (3,1,1)
 With weight: 4
 pt[4]:    location:  0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (5,1,1)
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (5,1,0)
-With weight: -1.84419e-17
+With weight: 5.16489e-16
 pt[6]:    location:  0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (5,0,1)
-With weight: 3.70424e-16
+With weight: 5.20671e-16
 
 On point:    location:  0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (5,1,1)
 pt[0]:    location:  0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (5,1,1)
 With weight: -13.3333
 pt[1]:    location:  0.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (5,1,0)
 With weight: 2.66667
 pt[2]:    location:  0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (5,0,1)
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (4,1,1)
 With weight: 4
 pt[4]:    location:  1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (6,1,1)
 With weight: 4
 pt[5]:    location:  0.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (4,1,0)
-With weight: -1.44435e-15
+With weight: 5.38239e-16
 pt[6]:    location:  1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (6,1,0)
-With weight: -1.72329e-15
+With weight: 1.1751e-15
 
 On point:    location:  1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (6,1,1)
 pt[0]:    location:  1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (6,1,1)
 With weight: -24
 pt[1]:    location:  1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (6,1,0)
 With weight: 4
 pt[2]:    location:  1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (6,0,1)
 With weight: 4
 pt[3]:    location:  0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (5,1,1)
 With weight: 4
 pt[4]:    location:  1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (7,1,1)
 With weight: 4
 pt[5]:    location:  1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (6,2,1)
 With weight: 4
 pt[6]:    location:  1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (6,1,2)
 With weight: 4
 
 On point:    location:  1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (7,1,1)
 pt[0]:    location:  1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (7,1,1)
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -1.75
+   is located on boundary: 0
    idx:     (7,1,0)
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (7,0,1)
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (6,1,1)
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (8,1,1)
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (7,2,1)
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (7,1,2)
 With weight: 4
 
 On point:    location: -1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (0,2,1)
 pt[0]:    location: -1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (0,2,1)
 With weight: -24
 pt[1]:    location: -1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (0,2,0)
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (0,1,1)
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (-1,2,1)
 With weight: 4
 pt[4]:    location: -1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (1,2,1)
 With weight: 4
 pt[5]:    location: -1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (0,3,1)
 With weight: 4
 pt[6]:    location: -1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (0,2,2)
 With weight: 4
 
 On point:    location: -1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (1,2,1)
 pt[0]:    location: -1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (1,2,1)
 With weight: -13.3333
 pt[1]:    location: -1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (1,2,0)
 With weight: 2.66667
 pt[2]:    location: -1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (1,1,1)
 With weight: 4
 pt[3]:    location: -1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (0,2,1)
 With weight: 2.66667
 pt[4]:    location: -1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (1,3,1)
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (1,1,0)
-With weight: -3.26767e-16
+With weight: -4.09907e-16
 pt[6]:    location: -1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (0,2,0)
-With weight: 7.25405e-16
+With weight: 1.05205e-15
 
 On point:    location:  1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (6,2,1)
 pt[0]:    location:  1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (6,2,1)
 With weight: -13.9608
 pt[1]:    location:  1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (6,2,0)
 With weight: 0.784314
 pt[2]:    location:  1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (6,1,1)
 With weight: 4
 pt[3]:    location:  1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (7,2,1)
 With weight: 3.29412
 pt[4]:    location:  1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (6,3,1)
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -1.75
+   is located on boundary: 0
    idx:     (6,1,0)
-With weight: -1.6916e-15
+With weight: 3.35952e-17
 pt[6]:    location:  0.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (5,2,0)
 With weight: 1.88235
 
 On point:    location:  1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (7,2,1)
 pt[0]:    location:  1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (7,2,1)
 With weight: -24
 pt[1]:    location:  1.75 -0.75 -1.75
+   is located on boundary: 0
    idx:     (7,2,0)
 With weight: 4
 pt[2]:    location:  1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (7,1,1)
 With weight: 4
 pt[3]:    location:  1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (6,2,1)
 With weight: 4
 pt[4]:    location:  2.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (8,2,1)
 With weight: 4
 pt[5]:    location:  1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (7,3,1)
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (7,2,2)
 With weight: 4
 
 On point:    location: -1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (0,3,1)
 pt[0]:    location: -1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (0,3,1)
 With weight: -24
 pt[1]:    location: -1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (0,3,0)
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (0,2,1)
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (-1,3,1)
 With weight: 4
 pt[4]:    location: -1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (1,3,1)
 With weight: 4
 pt[5]:    location: -1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (0,4,1)
 With weight: 4
 pt[6]:    location: -1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (0,3,2)
 With weight: 4
 
 On point:    location: -1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (1,3,1)
 pt[0]:    location: -1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (1,3,1)
 With weight: -13.3333
 pt[1]:    location: -1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (1,3,0)
 With weight: 2.66667
 pt[2]:    location: -1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (1,2,1)
 With weight: 4
 pt[3]:    location: -1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (0,3,1)
 With weight: 2.66667
 pt[4]:    location: -1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (1,4,1)
 With weight: 4
 pt[5]:    location: -1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (1,2,0)
-With weight: -3.26767e-16
+With weight: -4.09907e-16
 pt[6]:    location: -1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (0,3,0)
-With weight: 7.25405e-16
+With weight: 1.05205e-15
 
 On point:    location:  1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (6,3,1)
 pt[0]:    location:  1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (6,3,1)
 With weight: -13.9608
 pt[1]:    location:  1.25 -0.25 -1.75
+   is located on boundary: 0
    idx:     (6,3,0)
 With weight: 0.784314
 pt[2]:    location:  1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (6,2,1)
 With weight: 4
 pt[3]:    location:  1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (7,3,1)
 With weight: 3.29412
 pt[4]:    location:  1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (6,4,1)
 With weight: 4
 pt[5]:    location:  1.25 -0.75 -1.75
+   is located on boundary: 0
    idx:     (6,2,0)
-With weight: -1.6916e-15
+With weight: 3.35952e-17
 pt[6]:    location:  0.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (5,3,0)
 With weight: 1.88235
 
 On point:    location:  1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (7,3,1)
 pt[0]:    location:  1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (7,3,1)
 With weight: -24
 pt[1]:    location:  1.75 -0.25 -1.75
+   is located on boundary: 0
    idx:     (7,3,0)
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (7,2,1)
 With weight: 4
 pt[3]:    location:  1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (6,3,1)
 With weight: 4
 pt[4]:    location:  2.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (8,3,1)
 With weight: 4
 pt[5]:    location:  1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (7,4,1)
 With weight: 4
 pt[6]:    location:  1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (7,3,2)
 With weight: 4
 
 On point:    location: -1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (0,4,1)
 pt[0]:    location: -1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (0,4,1)
 With weight: -24
 pt[1]:    location: -1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (0,4,0)
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (0,3,1)
 With weight: 4
 pt[3]:    location: -2.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (-1,4,1)
 With weight: 4
 pt[4]:    location: -1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (1,4,1)
 With weight: 4
 pt[5]:    location: -1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (0,5,1)
 With weight: 4
 pt[6]:    location: -1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (0,4,2)
 With weight: 4
 
 On point:    location: -1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (1,4,1)
 pt[0]:    location: -1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (1,4,1)
 With weight: -13.3333
 pt[1]:    location: -1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (1,4,0)
 With weight: 2.66667
 pt[2]:    location: -1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (1,3,1)
 With weight: 4
 pt[3]:    location: -1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (0,4,1)
 With weight: 2.66667
 pt[4]:    location: -1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (1,5,1)
 With weight: 4
 pt[5]:    location: -1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (0,4,0)
-With weight: 1.32658e-15
+With weight: -1.50293e-16
 pt[6]:    location: -1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (1,5,0)
-With weight: 1.58396e-16
+With weight: -7.34622e-16
 
 On point:    location:  1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (6,4,1)
 pt[0]:    location:  1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (6,4,1)
 With weight: -13.3333
 pt[1]:    location:  1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (6,4,0)
-With weight: 1.01866e-15
+With weight: -1.30741e-15
 pt[2]:    location:  1.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (6,3,1)
 With weight: 4
 pt[3]:    location:  1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (7,4,1)
 With weight: 2.66667
 pt[4]:    location:  1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (6,5,1)
 With weight: 4
 pt[5]:    location:  0.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (5,4,0)
 With weight: 2
 pt[6]:    location:  1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (7,4,0)
 With weight: 0.666667
 
 On point:    location:  1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (7,4,1)
 pt[0]:    location:  1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (7,4,1)
 With weight: -24
 pt[1]:    location:  1.75  0.25 -1.75
+   is located on boundary: 0
    idx:     (7,4,0)
 With weight: 4
 pt[2]:    location:  1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (7,3,1)
 With weight: 4
 pt[3]:    location:  1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (6,4,1)
 With weight: 4
 pt[4]:    location:  2.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (8,4,1)
 With weight: 4
 pt[5]:    location:  1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (7,5,1)
 With weight: 4
 pt[6]:    location:  1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (7,4,2)
 With weight: 4
 
 On point:    location: -1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (0,5,1)
 pt[0]:    location: -1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (0,5,1)
 With weight: -24
 pt[1]:    location: -1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (0,5,0)
 With weight: 4
 pt[2]:    location: -1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (0,4,1)
 With weight: 4
 pt[3]:    location: -2.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (-1,5,1)
 With weight: 4
 pt[4]:    location: -1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (1,5,1)
 With weight: 4
 pt[5]:    location: -1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (0,6,1)
 With weight: 4
 pt[6]:    location: -1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (0,5,2)
 With weight: 4
 
 On point:    location: -1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (1,5,1)
 pt[0]:    location: -1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (1,5,1)
 With weight: -13.3333
 pt[1]:    location: -1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (1,5,0)
 With weight: 2.66667
 pt[2]:    location: -1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (1,4,1)
 With weight: 4
 pt[3]:    location: -1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (0,5,1)
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (1,6,1)
 With weight: 4
 pt[5]:    location: -1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (0,5,0)
-With weight: 3.52706e-16
+With weight: 1.50293e-16
 pt[6]:    location: -1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (0,4,1)
-With weight: 1.56998e-16
+With weight: -1.24779e-15
 
 On point:    location:  1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (6,5,1)
 pt[0]:    location:  1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (6,5,1)
 With weight: -13.9608
 pt[1]:    location:  1.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (6,5,0)
 With weight: 0.784314
 pt[2]:    location:  1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (6,4,1)
 With weight: 4
 pt[3]:    location:  1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (7,5,1)
 With weight: 3.29412
 pt[4]:    location:  1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (6,6,1)
 With weight: 4
 pt[5]:    location:  1.25  0.25 -1.75
+   is located on boundary: 0
    idx:     (6,4,0)
-With weight: -1.6916e-15
+With weight: 3.35952e-17
 pt[6]:    location:  0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (5,5,0)
 With weight: 1.88235
 
 On point:    location:  1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (7,5,1)
 pt[0]:    location:  1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (7,5,1)
 With weight: -24
 pt[1]:    location:  1.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (7,5,0)
 With weight: 4
 pt[2]:    location:  1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (7,4,1)
 With weight: 4
 pt[3]:    location:  1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (6,5,1)
 With weight: 4
 pt[4]:    location:  2.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (8,5,1)
 With weight: 4
 pt[5]:    location:  1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (7,6,1)
 With weight: 4
 pt[6]:    location:  1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (7,5,2)
 With weight: 4
 
 On point:    location: -1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (0,6,1)
 pt[0]:    location: -1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (0,6,1)
 With weight: -24
 pt[1]:    location: -1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (0,6,0)
 With weight: 4
 pt[2]:    location: -1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (0,5,1)
 With weight: 4
 pt[3]:    location: -2.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (-1,6,1)
 With weight: 4
 pt[4]:    location: -1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (1,6,1)
 With weight: 4
 pt[5]:    location: -1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (0,7,1)
 With weight: 4
 pt[6]:    location: -1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (0,6,2)
 With weight: 4
 
 On point:    location: -1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (1,6,1)
 pt[0]:    location: -1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (1,6,1)
 With weight: -24
 pt[1]:    location: -1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (1,6,0)
 With weight: 4
 pt[2]:    location: -1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (1,5,1)
 With weight: 4
 pt[3]:    location: -1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (0,6,1)
 With weight: 4
 pt[4]:    location: -0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (2,6,1)
 With weight: 4
 pt[5]:    location: -1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (1,7,1)
 With weight: 4
 pt[6]:    location: -1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (1,6,2)
 With weight: 4
 
 On point:    location: -0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (2,6,1)
 pt[0]:    location: -0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (2,6,1)
 With weight: -13.9608
 pt[1]:    location: -0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (2,6,0)
 With weight: 0.784314
 pt[2]:    location: -1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (1,6,1)
 With weight: 4
 pt[3]:    location: -0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (3,6,1)
 With weight: 4
 pt[4]:    location: -0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (2,7,1)
 With weight: 3.29412
 pt[5]:    location: -0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (2,5,0)
 With weight: 1.88235
 pt[6]:    location: -0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (3,6,0)
-With weight: -2.7868e-16
+With weight: 2.01571e-16
 
 On point:    location: -0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (3,6,1)
 pt[0]:    location: -0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (3,6,1)
 With weight: -13.9608
 pt[1]:    location: -0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (3,6,0)
 With weight: 0.784314
 pt[2]:    location: -0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (2,6,1)
 With weight: 4
 pt[3]:    location:  0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (4,6,1)
 With weight: 4
 pt[4]:    location: -0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (3,7,1)
 With weight: 3.29412
 pt[5]:    location: -0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (3,5,0)
 With weight: 1.88235
 pt[6]:    location: -0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (2,6,0)
-With weight: -1.62841e-15
+With weight: -1.94852e-15
 
 On point:    location:  0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (4,6,1)
 pt[0]:    location:  0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (4,6,1)
 With weight: -13.9608
 pt[1]:    location:  0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (4,6,0)
 With weight: 0.784314
 pt[2]:    location: -0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (3,6,1)
 With weight: 4
 pt[3]:    location:  0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (5,6,1)
 With weight: 4
 pt[4]:    location:  0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (4,7,1)
 With weight: 3.29412
 pt[5]:    location:  0.25  0.75 -1.75
+   is located on boundary: 0
    idx:     (4,5,0)
 With weight: 1.88235
 pt[6]:    location:  0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (5,6,0)
-With weight: -2.7868e-16
+With weight: 2.01571e-16
 
 On point:    location:  0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (5,6,1)
 pt[0]:    location:  0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (5,6,1)
 With weight: -13.9608
 pt[1]:    location:  0.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (5,6,0)
 With weight: 0.784314
 pt[2]:    location:  0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (4,6,1)
 With weight: 4
 pt[3]:    location:  1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (6,6,1)
 With weight: 4
 pt[4]:    location:  0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (5,7,1)
 With weight: 3.29412
 pt[5]:    location:  0.75  0.75 -1.75
+   is located on boundary: 0
    idx:     (5,5,0)
 With weight: 1.88235
 pt[6]:    location:  0.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (4,6,0)
-With weight: -1.62841e-15
+With weight: -1.94852e-15
 
 On point:    location:  1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (6,6,1)
 pt[0]:    location:  1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (6,6,1)
 With weight: -24
 pt[1]:    location:  1.25  1.25 -1.75
+   is located on boundary: 0
    idx:     (6,6,0)
 With weight: 4
 pt[2]:    location:  1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (6,5,1)
 With weight: 4
 pt[3]:    location:  0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (5,6,1)
 With weight: 4
 pt[4]:    location:  1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (7,6,1)
 With weight: 4
 pt[5]:    location:  1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (6,7,1)
 With weight: 4
 pt[6]:    location:  1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (6,6,2)
 With weight: 4
 
 On point:    location:  1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (7,6,1)
 pt[0]:    location:  1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (7,6,1)
 With weight: -24
 pt[1]:    location:  1.75  1.25 -1.75
+   is located on boundary: 0
    idx:     (7,6,0)
 With weight: 4
 pt[2]:    location:  1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (7,5,1)
 With weight: 4
 pt[3]:    location:  1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (6,6,1)
 With weight: 4
 pt[4]:    location:  2.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (8,6,1)
 With weight: 4
 pt[5]:    location:  1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (7,7,1)
 With weight: 4
 pt[6]:    location:  1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (7,6,2)
 With weight: 4
 
 On point:    location: -1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (0,7,1)
 pt[0]:    location: -1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (0,7,1)
 With weight: -24
 pt[1]:    location: -1.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (0,7,0)
 With weight: 4
 pt[2]:    location: -1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (0,6,1)
 With weight: 4
 pt[3]:    location: -2.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (-1,7,1)
 With weight: 4
 pt[4]:    location: -1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (1,7,1)
 With weight: 4
 pt[5]:    location: -1.75  2.25 -1.25
+   is located on boundary: 0
    idx:     (0,8,1)
 With weight: 4
 pt[6]:    location: -1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (0,7,2)
 With weight: 4
 
 On point:    location: -1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (1,7,1)
 pt[0]:    location: -1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (1,7,1)
 With weight: -24
 pt[1]:    location: -1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (1,7,0)
 With weight: 4
 pt[2]:    location: -1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (1,6,1)
 With weight: 4
 pt[3]:    location: -1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (0,7,1)
 With weight: 4
 pt[4]:    location: -0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (2,7,1)
 With weight: 4
 pt[5]:    location: -1.25  2.25 -1.25
+   is located on boundary: 0
    idx:     (1,8,1)
 With weight: 4
 pt[6]:    location: -1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (1,7,2)
 With weight: 4
 
 On point:    location: -0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (2,7,1)
 pt[0]:    location: -0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (2,7,1)
 With weight: -24
 pt[1]:    location: -0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (2,7,0)
 With weight: 4
 pt[2]:    location: -0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (2,6,1)
 With weight: 4
 pt[3]:    location: -1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (1,7,1)
 With weight: 4
 pt[4]:    location: -0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (3,7,1)
 With weight: 4
 pt[5]:    location: -0.75  2.25 -1.25
+   is located on boundary: 0
    idx:     (2,8,1)
 With weight: 4
 pt[6]:    location: -0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (2,7,2)
 With weight: 4
 
 On point:    location: -0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (3,7,1)
 pt[0]:    location: -0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (3,7,1)
 With weight: -24
 pt[1]:    location: -0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (3,7,0)
 With weight: 4
 pt[2]:    location: -0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (3,6,1)
 With weight: 4
 pt[3]:    location: -0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (2,7,1)
 With weight: 4
 pt[4]:    location:  0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (4,7,1)
 With weight: 4
 pt[5]:    location: -0.25  2.25 -1.25
+   is located on boundary: 0
    idx:     (3,8,1)
 With weight: 4
 pt[6]:    location: -0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (3,7,2)
 With weight: 4
 
 On point:    location:  0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (4,7,1)
 pt[0]:    location:  0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (4,7,1)
 With weight: -24
 pt[1]:    location:  0.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (4,7,0)
 With weight: 4
 pt[2]:    location:  0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (4,6,1)
 With weight: 4
 pt[3]:    location: -0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (3,7,1)
 With weight: 4
 pt[4]:    location:  0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (5,7,1)
 With weight: 4
 pt[5]:    location:  0.25  2.25 -1.25
+   is located on boundary: 0
    idx:     (4,8,1)
 With weight: 4
 pt[6]:    location:  0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (4,7,2)
 With weight: 4
 
 On point:    location:  0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (5,7,1)
 pt[0]:    location:  0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (5,7,1)
 With weight: -24
 pt[1]:    location:  0.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (5,7,0)
 With weight: 4
 pt[2]:    location:  0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (5,6,1)
 With weight: 4
 pt[3]:    location:  0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (4,7,1)
 With weight: 4
 pt[4]:    location:  1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (6,7,1)
 With weight: 4
 pt[5]:    location:  0.75  2.25 -1.25
+   is located on boundary: 0
    idx:     (5,8,1)
 With weight: 4
 pt[6]:    location:  0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (5,7,2)
 With weight: 4
 
 On point:    location:  1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (6,7,1)
 pt[0]:    location:  1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (6,7,1)
 With weight: -24
 pt[1]:    location:  1.25  1.75 -1.75
+   is located on boundary: 0
    idx:     (6,7,0)
 With weight: 4
 pt[2]:    location:  1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (6,6,1)
 With weight: 4
 pt[3]:    location:  0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (5,7,1)
 With weight: 4
 pt[4]:    location:  1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (7,7,1)
 With weight: 4
 pt[5]:    location:  1.25  2.25 -1.25
+   is located on boundary: 0
    idx:     (6,8,1)
 With weight: 4
 pt[6]:    location:  1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (6,7,2)
 With weight: 4
 
 On point:    location:  1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (7,7,1)
 pt[0]:    location:  1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (7,7,1)
 With weight: -24
 pt[1]:    location:  1.75  1.75 -1.75
+   is located on boundary: 0
    idx:     (7,7,0)
 With weight: 4
 pt[2]:    location:  1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (7,6,1)
 With weight: 4
 pt[3]:    location:  1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (6,7,1)
 With weight: 4
 pt[4]:    location:  2.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (8,7,1)
 With weight: 4
 pt[5]:    location:  1.75  2.25 -1.25
+   is located on boundary: 0
    idx:     (7,8,1)
 With weight: 4
 pt[6]:    location:  1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (7,7,2)
 With weight: 4
 
 On point:    location: -1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (0,0,2)
 pt[0]:    location: -1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (0,0,2)
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (0,0,1)
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -0.75
+   is located on boundary: 0
    idx:     (0,-1,2)
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (-1,0,2)
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (1,0,2)
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (0,1,2)
 With weight: 4
 pt[6]:    location: -1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (0,0,3)
 With weight: 4
 
 On point:    location: -1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (1,0,2)
 pt[0]:    location: -1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (1,0,2)
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (1,0,1)
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -0.75
+   is located on boundary: 0
    idx:     (1,-1,2)
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (0,0,2)
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (2,0,2)
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (1,1,2)
 With weight: 4
 pt[6]:    location: -1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (1,0,3)
 With weight: 4
 
 On point:    location: -0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (2,0,2)
 pt[0]:    location: -0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (2,0,2)
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (2,0,1)
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -0.75
+   is located on boundary: 0
    idx:     (2,-1,2)
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (1,0,2)
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (3,0,2)
 With weight: 4
 pt[5]:    location: -0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (2,0,3)
 With weight: 4
 pt[6]:    location: -0.75 -2.25 -1.25
+   is located on boundary: 0
    idx:     (2,-1,1)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location: -0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (3,0,2)
 pt[0]:    location: -0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (3,0,2)
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (3,0,1)
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -0.75
+   is located on boundary: 0
    idx:     (3,-1,2)
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (2,0,2)
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (4,0,2)
 With weight: 4
 pt[5]:    location: -0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (3,0,3)
 With weight: 4
 pt[6]:    location: -0.25 -2.25 -1.25
+   is located on boundary: 0
    idx:     (3,-1,1)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location:  0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (4,0,2)
 pt[0]:    location:  0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (4,0,2)
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (4,0,1)
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -0.75
+   is located on boundary: 0
    idx:     (4,-1,2)
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (3,0,2)
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (5,0,2)
 With weight: 4
 pt[5]:    location:  0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (4,0,3)
 With weight: 4
 pt[6]:    location:  0.25 -2.25 -1.25
+   is located on boundary: 0
    idx:     (4,-1,1)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location:  0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (5,0,2)
 pt[0]:    location:  0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (5,0,2)
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (5,0,1)
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -0.75
+   is located on boundary: 0
    idx:     (5,-1,2)
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (4,0,2)
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (6,0,2)
 With weight: 4
 pt[5]:    location:  0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (5,0,3)
 With weight: 4
 pt[6]:    location:  0.75 -2.25 -1.25
+   is located on boundary: 0
    idx:     (5,-1,1)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location:  1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (6,0,2)
 pt[0]:    location:  1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (6,0,2)
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (6,0,1)
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -0.75
+   is located on boundary: 0
    idx:     (6,-1,2)
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (5,0,2)
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (7,0,2)
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (6,1,2)
 With weight: 4
 pt[6]:    location:  1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (6,0,3)
 With weight: 4
 
 On point:    location:  1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (7,0,2)
 pt[0]:    location:  1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (7,0,2)
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -1.25
+   is located on boundary: 0
    idx:     (7,0,1)
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -0.75
+   is located on boundary: 0
    idx:     (7,-1,2)
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (6,0,2)
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (8,0,2)
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (7,1,2)
 With weight: 4
 pt[6]:    location:  1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (7,0,3)
 With weight: 4
 
 On point:    location: -1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (0,1,2)
 pt[0]:    location: -1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (0,1,2)
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (0,1,1)
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (0,0,2)
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (-1,1,2)
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (1,1,2)
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (0,2,2)
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (0,1,3)
 With weight: 4
 
 On point:    location: -1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (1,1,2)
 pt[0]:    location: -1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (1,1,2)
 With weight: -13.3333
 pt[1]:    location: -1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (1,1,1)
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (1,0,2)
 With weight: 2.66667
 pt[3]:    location: -1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (0,1,2)
 With weight: 2.66667
 pt[4]:    location: -1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (1,1,3)
 With weight: 4
 pt[5]:    location: -1.25 -1.75 -1.25
+   is located on boundary: 0
    idx:     (1,0,1)
-With weight: 3.94312e-16
+With weight: -9.11452e-17
 pt[6]:    location: -1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (0,1,1)
-With weight: -1.03306e-15
+With weight: -7.36121e-16
 
 On point:    location:  1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (6,1,2)
 pt[0]:    location:  1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (6,1,2)
 With weight: -14.1867
 pt[1]:    location:  1.25 -1.25 -1.25
+   is located on boundary: 0
    idx:     (6,1,1)
 With weight: 2.72
 pt[2]:    location:  1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (6,0,2)
 With weight: 1.38667
 pt[3]:    location:  1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (7,1,2)
 With weight: 3.52
 pt[4]:    location:  1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (6,1,3)
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (5,1,1)
 With weight: 1.28
 pt[6]:    location:  0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (5,0,2)
 With weight: 1.28
 
 On point:    location:  1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (7,1,2)
 pt[0]:    location:  1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (7,1,2)
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -1.25
+   is located on boundary: 0
    idx:     (7,1,1)
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (7,0,2)
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (6,1,2)
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (8,1,2)
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (7,2,2)
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (7,1,3)
 With weight: 4
 
 On point:    location: -1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (0,2,2)
 pt[0]:    location: -1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (0,2,2)
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (0,2,1)
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (0,1,2)
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -0.75
+   is located on boundary: 0
    idx:     (-1,2,2)
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (0,3,2)
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (0,2,3)
 With weight: 4
 pt[6]:    location: -2.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (-1,2,1)
-With weight: 3.4021e-16
+With weight: 1.13062e-15
 
 On point:    location:  1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (7,2,2)
 pt[0]:    location:  1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (7,2,2)
 With weight: -19.2941
 pt[1]:    location:  1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (7,2,1)
 With weight: 2.11765
 pt[2]:    location:  1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (7,1,2)
 With weight: 4
 pt[3]:    location:  2.25 -0.75 -0.75
+   is located on boundary: 0
    idx:     (8,2,2)
 With weight: 3.29412
 pt[4]:    location:  1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (7,3,2)
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (7,2,3)
 With weight: 4
 pt[6]:    location:  1.25 -0.75 -1.25
+   is located on boundary: 0
    idx:     (6,2,1)
 With weight: 1.88235
 
 On point:    location: -1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (0,3,2)
 pt[0]:    location: -1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (0,3,2)
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (0,3,1)
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (0,2,2)
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -0.75
+   is located on boundary: 0
    idx:     (-1,3,2)
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (0,4,2)
 With weight: 4
 pt[5]:    location: -1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (0,3,3)
 With weight: 4
 pt[6]:    location: -2.25 -0.25 -1.25
+   is located on boundary: 0
    idx:     (-1,3,1)
-With weight: 3.4021e-16
+With weight: 1.13062e-15
 
 On point:    location:  1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (7,3,2)
 pt[0]:    location:  1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (7,3,2)
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25 -1.25
+   is located on boundary: 0
    idx:     (7,3,1)
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (7,2,2)
 With weight: 4
 pt[3]:    location:  2.25 -0.25 -0.75
+   is located on boundary: 0
    idx:     (8,3,2)
 With weight: 2.66667
 pt[4]:    location:  1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (7,4,2)
 With weight: 4
 pt[5]:    location:  1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (7,3,3)
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -1.25
+   is located on boundary: 0
    idx:     (7,2,1)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location: -1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (0,4,2)
 pt[0]:    location: -1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (0,4,2)
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (0,4,1)
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (0,3,2)
 With weight: 4
 pt[3]:    location: -2.25  0.25 -0.75
+   is located on boundary: 0
    idx:     (-1,4,2)
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (0,5,2)
 With weight: 4
 pt[5]:    location: -1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (0,4,3)
 With weight: 4
 pt[6]:    location: -2.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (-1,4,1)
-With weight: 3.4021e-16
+With weight: 1.13062e-15
 
 On point:    location:  1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (7,4,2)
 pt[0]:    location:  1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (7,4,2)
 With weight: -19.2941
 pt[1]:    location:  1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (7,4,1)
 With weight: 2.11765
 pt[2]:    location:  1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (7,3,2)
 With weight: 4
 pt[3]:    location:  2.25  0.25 -0.75
+   is located on boundary: 0
    idx:     (8,4,2)
 With weight: 3.29412
 pt[4]:    location:  1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (7,5,2)
 With weight: 4
 pt[5]:    location:  1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (7,4,3)
 With weight: 4
 pt[6]:    location:  1.25  0.25 -1.25
+   is located on boundary: 0
    idx:     (6,4,1)
 With weight: 1.88235
 
 On point:    location: -1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (0,5,2)
 pt[0]:    location: -1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (0,5,2)
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (0,5,1)
 With weight: 4
 pt[2]:    location: -1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (0,4,2)
 With weight: 4
 pt[3]:    location: -2.25  0.75 -0.75
+   is located on boundary: 0
    idx:     (-1,5,2)
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (0,6,2)
 With weight: 4
 pt[5]:    location: -1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (0,5,3)
 With weight: 4
 pt[6]:    location: -2.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (-1,5,1)
-With weight: 3.4021e-16
+With weight: 1.13062e-15
 
 On point:    location:  1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (7,5,2)
 pt[0]:    location:  1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (7,5,2)
 With weight: -18.6667
 pt[1]:    location:  1.75  0.75 -1.25
+   is located on boundary: 0
    idx:     (7,5,1)
 With weight: 4
 pt[2]:    location:  1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (7,4,2)
 With weight: 4
 pt[3]:    location:  2.25  0.75 -0.75
+   is located on boundary: 0
    idx:     (8,5,2)
 With weight: 2.66667
 pt[4]:    location:  1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (7,6,2)
 With weight: 4
 pt[5]:    location:  1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (7,5,3)
 With weight: 4
 pt[6]:    location:  1.75  0.25 -1.25
+   is located on boundary: 0
    idx:     (7,4,1)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location: -1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (0,6,2)
 pt[0]:    location: -1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (0,6,2)
 With weight: -24
 pt[1]:    location: -1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (0,6,1)
 With weight: 4
 pt[2]:    location: -1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (0,5,2)
 With weight: 4
 pt[3]:    location: -2.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (-1,6,2)
 With weight: 4
 pt[4]:    location: -1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (1,6,2)
 With weight: 4
 pt[5]:    location: -1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (0,7,2)
 With weight: 4
 pt[6]:    location: -1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (0,6,3)
 With weight: 4
 
 On point:    location: -1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (1,6,2)
 pt[0]:    location: -1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (1,6,2)
 With weight: -13.3333
 pt[1]:    location: -1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (1,6,1)
 With weight: 1.33333
 pt[2]:    location: -1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (0,6,2)
 With weight: 2.66667
 pt[3]:    location: -1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (1,7,2)
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (1,6,3)
 With weight: 4
 pt[5]:    location: -1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (1,5,1)
 With weight: 2
 pt[6]:    location: -1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (1,7,1)
 With weight: 0.666667
 
 On point:    location:  1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (6,6,2)
 pt[0]:    location:  1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (6,6,2)
 With weight: -14.5882
 pt[1]:    location:  1.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (6,6,1)
 With weight: 0.235294
 pt[2]:    location:  1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (7,6,2)
 With weight: 3.29412
 pt[3]:    location:  1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (6,7,2)
 With weight: 3.29412
 pt[4]:    location:  1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (6,6,3)
 With weight: 4
 pt[5]:    location:  1.25  0.75 -1.25
+   is located on boundary: 0
    idx:     (6,5,1)
 With weight: 1.88235
 pt[6]:    location:  0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (5,6,1)
 With weight: 1.88235
 
 On point:    location:  1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (7,6,2)
 pt[0]:    location:  1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (7,6,2)
 With weight: -24
 pt[1]:    location:  1.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (7,6,1)
 With weight: 4
 pt[2]:    location:  1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (7,5,2)
 With weight: 4
 pt[3]:    location:  1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (6,6,2)
 With weight: 4
 pt[4]:    location:  2.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (8,6,2)
 With weight: 4
 pt[5]:    location:  1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (7,7,2)
 With weight: 4
 pt[6]:    location:  1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (7,6,3)
 With weight: 4
 
 On point:    location: -1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (0,7,2)
 pt[0]:    location: -1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (0,7,2)
 With weight: -24
 pt[1]:    location: -1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (0,7,1)
 With weight: 4
 pt[2]:    location: -1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (0,6,2)
 With weight: 4
 pt[3]:    location: -2.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (-1,7,2)
 With weight: 4
 pt[4]:    location: -1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (1,7,2)
 With weight: 4
 pt[5]:    location: -1.75  2.25 -0.75
+   is located on boundary: 0
    idx:     (0,8,2)
 With weight: 4
 pt[6]:    location: -1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (0,7,3)
 With weight: 4
 
 On point:    location: -1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (1,7,2)
 pt[0]:    location: -1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (1,7,2)
 With weight: -24
 pt[1]:    location: -1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (1,7,1)
 With weight: 4
 pt[2]:    location: -1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (1,6,2)
 With weight: 4
 pt[3]:    location: -1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (0,7,2)
 With weight: 4
 pt[4]:    location: -0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (2,7,2)
 With weight: 4
 pt[5]:    location: -1.25  2.25 -0.75
+   is located on boundary: 0
    idx:     (1,8,2)
 With weight: 4
 pt[6]:    location: -1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (1,7,3)
 With weight: 4
 
 On point:    location: -0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (2,7,2)
 pt[0]:    location: -0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (2,7,2)
 With weight: -18.6667
 pt[1]:    location: -0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (2,7,1)
 With weight: 4
 pt[2]:    location: -1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (1,7,2)
 With weight: 4
 pt[3]:    location: -0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (3,7,2)
 With weight: 4
 pt[4]:    location: -0.75  2.25 -0.75
+   is located on boundary: 0
    idx:     (2,8,2)
 With weight: 2.66667
 pt[5]:    location: -0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (2,7,3)
 With weight: 4
 pt[6]:    location: -0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (3,7,1)
-With weight: 1.00144e-15
+With weight: 1.09747e-15
 
 On point:    location: -0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (3,7,2)
 pt[0]:    location: -0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (3,7,2)
 With weight: -19.2941
 pt[1]:    location: -0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (3,7,1)
 With weight: 2.11765
 pt[2]:    location: -0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (2,7,2)
 With weight: 4
 pt[3]:    location:  0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (4,7,2)
 With weight: 4
 pt[4]:    location: -0.25  2.25 -0.75
+   is located on boundary: 0
    idx:     (3,8,2)
 With weight: 3.29412
 pt[5]:    location: -0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (3,7,3)
 With weight: 4
 pt[6]:    location: -0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (3,6,1)
 With weight: 1.88235
 
 On point:    location:  0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (4,7,2)
 pt[0]:    location:  0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (4,7,2)
 With weight: -19.2941
 pt[1]:    location:  0.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (4,7,1)
 With weight: 2.11765
 pt[2]:    location: -0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (3,7,2)
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (5,7,2)
 With weight: 4
 pt[4]:    location:  0.25  2.25 -0.75
+   is located on boundary: 0
    idx:     (4,8,2)
 With weight: 3.29412
 pt[5]:    location:  0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (4,7,3)
 With weight: 4
 pt[6]:    location:  0.25  1.25 -1.25
+   is located on boundary: 0
    idx:     (4,6,1)
 With weight: 1.88235
 
 On point:    location:  0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (5,7,2)
 pt[0]:    location:  0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (5,7,2)
 With weight: -19.2941
 pt[1]:    location:  0.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (5,7,1)
 With weight: 2.11765
 pt[2]:    location:  0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (4,7,2)
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (6,7,2)
 With weight: 4
 pt[4]:    location:  0.75  2.25 -0.75
+   is located on boundary: 0
    idx:     (5,8,2)
 With weight: 3.29412
 pt[5]:    location:  0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (5,7,3)
 With weight: 4
 pt[6]:    location:  0.75  1.25 -1.25
+   is located on boundary: 0
    idx:     (5,6,1)
 With weight: 1.88235
 
 On point:    location:  1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (6,7,2)
 pt[0]:    location:  1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (6,7,2)
 With weight: -24
 pt[1]:    location:  1.25  1.75 -1.25
+   is located on boundary: 0
    idx:     (6,7,1)
 With weight: 4
 pt[2]:    location:  1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (6,6,2)
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (5,7,2)
 With weight: 4
 pt[4]:    location:  1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (7,7,2)
 With weight: 4
 pt[5]:    location:  1.25  2.25 -0.75
+   is located on boundary: 0
    idx:     (6,8,2)
 With weight: 4
 pt[6]:    location:  1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (6,7,3)
 With weight: 4
 
 On point:    location:  1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (7,7,2)
 pt[0]:    location:  1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (7,7,2)
 With weight: -24
 pt[1]:    location:  1.75  1.75 -1.25
+   is located on boundary: 0
    idx:     (7,7,1)
 With weight: 4
 pt[2]:    location:  1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (7,6,2)
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (6,7,2)
 With weight: 4
 pt[4]:    location:  2.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (8,7,2)
 With weight: 4
 pt[5]:    location:  1.75  2.25 -0.75
+   is located on boundary: 0
    idx:     (7,8,2)
 With weight: 4
 pt[6]:    location:  1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (7,7,3)
 With weight: 4
 
 On point:    location: -1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (0,0,3)
 pt[0]:    location: -1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (0,0,3)
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (0,0,2)
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -0.25
+   is located on boundary: 0
    idx:     (0,-1,3)
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (-1,0,3)
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (1,0,3)
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (0,1,3)
 With weight: 4
 pt[6]:    location: -1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (0,0,4)
 With weight: 4
 
 On point:    location: -1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (1,0,3)
 pt[0]:    location: -1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (1,0,3)
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (1,0,2)
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -0.25
+   is located on boundary: 0
    idx:     (1,-1,3)
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (0,0,3)
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (2,0,3)
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (1,1,3)
 With weight: 4
 pt[6]:    location: -1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (1,0,4)
 With weight: 4
 
 On point:    location: -0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (2,0,3)
 pt[0]:    location: -0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (2,0,3)
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (2,0,2)
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -0.25
+   is located on boundary: 0
    idx:     (2,-1,3)
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (1,0,3)
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (3,0,3)
 With weight: 4
 pt[5]:    location: -0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (2,0,4)
 With weight: 4
 pt[6]:    location: -0.75 -2.25 -0.75
+   is located on boundary: 0
    idx:     (2,-1,2)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location: -0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (3,0,3)
 pt[0]:    location: -0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (3,0,3)
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (3,0,2)
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -0.25
+   is located on boundary: 0
    idx:     (3,-1,3)
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (2,0,3)
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (4,0,3)
 With weight: 4
 pt[5]:    location: -0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (3,0,4)
 With weight: 4
 pt[6]:    location: -0.25 -2.25 -0.75
+   is located on boundary: 0
    idx:     (3,-1,2)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location:  0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (4,0,3)
 pt[0]:    location:  0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (4,0,3)
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (4,0,2)
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -0.25
+   is located on boundary: 0
    idx:     (4,-1,3)
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (3,0,3)
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (5,0,3)
 With weight: 4
 pt[5]:    location:  0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (4,0,4)
 With weight: 4
 pt[6]:    location:  0.25 -2.25 -0.75
+   is located on boundary: 0
    idx:     (4,-1,2)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location:  0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (5,0,3)
 pt[0]:    location:  0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (5,0,3)
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (5,0,2)
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -0.25
+   is located on boundary: 0
    idx:     (5,-1,3)
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (4,0,3)
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (6,0,3)
 With weight: 4
 pt[5]:    location:  0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (5,0,4)
 With weight: 4
 pt[6]:    location:  0.75 -2.25 -0.75
+   is located on boundary: 0
    idx:     (5,-1,2)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location:  1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (6,0,3)
 pt[0]:    location:  1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (6,0,3)
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (6,0,2)
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -0.25
+   is located on boundary: 0
    idx:     (6,-1,3)
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (5,0,3)
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (7,0,3)
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (6,1,3)
 With weight: 4
 pt[6]:    location:  1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (6,0,4)
 With weight: 4
 
 On point:    location:  1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (7,0,3)
 pt[0]:    location:  1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (7,0,3)
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -0.75
+   is located on boundary: 0
    idx:     (7,0,2)
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -0.25
+   is located on boundary: 0
    idx:     (7,-1,3)
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (6,0,3)
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (8,0,3)
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (7,1,3)
 With weight: 4
 pt[6]:    location:  1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (7,0,4)
 With weight: 4
 
 On point:    location: -1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (0,1,3)
 pt[0]:    location: -1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (0,1,3)
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (0,1,2)
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (0,0,3)
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (-1,1,3)
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (1,1,3)
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (0,2,3)
 With weight: 4
 pt[6]:    location: -1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (0,1,4)
 With weight: 4
 
 On point:    location: -1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (1,1,3)
 pt[0]:    location: -1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (1,1,3)
 With weight: -13.3333
 pt[1]:    location: -1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (1,1,2)
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (1,0,3)
 With weight: 2.66667
 pt[3]:    location: -1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (0,1,3)
 With weight: 2.66667
 pt[4]:    location: -1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (1,1,4)
 With weight: 4
 pt[5]:    location: -1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (1,0,2)
-With weight: 3.94312e-16
+With weight: -9.11452e-17
 pt[6]:    location: -1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (0,1,2)
-With weight: -1.03306e-15
+With weight: -7.36121e-16
 
 On point:    location:  1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (6,1,3)
 pt[0]:    location:  1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (6,1,3)
 With weight: -13.3333
 pt[1]:    location:  1.25 -1.25 -0.75
+   is located on boundary: 0
    idx:     (6,1,2)
 With weight: 4
 pt[2]:    location:  1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (6,0,3)
 With weight: 2.66667
 pt[3]:    location:  1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (7,1,3)
 With weight: 2.66667
 pt[4]:    location:  1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (6,1,4)
 With weight: 4
 pt[5]:    location:  1.25 -1.75 -0.75
+   is located on boundary: 0
    idx:     (6,0,2)
-With weight: 3.94312e-16
+With weight: -9.11452e-17
 pt[6]:    location:  1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (7,1,2)
-With weight: -1.03306e-15
+With weight: -7.36121e-16
 
 On point:    location:  1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (7,1,3)
 pt[0]:    location:  1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (7,1,3)
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (7,1,2)
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (7,0,3)
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (6,1,3)
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (8,1,3)
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (7,2,3)
 With weight: 4
 pt[6]:    location:  1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (7,1,4)
 With weight: 4
 
 On point:    location: -1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (0,2,3)
 pt[0]:    location: -1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (0,2,3)
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (0,2,2)
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (0,1,3)
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -0.25
+   is located on boundary: 0
    idx:     (-1,2,3)
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (0,3,3)
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (0,2,4)
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (0,1,2)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location:  1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (7,2,3)
 pt[0]:    location:  1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (7,2,3)
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (7,2,2)
 With weight: 4
 pt[2]:    location:  1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (7,1,3)
 With weight: 4
 pt[3]:    location:  2.25 -0.75 -0.25
+   is located on boundary: 0
    idx:     (8,2,3)
 With weight: 2.66667
 pt[4]:    location:  1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (7,3,3)
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (7,2,4)
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -0.75
+   is located on boundary: 0
    idx:     (7,1,2)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location: -1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (0,3,3)
 pt[0]:    location: -1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (0,3,3)
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (0,3,2)
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (0,2,3)
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -0.25
+   is located on boundary: 0
    idx:     (-1,3,3)
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (0,4,3)
 With weight: 4
 pt[5]:    location: -1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (0,3,4)
 With weight: 4
 pt[6]:    location: -1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (0,2,2)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location:  1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (7,3,3)
 pt[0]:    location:  1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (7,3,3)
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25 -0.75
+   is located on boundary: 0
    idx:     (7,3,2)
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (7,2,3)
 With weight: 4
 pt[3]:    location:  2.25 -0.25 -0.25
+   is located on boundary: 0
    idx:     (8,3,3)
 With weight: 2.66667
 pt[4]:    location:  1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (7,4,3)
 With weight: 4
 pt[5]:    location:  1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (7,3,4)
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -0.75
+   is located on boundary: 0
    idx:     (7,2,2)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location: -1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (0,4,3)
 pt[0]:    location: -1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (0,4,3)
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (0,4,2)
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (0,3,3)
 With weight: 4
 pt[3]:    location: -2.25  0.25 -0.25
+   is located on boundary: 0
    idx:     (-1,4,3)
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (0,5,3)
 With weight: 4
 pt[5]:    location: -1.75  0.25  0.25
+   is located on boundary: 0
    idx:     (0,4,4)
 With weight: 4
 pt[6]:    location: -2.25  0.25 -0.75
+   is located on boundary: 0
    idx:     (-1,4,2)
-With weight: 3.4021e-16
+With weight: 1.13062e-15
 
 On point:    location:  1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (7,4,3)
 pt[0]:    location:  1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (7,4,3)
 With weight: -18.6667
 pt[1]:    location:  1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (7,4,2)
 With weight: 4
 pt[2]:    location:  1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (7,3,3)
 With weight: 4
 pt[3]:    location:  2.25  0.25 -0.25
+   is located on boundary: 0
    idx:     (8,4,3)
 With weight: 2.66667
 pt[4]:    location:  1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (7,5,3)
 With weight: 4
 pt[5]:    location: 1.75 0.25 0.25
+   is located on boundary: 0
    idx:     (7,4,4)
 With weight: 4
 pt[6]:    location:  2.25  0.25 -0.75
+   is located on boundary: 0
    idx:     (8,4,2)
-With weight: 3.4021e-16
+With weight: 1.13062e-15
 
 On point:    location: -1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (0,5,3)
 pt[0]:    location: -1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (0,5,3)
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (0,5,2)
 With weight: 4
 pt[2]:    location: -1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (0,4,3)
 With weight: 4
 pt[3]:    location: -2.25  0.75 -0.25
+   is located on boundary: 0
    idx:     (-1,5,3)
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (0,6,3)
 With weight: 4
 pt[5]:    location: -1.75  0.75  0.25
+   is located on boundary: 0
    idx:     (0,5,4)
 With weight: 4
 pt[6]:    location: -1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (0,4,2)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location:  1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (7,5,3)
 pt[0]:    location:  1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (7,5,3)
 With weight: -18.6667
 pt[1]:    location:  1.75  0.75 -0.75
+   is located on boundary: 0
    idx:     (7,5,2)
 With weight: 4
 pt[2]:    location:  1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (7,4,3)
 With weight: 4
 pt[3]:    location:  2.25  0.75 -0.25
+   is located on boundary: 0
    idx:     (8,5,3)
 With weight: 2.66667
 pt[4]:    location:  1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (7,6,3)
 With weight: 4
 pt[5]:    location: 1.75 0.75 0.25
+   is located on boundary: 0
    idx:     (7,5,4)
 With weight: 4
 pt[6]:    location:  1.75  0.25 -0.75
+   is located on boundary: 0
    idx:     (7,4,2)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location: -1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (0,6,3)
 pt[0]:    location: -1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (0,6,3)
 With weight: -24
 pt[1]:    location: -1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (0,6,2)
 With weight: 4
 pt[2]:    location: -1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (0,5,3)
 With weight: 4
 pt[3]:    location: -2.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (-1,6,3)
 With weight: 4
 pt[4]:    location: -1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (1,6,3)
 With weight: 4
 pt[5]:    location: -1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (0,7,3)
 With weight: 4
 pt[6]:    location: -1.75  1.25  0.25
+   is located on boundary: 0
    idx:     (0,6,4)
 With weight: 4
 
 On point:    location: -1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (1,6,3)
 pt[0]:    location: -1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (1,6,3)
 With weight: -13.9608
 pt[1]:    location: -1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (1,6,2)
 With weight: 4
 pt[2]:    location: -1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (0,6,3)
 With weight: 0.784314
 pt[3]:    location: -1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (1,7,3)
 With weight: 3.29412
 pt[4]:    location: -1.25  1.25  0.25
+   is located on boundary: 0
    idx:     (1,6,4)
 With weight: 4
 pt[5]:    location: -1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (0,6,2)
-With weight: -8.85313e-16
+With weight: -7.39094e-16
 pt[6]:    location: -1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (0,5,3)
 With weight: 1.88235
 
 On point:    location:  1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (6,6,3)
 pt[0]:    location:  1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (6,6,3)
 With weight: -13.3333
 pt[1]:    location:  1.25  1.25 -0.75
+   is located on boundary: 0
    idx:     (6,6,2)
 With weight: 4
 pt[2]:    location:  1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (7,6,3)
 With weight: 2.66667
 pt[3]:    location:  1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (6,7,3)
 With weight: 2.66667
 pt[4]:    location: 1.25 1.25 0.25
+   is located on boundary: 0
    idx:     (6,6,4)
 With weight: 4
 pt[5]:    location:  1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (7,6,2)
-With weight: -2.31114e-16
+With weight: 3.03817e-17
 pt[6]:    location:  1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (6,7,2)
-With weight: -1.5531e-15
+With weight: -3.14198e-16
 
 On point:    location:  1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (7,6,3)
 pt[0]:    location:  1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (7,6,3)
 With weight: -24
 pt[1]:    location:  1.75  1.25 -0.75
+   is located on boundary: 0
    idx:     (7,6,2)
 With weight: 4
 pt[2]:    location:  1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (7,5,3)
 With weight: 4
 pt[3]:    location:  1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (6,6,3)
 With weight: 4
 pt[4]:    location:  2.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (8,6,3)
 With weight: 4
 pt[5]:    location:  1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (7,7,3)
 With weight: 4
 pt[6]:    location: 1.75 1.25 0.25
+   is located on boundary: 0
    idx:     (7,6,4)
 With weight: 4
 
 On point:    location: -1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (0,7,3)
 pt[0]:    location: -1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (0,7,3)
 With weight: -24
 pt[1]:    location: -1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (0,7,2)
 With weight: 4
 pt[2]:    location: -1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (0,6,3)
 With weight: 4
 pt[3]:    location: -2.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (-1,7,3)
 With weight: 4
 pt[4]:    location: -1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (1,7,3)
 With weight: 4
 pt[5]:    location: -1.75  2.25 -0.25
+   is located on boundary: 0
    idx:     (0,8,3)
 With weight: 4
 pt[6]:    location: -1.75  1.75  0.25
+   is located on boundary: 0
    idx:     (0,7,4)
 With weight: 4
 
 On point:    location: -1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (1,7,3)
 pt[0]:    location: -1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (1,7,3)
 With weight: -24
 pt[1]:    location: -1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (1,7,2)
 With weight: 4
 pt[2]:    location: -1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (1,6,3)
 With weight: 4
 pt[3]:    location: -1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (0,7,3)
 With weight: 4
 pt[4]:    location: -0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (2,7,3)
 With weight: 4
 pt[5]:    location: -1.25  2.25 -0.25
+   is located on boundary: 0
    idx:     (1,8,3)
 With weight: 4
 pt[6]:    location: -1.25  1.75  0.25
+   is located on boundary: 0
    idx:     (1,7,4)
 With weight: 4
 
 On point:    location: -0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (2,7,3)
 pt[0]:    location: -0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (2,7,3)
 With weight: -18.6667
 pt[1]:    location: -0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (2,7,2)
 With weight: 4
 pt[2]:    location: -1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (1,7,3)
 With weight: 4
 pt[3]:    location: -0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (3,7,3)
 With weight: 4
 pt[4]:    location: -0.75  2.25 -0.25
+   is located on boundary: 0
    idx:     (2,8,3)
 With weight: 2.66667
 pt[5]:    location: -0.75  1.75  0.25
+   is located on boundary: 0
    idx:     (2,7,4)
 With weight: 4
 pt[6]:    location: -1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (1,7,2)
-With weight: 8.54259e-16
+With weight: 8.23102e-16
 
 On point:    location: -0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (3,7,3)
 pt[0]:    location: -0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (3,7,3)
 With weight: -18.6667
 pt[1]:    location: -0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (3,7,2)
 With weight: 4
 pt[2]:    location: -0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (2,7,3)
 With weight: 4
 pt[3]:    location:  0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (4,7,3)
 With weight: 4
 pt[4]:    location: -0.25  2.25 -0.25
+   is located on boundary: 0
    idx:     (3,8,3)
 With weight: 2.66667
 pt[5]:    location: -0.25  1.75  0.25
+   is located on boundary: 0
    idx:     (3,7,4)
 With weight: 4
 pt[6]:    location: -0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (2,7,2)
-With weight: 8.54259e-16
+With weight: 8.23102e-16
 
 On point:    location:  0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (4,7,3)
 pt[0]:    location:  0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (4,7,3)
 With weight: -18.6667
 pt[1]:    location:  0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (4,7,2)
 With weight: 4
 pt[2]:    location: -0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (3,7,3)
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (5,7,3)
 With weight: 4
 pt[4]:    location:  0.25  2.25 -0.25
+   is located on boundary: 0
    idx:     (4,8,3)
 With weight: 2.66667
 pt[5]:    location: 0.25 1.75 0.25
+   is located on boundary: 0
    idx:     (4,7,4)
 With weight: 4
 pt[6]:    location:  0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (5,7,2)
-With weight: 1.00144e-15
+With weight: 1.09747e-15
 
 On point:    location:  0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (5,7,3)
 pt[0]:    location:  0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (5,7,3)
 With weight: -18.6667
 pt[1]:    location:  0.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (5,7,2)
 With weight: 4
 pt[2]:    location:  0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (4,7,3)
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (6,7,3)
 With weight: 4
 pt[4]:    location:  0.75  2.25 -0.25
+   is located on boundary: 0
    idx:     (5,8,3)
 With weight: 2.66667
 pt[5]:    location: 0.75 1.75 0.25
+   is located on boundary: 0
    idx:     (5,7,4)
 With weight: 4
 pt[6]:    location:  0.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (4,7,2)
-With weight: 8.54259e-16
+With weight: 8.23102e-16
 
 On point:    location:  1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (6,7,3)
 pt[0]:    location:  1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (6,7,3)
 With weight: -24
 pt[1]:    location:  1.25  1.75 -0.75
+   is located on boundary: 0
    idx:     (6,7,2)
 With weight: 4
 pt[2]:    location:  1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (6,6,3)
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (5,7,3)
 With weight: 4
 pt[4]:    location:  1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (7,7,3)
 With weight: 4
 pt[5]:    location:  1.25  2.25 -0.25
+   is located on boundary: 0
    idx:     (6,8,3)
 With weight: 4
 pt[6]:    location: 1.25 1.75 0.25
+   is located on boundary: 0
    idx:     (6,7,4)
 With weight: 4
 
 On point:    location:  1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (7,7,3)
 pt[0]:    location:  1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (7,7,3)
 With weight: -24
 pt[1]:    location:  1.75  1.75 -0.75
+   is located on boundary: 0
    idx:     (7,7,2)
 With weight: 4
 pt[2]:    location:  1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (7,6,3)
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (6,7,3)
 With weight: 4
 pt[4]:    location:  2.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (8,7,3)
 With weight: 4
 pt[5]:    location:  1.75  2.25 -0.25
+   is located on boundary: 0
    idx:     (7,8,3)
 With weight: 4
 pt[6]:    location: 1.75 1.75 0.25
+   is located on boundary: 0
    idx:     (7,7,4)
 With weight: 4
 
 On point:    location: -1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (0,0,4)
 pt[0]:    location: -1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (0,0,4)
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (0,0,3)
 With weight: 4
 pt[2]:    location: -1.75 -2.25  0.25
+   is located on boundary: 0
    idx:     (0,-1,4)
 With weight: 4
 pt[3]:    location: -2.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (-1,0,4)
 With weight: 4
 pt[4]:    location: -1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (1,0,4)
 With weight: 4
 pt[5]:    location: -1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (0,1,4)
 With weight: 4
 pt[6]:    location: -1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (0,0,5)
 With weight: 4
 
 On point:    location: -1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (1,0,4)
 pt[0]:    location: -1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (1,0,4)
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (1,0,3)
 With weight: 4
 pt[2]:    location: -1.25 -2.25  0.25
+   is located on boundary: 0
    idx:     (1,-1,4)
 With weight: 4
 pt[3]:    location: -1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (0,0,4)
 With weight: 4
 pt[4]:    location: -0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (2,0,4)
 With weight: 4
 pt[5]:    location: -1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (1,1,4)
 With weight: 4
 pt[6]:    location: -1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (1,0,5)
 With weight: 4
 
 On point:    location: -0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (2,0,4)
 pt[0]:    location: -0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (2,0,4)
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (2,0,3)
 With weight: 4
 pt[2]:    location: -0.75 -2.25  0.25
+   is located on boundary: 0
    idx:     (2,-1,4)
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (1,0,4)
 With weight: 4
 pt[4]:    location: -0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (3,0,4)
 With weight: 4
 pt[5]:    location: -0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (2,0,5)
 With weight: 4
 pt[6]:    location: -1.25 -2.25  0.25
+   is located on boundary: 0
    idx:     (1,-1,4)
-With weight: 8.04978e-16
+With weight: 6.03e-16
 
 On point:    location: -0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (3,0,4)
 pt[0]:    location: -0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (3,0,4)
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (3,0,3)
 With weight: 4
 pt[2]:    location: -0.25 -2.25  0.25
+   is located on boundary: 0
    idx:     (3,-1,4)
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (2,0,4)
 With weight: 4
 pt[4]:    location:  0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (4,0,4)
 With weight: 4
 pt[5]:    location: -0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (3,0,5)
 With weight: 4
 pt[6]:    location: -0.75 -2.25  0.25
+   is located on boundary: 0
    idx:     (2,-1,4)
-With weight: 8.04978e-16
+With weight: 6.03e-16
 
 On point:    location:  0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (4,0,4)
 pt[0]:    location:  0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (4,0,4)
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (4,0,3)
 With weight: 4
 pt[2]:    location:  0.25 -2.25  0.25
+   is located on boundary: 0
    idx:     (4,-1,4)
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (3,0,4)
 With weight: 4
 pt[4]:    location:  0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (5,0,4)
 With weight: 4
 pt[5]:    location:  0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (4,0,5)
 With weight: 4
 pt[6]:    location:  0.75 -2.25  0.25
+   is located on boundary: 0
    idx:     (5,-1,4)
-With weight: -8.7435e-16
+With weight: -6.85912e-16
 
 On point:    location:  0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (5,0,4)
 pt[0]:    location:  0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (5,0,4)
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (5,0,3)
 With weight: 4
 pt[2]:    location:  0.75 -2.25  0.25
+   is located on boundary: 0
    idx:     (5,-1,4)
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (4,0,4)
 With weight: 4
 pt[4]:    location:  1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (6,0,4)
 With weight: 4
 pt[5]:    location:  0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (5,0,5)
 With weight: 4
 pt[6]:    location:  0.25 -2.25  0.25
+   is located on boundary: 0
    idx:     (4,-1,4)
-With weight: 8.04978e-16
+With weight: 6.03e-16
 
 On point:    location:  1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (6,0,4)
 pt[0]:    location:  1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (6,0,4)
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -0.25
+   is located on boundary: 0
    idx:     (6,0,3)
 With weight: 4
 pt[2]:    location:  1.25 -2.25  0.25
+   is located on boundary: 0
    idx:     (6,-1,4)
 With weight: 4
 pt[3]:    location:  0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (5,0,4)
 With weight: 4
 pt[4]:    location:  1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (7,0,4)
 With weight: 4
 pt[5]:    location:  1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (6,1,4)
 With weight: 4
 pt[6]:    location:  1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (6,0,5)
 With weight: 4
 
 On point:    location:  1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (7,0,4)
 pt[0]:    location:  1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (7,0,4)
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -0.25
+   is located on boundary: 0
    idx:     (7,0,3)
 With weight: 4
 pt[2]:    location:  1.75 -2.25  0.25
+   is located on boundary: 0
    idx:     (7,-1,4)
 With weight: 4
 pt[3]:    location:  1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (6,0,4)
 With weight: 4
 pt[4]:    location:  2.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (8,0,4)
 With weight: 4
 pt[5]:    location:  1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (7,1,4)
 With weight: 4
 pt[6]:    location:  1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (7,0,5)
 With weight: 4
 
 On point:    location: -1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (0,1,4)
 pt[0]:    location: -1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (0,1,4)
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (0,1,3)
 With weight: 4
 pt[2]:    location: -1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (0,0,4)
 With weight: 4
 pt[3]:    location: -2.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (-1,1,4)
 With weight: 4
 pt[4]:    location: -1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (1,1,4)
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (0,2,4)
 With weight: 4
 pt[6]:    location: -1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (0,1,5)
 With weight: 4
 
 On point:    location: -1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (1,1,4)
 pt[0]:    location: -1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (1,1,4)
 With weight: -13.9608
 pt[1]:    location: -1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (1,1,3)
 With weight: 4
 pt[2]:    location: -1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (1,0,4)
 With weight: 3.29412
 pt[3]:    location: -1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (0,1,4)
 With weight: 0.784314
 pt[4]:    location: -1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (1,1,5)
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (0,2,4)
 With weight: 1.88235
 pt[6]:    location: -1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (1,0,5)
-With weight: -1.94411e-16
+With weight: -1.55529e-15
 
 On point:    location:  1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (6,1,4)
 pt[0]:    location:  1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (6,1,4)
 With weight: -13.3333
 pt[1]:    location:  1.25 -1.25 -0.25
+   is located on boundary: 0
    idx:     (6,1,3)
 With weight: 4
 pt[2]:    location:  1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (6,0,4)
-With weight: -2.53666e-16
+With weight: 6.03419e-16
 pt[3]:    location:  1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (7,1,4)
 With weight: 2.66667
 pt[4]:    location:  1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (6,1,5)
 With weight: 4
 pt[5]:    location:  0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (5,0,4)
 With weight: 2
 pt[6]:    location:  1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (7,0,4)
 With weight: 0.666667
 
 On point:    location:  1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (7,1,4)
 pt[0]:    location:  1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (7,1,4)
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -0.25
+   is located on boundary: 0
    idx:     (7,1,3)
 With weight: 4
 pt[2]:    location:  1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (7,0,4)
 With weight: 4
 pt[3]:    location:  1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (6,1,4)
 With weight: 4
 pt[4]:    location:  2.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (8,1,4)
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (7,2,4)
 With weight: 4
 pt[6]:    location:  1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (7,1,5)
 With weight: 4
 
 On point:    location: -1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (0,2,4)
 pt[0]:    location: -1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (0,2,4)
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (0,2,3)
 With weight: 4
 pt[2]:    location: -1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (0,1,4)
 With weight: 4
 pt[3]:    location: -2.25 -0.75  0.25
+   is located on boundary: 0
    idx:     (-1,2,4)
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (0,3,4)
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (0,2,5)
 With weight: 4
 pt[6]:    location: -2.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (-1,1,4)
-With weight: 1.82203e-15
+With weight: 1.3869e-15
 
 On point:    location:  1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (7,2,4)
 pt[0]:    location:  1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (7,2,4)
 With weight: -19.2941
 pt[1]:    location:  1.75 -0.75 -0.25
+   is located on boundary: 0
    idx:     (7,2,3)
 With weight: 4
 pt[2]:    location:  1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (7,1,4)
 With weight: 2.11765
 pt[3]:    location:  2.25 -0.75  0.25
+   is located on boundary: 0
    idx:     (8,2,4)
 With weight: 3.29412
 pt[4]:    location:  1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (7,3,4)
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (7,2,5)
 With weight: 4
 pt[6]:    location:  1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (6,1,4)
 With weight: 1.88235
 
 On point:    location: -1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (0,3,4)
 pt[0]:    location: -1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (0,3,4)
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (0,3,3)
 With weight: 4
 pt[2]:    location: -1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (0,2,4)
 With weight: 4
 pt[3]:    location: -2.25 -0.25  0.25
+   is located on boundary: 0
    idx:     (-1,3,4)
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25  0.25
+   is located on boundary: 0
    idx:     (0,4,4)
 With weight: 4
 pt[5]:    location: -1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (0,3,5)
 With weight: 4
 pt[6]:    location: -2.25 -0.75  0.25
+   is located on boundary: 0
    idx:     (-1,2,4)
-With weight: 1.82203e-15
+With weight: 1.3869e-15
 
 On point:    location:  1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (7,3,4)
 pt[0]:    location:  1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (7,3,4)
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25 -0.25
+   is located on boundary: 0
    idx:     (7,3,3)
 With weight: 4
 pt[2]:    location:  1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (7,2,4)
 With weight: 4
 pt[3]:    location:  2.25 -0.25  0.25
+   is located on boundary: 0
    idx:     (8,3,4)
 With weight: 2.66667
 pt[4]:    location: 1.75 0.25 0.25
+   is located on boundary: 0
    idx:     (7,4,4)
 With weight: 4
 pt[5]:    location:  1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (7,3,5)
 With weight: 4
 pt[6]:    location:  2.25 -0.75  0.25
+   is located on boundary: 0
    idx:     (8,2,4)
-With weight: 1.82203e-15
+With weight: 1.3869e-15
 
 On point:    location: -1.75  0.25  0.25
+   is located on boundary: 0
    idx:     (0,4,4)
 pt[0]:    location: -1.75  0.25  0.25
+   is located on boundary: 0
    idx:     (0,4,4)
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (0,4,3)
 With weight: 4
 pt[2]:    location: -1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (0,3,4)
 With weight: 4
 pt[3]:    location: -2.25  0.25  0.25
+   is located on boundary: 0
    idx:     (-1,4,4)
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75  0.25
+   is located on boundary: 0
    idx:     (0,5,4)
 With weight: 4
 pt[5]:    location: -1.75  0.25  0.75
+   is located on boundary: 0
    idx:     (0,4,5)
 With weight: 4
 pt[6]:    location: -2.25  0.75  0.25
+   is located on boundary: 0
    idx:     (-1,5,4)
-With weight: -1.05423e-15
+With weight: -1.47735e-15
 
 On point:    location: 1.75 0.25 0.25
+   is located on boundary: 0
    idx:     (7,4,4)
 pt[0]:    location: 1.75 0.25 0.25
+   is located on boundary: 0
    idx:     (7,4,4)
 With weight: -18.6667
 pt[1]:    location:  1.75  0.25 -0.25
+   is located on boundary: 0
    idx:     (7,4,3)
 With weight: 4
 pt[2]:    location:  1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (7,3,4)
 With weight: 4
 pt[3]:    location: 2.25 0.25 0.25
+   is located on boundary: 0
    idx:     (8,4,4)
 With weight: 2.66667
 pt[4]:    location: 1.75 0.75 0.25
+   is located on boundary: 0
    idx:     (7,5,4)
 With weight: 4
 pt[5]:    location: 1.75 0.25 0.75
+   is located on boundary: 0
    idx:     (7,4,5)
 With weight: 4
 pt[6]:    location: 2.25 0.75 0.25
+   is located on boundary: 0
    idx:     (8,5,4)
-With weight: -1.05423e-15
+With weight: -1.47735e-15
 
 On point:    location: -1.75  0.75  0.25
+   is located on boundary: 0
    idx:     (0,5,4)
 pt[0]:    location: -1.75  0.75  0.25
+   is located on boundary: 0
    idx:     (0,5,4)
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (0,5,3)
 With weight: 4
 pt[2]:    location: -1.75  0.25  0.25
+   is located on boundary: 0
    idx:     (0,4,4)
 With weight: 4
 pt[3]:    location: -2.25  0.75  0.25
+   is located on boundary: 0
    idx:     (-1,5,4)
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25  0.25
+   is located on boundary: 0
    idx:     (0,6,4)
 With weight: 4
 pt[5]:    location: -1.75  0.75  0.75
+   is located on boundary: 0
    idx:     (0,5,5)
 With weight: 4
 pt[6]:    location: -2.25  0.25  0.25
+   is located on boundary: 0
    idx:     (-1,4,4)
-With weight: 1.82203e-15
+With weight: 1.3869e-15
 
 On point:    location: 1.75 0.75 0.25
+   is located on boundary: 0
    idx:     (7,5,4)
 pt[0]:    location: 1.75 0.75 0.25
+   is located on boundary: 0
    idx:     (7,5,4)
 With weight: -19.2941
 pt[1]:    location:  1.75  0.75 -0.25
+   is located on boundary: 0
    idx:     (7,5,3)
 With weight: 4
 pt[2]:    location: 1.75 0.25 0.25
+   is located on boundary: 0
    idx:     (7,4,4)
 With weight: 4
 pt[3]:    location: 2.25 0.75 0.25
+   is located on boundary: 0
    idx:     (8,5,4)
 With weight: 3.29412
 pt[4]:    location: 1.75 1.25 0.25
+   is located on boundary: 0
    idx:     (7,6,4)
 With weight: 2.11765
 pt[5]:    location: 1.75 0.75 0.75
+   is located on boundary: 0
    idx:     (7,5,5)
 With weight: 4
 pt[6]:    location: 1.25 1.25 0.25
+   is located on boundary: 0
    idx:     (6,6,4)
 With weight: 1.88235
 
 On point:    location: -1.75  1.25  0.25
+   is located on boundary: 0
    idx:     (0,6,4)
 pt[0]:    location: -1.75  1.25  0.25
+   is located on boundary: 0
    idx:     (0,6,4)
 With weight: -24
 pt[1]:    location: -1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (0,6,3)
 With weight: 4
 pt[2]:    location: -1.75  0.75  0.25
+   is located on boundary: 0
    idx:     (0,5,4)
 With weight: 4
 pt[3]:    location: -2.25  1.25  0.25
+   is located on boundary: 0
    idx:     (-1,6,4)
 With weight: 4
 pt[4]:    location: -1.25  1.25  0.25
+   is located on boundary: 0
    idx:     (1,6,4)
 With weight: 4
 pt[5]:    location: -1.75  1.75  0.25
+   is located on boundary: 0
    idx:     (0,7,4)
 With weight: 4
 pt[6]:    location: -1.75  1.25  0.75
+   is located on boundary: 0
    idx:     (0,6,5)
 With weight: 4
 
 On point:    location: -1.25  1.25  0.25
+   is located on boundary: 0
    idx:     (1,6,4)
 pt[0]:    location: -1.25  1.25  0.25
+   is located on boundary: 0
    idx:     (1,6,4)
 With weight: -13.3333
 pt[1]:    location: -1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (1,6,3)
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.25
+   is located on boundary: 0
    idx:     (0,6,4)
 With weight: 2.66667
 pt[3]:    location: -1.25  1.75  0.25
+   is located on boundary: 0
    idx:     (1,7,4)
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25  0.75
+   is located on boundary: 0
    idx:     (1,6,5)
 With weight: 4
 pt[5]:    location: -1.75  1.75  0.25
+   is located on boundary: 0
    idx:     (0,7,4)
-With weight: 1.14237e-16
+With weight: 4.50879e-16
 pt[6]:    location: -1.75  1.25  0.75
+   is located on boundary: 0
    idx:     (0,6,5)
-With weight: -2.86472e-16
+With weight: 1.30313e-16
 
 On point:    location: 1.25 1.25 0.25
+   is located on boundary: 0
    idx:     (6,6,4)
 pt[0]:    location: 1.25 1.25 0.25
+   is located on boundary: 0
    idx:     (6,6,4)
 With weight: -13.3333
 pt[1]:    location:  1.25  1.25 -0.25
+   is located on boundary: 0
    idx:     (6,6,3)
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.25
+   is located on boundary: 0
    idx:     (7,6,4)
 With weight: 2.66667
 pt[3]:    location: 1.25 1.75 0.25
+   is located on boundary: 0
    idx:     (6,7,4)
-With weight: -9.32461e-17
+With weight: -2.16225e-15
 pt[4]:    location: 1.25 1.25 0.75
+   is located on boundary: 0
    idx:     (6,6,5)
 With weight: 4
 pt[5]:    location: 0.75 1.75 0.25
+   is located on boundary: 0
    idx:     (5,7,4)
 With weight: 2
 pt[6]:    location: 1.75 1.75 0.25
+   is located on boundary: 0
    idx:     (7,7,4)
 With weight: 0.666667
 
 On point:    location: 1.75 1.25 0.25
+   is located on boundary: 0
    idx:     (7,6,4)
 pt[0]:    location: 1.75 1.25 0.25
+   is located on boundary: 0
    idx:     (7,6,4)
 With weight: -24
 pt[1]:    location:  1.75  1.25 -0.25
+   is located on boundary: 0
    idx:     (7,6,3)
 With weight: 4
 pt[2]:    location: 1.75 0.75 0.25
+   is located on boundary: 0
    idx:     (7,5,4)
 With weight: 4
 pt[3]:    location: 1.25 1.25 0.25
+   is located on boundary: 0
    idx:     (6,6,4)
 With weight: 4
 pt[4]:    location: 2.25 1.25 0.25
+   is located on boundary: 0
    idx:     (8,6,4)
 With weight: 4
 pt[5]:    location: 1.75 1.75 0.25
+   is located on boundary: 0
    idx:     (7,7,4)
 With weight: 4
 pt[6]:    location: 1.75 1.25 0.75
+   is located on boundary: 0
    idx:     (7,6,5)
 With weight: 4
 
 On point:    location: -1.75  1.75  0.25
+   is located on boundary: 0
    idx:     (0,7,4)
 pt[0]:    location: -1.75  1.75  0.25
+   is located on boundary: 0
    idx:     (0,7,4)
 With weight: -24
 pt[1]:    location: -1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (0,7,3)
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.25
+   is located on boundary: 0
    idx:     (0,6,4)
 With weight: 4
 pt[3]:    location: -2.25  1.75  0.25
+   is located on boundary: 0
    idx:     (-1,7,4)
 With weight: 4
 pt[4]:    location: -1.25  1.75  0.25
+   is located on boundary: 0
    idx:     (1,7,4)
 With weight: 4
 pt[5]:    location: -1.75  2.25  0.25
+   is located on boundary: 0
    idx:     (0,8,4)
 With weight: 4
 pt[6]:    location: -1.75  1.75  0.75
+   is located on boundary: 0
    idx:     (0,7,5)
 With weight: 4
 
 On point:    location: -1.25  1.75  0.25
+   is located on boundary: 0
    idx:     (1,7,4)
 pt[0]:    location: -1.25  1.75  0.25
+   is located on boundary: 0
    idx:     (1,7,4)
 With weight: -24
 pt[1]:    location: -1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (1,7,3)
 With weight: 4
 pt[2]:    location: -1.25  1.25  0.25
+   is located on boundary: 0
    idx:     (1,6,4)
 With weight: 4
 pt[3]:    location: -1.75  1.75  0.25
+   is located on boundary: 0
    idx:     (0,7,4)
 With weight: 4
 pt[4]:    location: -0.75  1.75  0.25
+   is located on boundary: 0
    idx:     (2,7,4)
 With weight: 4
 pt[5]:    location: -1.25  2.25  0.25
+   is located on boundary: 0
    idx:     (1,8,4)
 With weight: 4
 pt[6]:    location: -1.25  1.75  0.75
+   is located on boundary: 0
    idx:     (1,7,5)
 With weight: 4
 
 On point:    location: -0.75  1.75  0.25
+   is located on boundary: 0
    idx:     (2,7,4)
 pt[0]:    location: -0.75  1.75  0.25
+   is located on boundary: 0
    idx:     (2,7,4)
 With weight: -19.2941
 pt[1]:    location: -0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (2,7,3)
 With weight: 4
 pt[2]:    location: -1.25  1.75  0.25
+   is located on boundary: 0
    idx:     (1,7,4)
 With weight: 2.11765
 pt[3]:    location: -0.25  1.75  0.25
+   is located on boundary: 0
    idx:     (3,7,4)
 With weight: 4
 pt[4]:    location: -0.75  2.25  0.25
+   is located on boundary: 0
    idx:     (2,8,4)
 With weight: 3.29412
 pt[5]:    location: -0.75  1.75  0.75
+   is located on boundary: 0
    idx:     (2,7,5)
 With weight: 4
 pt[6]:    location: -1.25  1.25  0.25
+   is located on boundary: 0
    idx:     (1,6,4)
 With weight: 1.88235
 
 On point:    location: -0.25  1.75  0.25
+   is located on boundary: 0
    idx:     (3,7,4)
 pt[0]:    location: -0.25  1.75  0.25
+   is located on boundary: 0
    idx:     (3,7,4)
 With weight: -18.6667
 pt[1]:    location: -0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (3,7,3)
 With weight: 4
 pt[2]:    location: -0.75  1.75  0.25
+   is located on boundary: 0
    idx:     (2,7,4)
 With weight: 4
 pt[3]:    location: 0.25 1.75 0.25
+   is located on boundary: 0
    idx:     (4,7,4)
 With weight: 4
 pt[4]:    location: -0.25  2.25  0.25
+   is located on boundary: 0
    idx:     (3,8,4)
 With weight: 2.66667
 pt[5]:    location: -0.25  1.75  0.75
+   is located on boundary: 0
    idx:     (3,7,5)
 With weight: 4
 pt[6]:    location: -0.75  2.25  0.25
+   is located on boundary: 0
    idx:     (2,8,4)
-With weight: -4.81377e-16
+With weight: -5.87925e-16
 
 On point:    location: 0.25 1.75 0.25
+   is located on boundary: 0
    idx:     (4,7,4)
 pt[0]:    location: 0.25 1.75 0.25
+   is located on boundary: 0
    idx:     (4,7,4)
 With weight: -18.6667
 pt[1]:    location:  0.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (4,7,3)
 With weight: 4
 pt[2]:    location: -0.25  1.75  0.25
+   is located on boundary: 0
    idx:     (3,7,4)
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.25
+   is located on boundary: 0
    idx:     (5,7,4)
 With weight: 4
 pt[4]:    location: 0.25 2.25 0.25
+   is located on boundary: 0
    idx:     (4,8,4)
 With weight: 2.66667
 pt[5]:    location: 0.25 1.75 0.75
+   is located on boundary: 0
    idx:     (4,7,5)
 With weight: 4
 pt[6]:    location: 0.75 2.25 0.25
+   is located on boundary: 0
    idx:     (5,8,4)
-With weight: -1.28189e-15
+With weight: -7.31137e-16
 
 On point:    location: 0.75 1.75 0.25
+   is located on boundary: 0
    idx:     (5,7,4)
 pt[0]:    location: 0.75 1.75 0.25
+   is located on boundary: 0
    idx:     (5,7,4)
 With weight: -19.2941
 pt[1]:    location:  0.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (5,7,3)
 With weight: 4
 pt[2]:    location: 0.25 1.75 0.25
+   is located on boundary: 0
    idx:     (4,7,4)
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.25
+   is located on boundary: 0
    idx:     (6,7,4)
 With weight: 2.11765
 pt[4]:    location: 0.75 2.25 0.25
+   is located on boundary: 0
    idx:     (5,8,4)
 With weight: 3.29412
 pt[5]:    location: 0.75 1.75 0.75
+   is located on boundary: 0
    idx:     (5,7,5)
 With weight: 4
 pt[6]:    location: 1.25 1.25 0.25
+   is located on boundary: 0
    idx:     (6,6,4)
 With weight: 1.88235
 
 On point:    location: 1.25 1.75 0.25
+   is located on boundary: 0
    idx:     (6,7,4)
 pt[0]:    location: 1.25 1.75 0.25
+   is located on boundary: 0
    idx:     (6,7,4)
 With weight: -24
 pt[1]:    location:  1.25  1.75 -0.25
+   is located on boundary: 0
    idx:     (6,7,3)
 With weight: 4
 pt[2]:    location: 1.25 1.25 0.25
+   is located on boundary: 0
    idx:     (6,6,4)
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.25
+   is located on boundary: 0
    idx:     (5,7,4)
 With weight: 4
 pt[4]:    location: 1.75 1.75 0.25
+   is located on boundary: 0
    idx:     (7,7,4)
 With weight: 4
 pt[5]:    location: 1.25 2.25 0.25
+   is located on boundary: 0
    idx:     (6,8,4)
 With weight: 4
 pt[6]:    location: 1.25 1.75 0.75
+   is located on boundary: 0
    idx:     (6,7,5)
 With weight: 4
 
 On point:    location: 1.75 1.75 0.25
+   is located on boundary: 0
    idx:     (7,7,4)
 pt[0]:    location: 1.75 1.75 0.25
+   is located on boundary: 0
    idx:     (7,7,4)
 With weight: -24
 pt[1]:    location:  1.75  1.75 -0.25
+   is located on boundary: 0
    idx:     (7,7,3)
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.25
+   is located on boundary: 0
    idx:     (7,6,4)
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.25
+   is located on boundary: 0
    idx:     (6,7,4)
 With weight: 4
 pt[4]:    location: 2.25 1.75 0.25
+   is located on boundary: 0
    idx:     (8,7,4)
 With weight: 4
 pt[5]:    location: 1.75 2.25 0.25
+   is located on boundary: 0
    idx:     (7,8,4)
 With weight: 4
 pt[6]:    location: 1.75 1.75 0.75
+   is located on boundary: 0
    idx:     (7,7,5)
 With weight: 4
 
 On point:    location: -1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (0,0,5)
 pt[0]:    location: -1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (0,0,5)
 With weight: -24
 pt[1]:    location: -1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (0,0,4)
 With weight: 4
 pt[2]:    location: -1.75 -2.25  0.75
+   is located on boundary: 0
    idx:     (0,-1,5)
 With weight: 4
 pt[3]:    location: -2.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (-1,0,5)
 With weight: 4
 pt[4]:    location: -1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (1,0,5)
 With weight: 4
 pt[5]:    location: -1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (0,1,5)
 With weight: 4
 pt[6]:    location: -1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (0,0,6)
 With weight: 4
 
 On point:    location: -1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (1,0,5)
 pt[0]:    location: -1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (1,0,5)
 With weight: -24
 pt[1]:    location: -1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (1,0,4)
 With weight: 4
 pt[2]:    location: -1.25 -2.25  0.75
+   is located on boundary: 0
    idx:     (1,-1,5)
 With weight: 4
 pt[3]:    location: -1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (0,0,5)
 With weight: 4
 pt[4]:    location: -0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (2,0,5)
 With weight: 4
 pt[5]:    location: -1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (1,1,5)
 With weight: 4
 pt[6]:    location: -1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (1,0,6)
 With weight: 4
 
 On point:    location: -0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (2,0,5)
 pt[0]:    location: -0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (2,0,5)
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (2,0,4)
 With weight: 4
 pt[2]:    location: -0.75 -2.25  0.75
+   is located on boundary: 0
    idx:     (2,-1,5)
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (1,0,5)
 With weight: 4
 pt[4]:    location: -0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (3,0,5)
 With weight: 4
 pt[5]:    location: -0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (2,0,6)
 With weight: 4
 pt[6]:    location: -0.75 -2.25  0.25
+   is located on boundary: 0
    idx:     (2,-1,4)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location: -0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (3,0,5)
 pt[0]:    location: -0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (3,0,5)
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (3,0,4)
 With weight: 4
 pt[2]:    location: -0.25 -2.25  0.75
+   is located on boundary: 0
    idx:     (3,-1,5)
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (2,0,5)
 With weight: 4
 pt[4]:    location:  0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (4,0,5)
 With weight: 4
 pt[5]:    location: -0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (3,0,6)
 With weight: 4
 pt[6]:    location: -0.25 -2.25  0.25
+   is located on boundary: 0
    idx:     (3,-1,4)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location:  0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (4,0,5)
 pt[0]:    location:  0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (4,0,5)
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (4,0,4)
 With weight: 4
 pt[2]:    location:  0.25 -2.25  0.75
+   is located on boundary: 0
    idx:     (4,-1,5)
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (3,0,5)
 With weight: 4
 pt[4]:    location:  0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (5,0,5)
 With weight: 4
 pt[5]:    location:  0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (4,0,6)
 With weight: 4
 pt[6]:    location:  0.25 -2.25  0.25
+   is located on boundary: 0
    idx:     (4,-1,4)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location:  0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (5,0,5)
 pt[0]:    location:  0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (5,0,5)
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (5,0,4)
 With weight: 4
 pt[2]:    location:  0.75 -2.25  0.75
+   is located on boundary: 0
    idx:     (5,-1,5)
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (4,0,5)
 With weight: 4
 pt[4]:    location:  1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (6,0,5)
 With weight: 4
 pt[5]:    location:  0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (5,0,6)
 With weight: 4
 pt[6]:    location:  0.75 -2.25  0.25
+   is located on boundary: 0
    idx:     (5,-1,4)
-With weight: 6.25612e-16
+With weight: 1.05525e-15
 
 On point:    location:  1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (6,0,5)
 pt[0]:    location:  1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (6,0,5)
 With weight: -24
 pt[1]:    location:  1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (6,0,4)
 With weight: 4
 pt[2]:    location:  1.25 -2.25  0.75
+   is located on boundary: 0
    idx:     (6,-1,5)
 With weight: 4
 pt[3]:    location:  0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (5,0,5)
 With weight: 4
 pt[4]:    location:  1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (7,0,5)
 With weight: 4
 pt[5]:    location:  1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (6,1,5)
 With weight: 4
 pt[6]:    location:  1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (6,0,6)
 With weight: 4
 
 On point:    location:  1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (7,0,5)
 pt[0]:    location:  1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (7,0,5)
 With weight: -24
 pt[1]:    location:  1.75 -1.75  0.25
+   is located on boundary: 0
    idx:     (7,0,4)
 With weight: 4
 pt[2]:    location:  1.75 -2.25  0.75
+   is located on boundary: 0
    idx:     (7,-1,5)
 With weight: 4
 pt[3]:    location:  1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (6,0,5)
 With weight: 4
 pt[4]:    location:  2.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (8,0,5)
 With weight: 4
 pt[5]:    location:  1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (7,1,5)
 With weight: 4
 pt[6]:    location:  1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (7,0,6)
 With weight: 4
 
 On point:    location: -1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (0,1,5)
 pt[0]:    location: -1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (0,1,5)
 With weight: -24
 pt[1]:    location: -1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (0,1,4)
 With weight: 4
 pt[2]:    location: -1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (0,0,5)
 With weight: 4
 pt[3]:    location: -2.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (-1,1,5)
 With weight: 4
 pt[4]:    location: -1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (1,1,5)
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (0,2,5)
 With weight: 4
 pt[6]:    location: -1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (0,1,6)
 With weight: 4
 
 On point:    location: -1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (1,1,5)
 pt[0]:    location: -1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (1,1,5)
 With weight: -13.3333
 pt[1]:    location: -1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (1,1,4)
 With weight: 4
 pt[2]:    location: -1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (1,0,5)
 With weight: 2.66667
 pt[3]:    location: -1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (0,1,5)
 With weight: 2.66667
 pt[4]:    location: -1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (1,1,6)
 With weight: 4
 pt[5]:    location: -1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (0,1,4)
-With weight: -1.60785e-15
+With weight: -1.19224e-15
 pt[6]:    location: -1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (0,0,5)
-With weight: 9.01758e-16
+With weight: 1.05205e-15
 
 On point:    location:  1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (6,1,5)
 pt[0]:    location:  1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (6,1,5)
 With weight: -13.9608
 pt[1]:    location:  1.25 -1.25  0.25
+   is located on boundary: 0
    idx:     (6,1,4)
 With weight: 4
 pt[2]:    location:  1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (6,0,5)
 With weight: 0.784314
 pt[3]:    location:  1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (7,1,5)
 With weight: 3.29412
 pt[4]:    location:  1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (6,1,6)
 With weight: 4
 pt[5]:    location:  1.25 -1.75  0.25
+   is located on boundary: 0
    idx:     (6,0,4)
-With weight: -8.18123e-16
+With weight: -6.71904e-17
 pt[6]:    location:  0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (5,0,5)
 With weight: 1.88235
 
 On point:    location:  1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (7,1,5)
 pt[0]:    location:  1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (7,1,5)
 With weight: -24
 pt[1]:    location:  1.75 -1.25  0.25
+   is located on boundary: 0
    idx:     (7,1,4)
 With weight: 4
 pt[2]:    location:  1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (7,0,5)
 With weight: 4
 pt[3]:    location:  1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (6,1,5)
 With weight: 4
 pt[4]:    location:  2.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (8,1,5)
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (7,2,5)
 With weight: 4
 pt[6]:    location:  1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (7,1,6)
 With weight: 4
 
 On point:    location: -1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (0,2,5)
 pt[0]:    location: -1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (0,2,5)
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (0,2,4)
 With weight: 4
 pt[2]:    location: -1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (0,1,5)
 With weight: 4
 pt[3]:    location: -2.25 -0.75  0.75
+   is located on boundary: 0
    idx:     (-1,2,5)
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (0,3,5)
 With weight: 4
 pt[5]:    location: -1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (0,2,6)
 With weight: 4
 pt[6]:    location: -2.25 -0.75  0.25
+   is located on boundary: 0
    idx:     (-1,2,4)
-With weight: 3.4021e-16
+With weight: 1.13062e-15
 
 On point:    location:  1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (7,2,5)
 pt[0]:    location:  1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (7,2,5)
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (7,2,4)
 With weight: 4
 pt[2]:    location:  1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (7,1,5)
 With weight: 4
 pt[3]:    location:  2.25 -0.75  0.75
+   is located on boundary: 0
    idx:     (8,2,5)
 With weight: 2.66667
 pt[4]:    location:  1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (7,3,5)
 With weight: 4
 pt[5]:    location:  1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (7,2,6)
 With weight: 4
 pt[6]:    location:  1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (7,3,4)
-With weight: 4.15271e-16
+With weight: 2.60649e-16
 
 On point:    location: -1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (0,3,5)
 pt[0]:    location: -1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (0,3,5)
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (0,3,4)
 With weight: 4
 pt[2]:    location: -1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (0,2,5)
 With weight: 4
 pt[3]:    location: -2.25 -0.25  0.75
+   is located on boundary: 0
    idx:     (-1,3,5)
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25  0.75
+   is located on boundary: 0
    idx:     (0,4,5)
 With weight: 4
 pt[5]:    location: -1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (0,3,6)
 With weight: 4
 pt[6]:    location: -1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (0,2,4)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location:  1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (7,3,5)
 pt[0]:    location:  1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (7,3,5)
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25  0.25
+   is located on boundary: 0
    idx:     (7,3,4)
 With weight: 4
 pt[2]:    location:  1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (7,2,5)
 With weight: 4
 pt[3]:    location:  2.25 -0.25  0.75
+   is located on boundary: 0
    idx:     (8,3,5)
 With weight: 2.66667
 pt[4]:    location: 1.75 0.25 0.75
+   is located on boundary: 0
    idx:     (7,4,5)
 With weight: 4
 pt[5]:    location:  1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (7,3,6)
 With weight: 4
 pt[6]:    location:  1.75 -0.75  0.25
+   is located on boundary: 0
    idx:     (7,2,4)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location: -1.75  0.25  0.75
+   is located on boundary: 0
    idx:     (0,4,5)
 pt[0]:    location: -1.75  0.25  0.75
+   is located on boundary: 0
    idx:     (0,4,5)
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25  0.25
+   is located on boundary: 0
    idx:     (0,4,4)
 With weight: 4
 pt[2]:    location: -1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (0,3,5)
 With weight: 4
 pt[3]:    location: -2.25  0.25  0.75
+   is located on boundary: 0
    idx:     (-1,4,5)
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75  0.75
+   is located on boundary: 0
    idx:     (0,5,5)
 With weight: 4
 pt[5]:    location: -1.75  0.25  1.25
+   is located on boundary: 0
    idx:     (0,4,6)
 With weight: 4
 pt[6]:    location: -2.25  0.25  0.25
+   is located on boundary: 0
    idx:     (-1,4,4)
-With weight: 3.4021e-16
+With weight: 1.13062e-15
 
 On point:    location: 1.75 0.25 0.75
+   is located on boundary: 0
    idx:     (7,4,5)
 pt[0]:    location: 1.75 0.25 0.75
+   is located on boundary: 0
    idx:     (7,4,5)
 With weight: -18.6667
 pt[1]:    location: 1.75 0.25 0.25
+   is located on boundary: 0
    idx:     (7,4,4)
 With weight: 4
 pt[2]:    location:  1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (7,3,5)
 With weight: 4
 pt[3]:    location: 2.25 0.25 0.75
+   is located on boundary: 0
    idx:     (8,4,5)
 With weight: 2.66667
 pt[4]:    location: 1.75 0.75 0.75
+   is located on boundary: 0
    idx:     (7,5,5)
 With weight: 4
 pt[5]:    location: 1.75 0.25 1.25
+   is located on boundary: 0
    idx:     (7,4,6)
 With weight: 4
 pt[6]:    location: 1.75 0.75 0.25
+   is located on boundary: 0
    idx:     (7,5,4)
-With weight: 4.15271e-16
+With weight: 2.60649e-16
 
 On point:    location: -1.75  0.75  0.75
+   is located on boundary: 0
    idx:     (0,5,5)
 pt[0]:    location: -1.75  0.75  0.75
+   is located on boundary: 0
    idx:     (0,5,5)
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75  0.25
+   is located on boundary: 0
    idx:     (0,5,4)
 With weight: 4
 pt[2]:    location: -1.75  0.25  0.75
+   is located on boundary: 0
    idx:     (0,4,5)
 With weight: 4
 pt[3]:    location: -2.25  0.75  0.75
+   is located on boundary: 0
    idx:     (-1,5,5)
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25  0.75
+   is located on boundary: 0
    idx:     (0,6,5)
 With weight: 4
 pt[5]:    location: -1.75  0.75  1.25
+   is located on boundary: 0
    idx:     (0,5,6)
 With weight: 4
 pt[6]:    location: -1.75  0.25  0.25
+   is located on boundary: 0
    idx:     (0,4,4)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location: 1.75 0.75 0.75
+   is located on boundary: 0
    idx:     (7,5,5)
 pt[0]:    location: 1.75 0.75 0.75
+   is located on boundary: 0
    idx:     (7,5,5)
 With weight: -18.6667
 pt[1]:    location: 1.75 0.75 0.25
+   is located on boundary: 0
    idx:     (7,5,4)
 With weight: 4
 pt[2]:    location: 1.75 0.25 0.75
+   is located on boundary: 0
    idx:     (7,4,5)
 With weight: 4
 pt[3]:    location: 2.25 0.75 0.75
+   is located on boundary: 0
    idx:     (8,5,5)
 With weight: 2.66667
 pt[4]:    location: 1.75 1.25 0.75
+   is located on boundary: 0
    idx:     (7,6,5)
 With weight: 4
 pt[5]:    location: 1.75 0.75 1.25
+   is located on boundary: 0
    idx:     (7,5,6)
 With weight: 4
 pt[6]:    location: 1.75 0.25 0.25
+   is located on boundary: 0
    idx:     (7,4,4)
-With weight: 1.52088e-15
+With weight: -7.27074e-16
 
 On point:    location: -1.75  1.25  0.75
+   is located on boundary: 0
    idx:     (0,6,5)
 pt[0]:    location: -1.75  1.25  0.75
+   is located on boundary: 0
    idx:     (0,6,5)
 With weight: -24
 pt[1]:    location: -1.75  1.25  0.25
+   is located on boundary: 0
    idx:     (0,6,4)
 With weight: 4
 pt[2]:    location: -1.75  0.75  0.75
+   is located on boundary: 0
    idx:     (0,5,5)
 With weight: 4
 pt[3]:    location: -2.25  1.25  0.75
+   is located on boundary: 0
    idx:     (-1,6,5)
 With weight: 4
 pt[4]:    location: -1.25  1.25  0.75
+   is located on boundary: 0
    idx:     (1,6,5)
 With weight: 4
 pt[5]:    location: -1.75  1.75  0.75
+   is located on boundary: 0
    idx:     (0,7,5)
 With weight: 4
 pt[6]:    location: -1.75  1.25  1.25
+   is located on boundary: 0
    idx:     (0,6,6)
 With weight: 4
 
 On point:    location: -1.25  1.25  0.75
+   is located on boundary: 0
    idx:     (1,6,5)
 pt[0]:    location: -1.25  1.25  0.75
+   is located on boundary: 0
    idx:     (1,6,5)
 With weight: -13.3333
 pt[1]:    location: -1.25  1.25  0.25
+   is located on boundary: 0
    idx:     (1,6,4)
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.75
+   is located on boundary: 0
    idx:     (0,6,5)
 With weight: 2.66667
 pt[3]:    location: -1.25  1.75  0.75
+   is located on boundary: 0
    idx:     (1,7,5)
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25  1.25
+   is located on boundary: 0
    idx:     (1,6,6)
 With weight: 4
 pt[5]:    location: -1.75  1.25  0.25
+   is located on boundary: 0
    idx:     (0,6,4)
-With weight: -2.31114e-16
+With weight: 3.03817e-17
 pt[6]:    location: -1.25  1.75  0.25
+   is located on boundary: 0
    idx:     (1,7,4)
-With weight: -1.5531e-15
+With weight: -3.14198e-16
 
 On point:    location: 1.25 1.25 0.75
+   is located on boundary: 0
    idx:     (6,6,5)
 pt[0]:    location: 1.25 1.25 0.75
+   is located on boundary: 0
    idx:     (6,6,5)
 With weight: -13.9608
 pt[1]:    location: 1.25 1.25 0.25
+   is located on boundary: 0
    idx:     (6,6,4)
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.75
+   is located on boundary: 0
    idx:     (7,6,5)
 With weight: 3.29412
 pt[3]:    location: 1.25 1.75 0.75
+   is located on boundary: 0
    idx:     (6,7,5)
 With weight: 0.784314
 pt[4]:    location: 1.25 1.25 1.25
+   is located on boundary: 0
    idx:     (6,6,6)
 With weight: 4
 pt[5]:    location: 1.25 1.75 0.25
+   is located on boundary: 0
    idx:     (6,7,4)
-With weight: 1.73895e-16
+With weight: 2.01571e-16
 pt[6]:    location: 0.75 1.75 0.75
+   is located on boundary: 0
    idx:     (5,7,5)
 With weight: 1.88235
 
 On point:    location: 1.75 1.25 0.75
+   is located on boundary: 0
    idx:     (7,6,5)
 pt[0]:    location: 1.75 1.25 0.75
+   is located on boundary: 0
    idx:     (7,6,5)
 With weight: -24
 pt[1]:    location: 1.75 1.25 0.25
+   is located on boundary: 0
    idx:     (7,6,4)
 With weight: 4
 pt[2]:    location: 1.75 0.75 0.75
+   is located on boundary: 0
    idx:     (7,5,5)
 With weight: 4
 pt[3]:    location: 1.25 1.25 0.75
+   is located on boundary: 0
    idx:     (6,6,5)
 With weight: 4
 pt[4]:    location: 2.25 1.25 0.75
+   is located on boundary: 0
    idx:     (8,6,5)
 With weight: 4
 pt[5]:    location: 1.75 1.75 0.75
+   is located on boundary: 0
    idx:     (7,7,5)
 With weight: 4
 pt[6]:    location: 1.75 1.25 1.25
+   is located on boundary: 0
    idx:     (7,6,6)
 With weight: 4
 
 On point:    location: -1.75  1.75  0.75
+   is located on boundary: 0
    idx:     (0,7,5)
 pt[0]:    location: -1.75  1.75  0.75
+   is located on boundary: 0
    idx:     (0,7,5)
 With weight: -24
 pt[1]:    location: -1.75  1.75  0.25
+   is located on boundary: 0
    idx:     (0,7,4)
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.75
+   is located on boundary: 0
    idx:     (0,6,5)
 With weight: 4
 pt[3]:    location: -2.25  1.75  0.75
+   is located on boundary: 0
    idx:     (-1,7,5)
 With weight: 4
 pt[4]:    location: -1.25  1.75  0.75
+   is located on boundary: 0
    idx:     (1,7,5)
 With weight: 4
 pt[5]:    location: -1.75  2.25  0.75
+   is located on boundary: 0
    idx:     (0,8,5)
 With weight: 4
 pt[6]:    location: -1.75  1.75  1.25
+   is located on boundary: 0
    idx:     (0,7,6)
 With weight: 4
 
 On point:    location: -1.25  1.75  0.75
+   is located on boundary: 0
    idx:     (1,7,5)
 pt[0]:    location: -1.25  1.75  0.75
+   is located on boundary: 0
    idx:     (1,7,5)
 With weight: -24
 pt[1]:    location: -1.25  1.75  0.25
+   is located on boundary: 0
    idx:     (1,7,4)
 With weight: 4
 pt[2]:    location: -1.25  1.25  0.75
+   is located on boundary: 0
    idx:     (1,6,5)
 With weight: 4
 pt[3]:    location: -1.75  1.75  0.75
+   is located on boundary: 0
    idx:     (0,7,5)
 With weight: 4
 pt[4]:    location: -0.75  1.75  0.75
+   is located on boundary: 0
    idx:     (2,7,5)
 With weight: 4
 pt[5]:    location: -1.25  2.25  0.75
+   is located on boundary: 0
    idx:     (1,8,5)
 With weight: 4
 pt[6]:    location: -1.25  1.75  1.25
+   is located on boundary: 0
    idx:     (1,7,6)
 With weight: 4
 
 On point:    location: -0.75  1.75  0.75
+   is located on boundary: 0
    idx:     (2,7,5)
 pt[0]:    location: -0.75  1.75  0.75
+   is located on boundary: 0
    idx:     (2,7,5)
 With weight: -18.6667
 pt[1]:    location: -0.75  1.75  0.25
+   is located on boundary: 0
    idx:     (2,7,4)
 With weight: 4
 pt[2]:    location: -1.25  1.75  0.75
+   is located on boundary: 0
    idx:     (1,7,5)
 With weight: 4
 pt[3]:    location: -0.25  1.75  0.75
+   is located on boundary: 0
    idx:     (3,7,5)
 With weight: 4
 pt[4]:    location: -0.75  2.25  0.75
+   is located on boundary: 0
    idx:     (2,8,5)
 With weight: 2.66667
 pt[5]:    location: -0.75  1.75  1.25
+   is located on boundary: 0
    idx:     (2,7,6)
 With weight: 4
 pt[6]:    location: -0.25  1.75  0.25
+   is located on boundary: 0
    idx:     (3,7,4)
-With weight: 1.00144e-15
+With weight: 1.09747e-15
 
 On point:    location: -0.25  1.75  0.75
+   is located on boundary: 0
    idx:     (3,7,5)
 pt[0]:    location: -0.25  1.75  0.75
+   is located on boundary: 0
    idx:     (3,7,5)
 With weight: -18.6667
 pt[1]:    location: -0.25  1.75  0.25
+   is located on boundary: 0
    idx:     (3,7,4)
 With weight: 4
 pt[2]:    location: -0.75  1.75  0.75
+   is located on boundary: 0
    idx:     (2,7,5)
 With weight: 4
 pt[3]:    location: 0.25 1.75 0.75
+   is located on boundary: 0
    idx:     (4,7,5)
 With weight: 4
 pt[4]:    location: -0.25  2.25  0.75
+   is located on boundary: 0
    idx:     (3,8,5)
 With weight: 2.66667
 pt[5]:    location: -0.25  1.75  1.25
+   is located on boundary: 0
    idx:     (3,7,6)
 With weight: 4
 pt[6]:    location: -0.75  1.75  0.25
+   is located on boundary: 0
    idx:     (2,7,4)
-With weight: 8.54259e-16
+With weight: 8.23102e-16
 
 On point:    location: 0.25 1.75 0.75
+   is located on boundary: 0
    idx:     (4,7,5)
 pt[0]:    location: 0.25 1.75 0.75
+   is located on boundary: 0
    idx:     (4,7,5)
 With weight: -18.6667
 pt[1]:    location: 0.25 1.75 0.25
+   is located on boundary: 0
    idx:     (4,7,4)
 With weight: 4
 pt[2]:    location: -0.25  1.75  0.75
+   is located on boundary: 0
    idx:     (3,7,5)
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.75
+   is located on boundary: 0
    idx:     (5,7,5)
 With weight: 4
 pt[4]:    location: 0.25 2.25 0.75
+   is located on boundary: 0
    idx:     (4,8,5)
 With weight: 2.66667
 pt[5]:    location: 0.25 1.75 1.25
+   is located on boundary: 0
    idx:     (4,7,6)
 With weight: 4
 pt[6]:    location: 0.75 1.75 0.25
+   is located on boundary: 0
    idx:     (5,7,4)
-With weight: 1.00144e-15
+With weight: 1.09747e-15
 
 On point:    location: 0.75 1.75 0.75
+   is located on boundary: 0
    idx:     (5,7,5)
 pt[0]:    location: 0.75 1.75 0.75
+   is located on boundary: 0
    idx:     (5,7,5)
 With weight: -18.6667
 pt[1]:    location: 0.75 1.75 0.25
+   is located on boundary: 0
    idx:     (5,7,4)
 With weight: 4
 pt[2]:    location: 0.25 1.75 0.75
+   is located on boundary: 0
    idx:     (4,7,5)
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.75
+   is located on boundary: 0
    idx:     (6,7,5)
 With weight: 4
 pt[4]:    location: 0.75 2.25 0.75
+   is located on boundary: 0
    idx:     (5,8,5)
 With weight: 2.66667
 pt[5]:    location: 0.75 1.75 1.25
+   is located on boundary: 0
    idx:     (5,7,6)
 With weight: 4
 pt[6]:    location: 0.25 1.75 0.25
+   is located on boundary: 0
    idx:     (4,7,4)
-With weight: 8.54259e-16
+With weight: 8.23102e-16
 
 On point:    location: 1.25 1.75 0.75
+   is located on boundary: 0
    idx:     (6,7,5)
 pt[0]:    location: 1.25 1.75 0.75
+   is located on boundary: 0
    idx:     (6,7,5)
 With weight: -24
 pt[1]:    location: 1.25 1.75 0.25
+   is located on boundary: 0
    idx:     (6,7,4)
 With weight: 4
 pt[2]:    location: 1.25 1.25 0.75
+   is located on boundary: 0
    idx:     (6,6,5)
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.75
+   is located on boundary: 0
    idx:     (5,7,5)
 With weight: 4
 pt[4]:    location: 1.75 1.75 0.75
+   is located on boundary: 0
    idx:     (7,7,5)
 With weight: 4
 pt[5]:    location: 1.25 2.25 0.75
+   is located on boundary: 0
    idx:     (6,8,5)
 With weight: 4
 pt[6]:    location: 1.25 1.75 1.25
+   is located on boundary: 0
    idx:     (6,7,6)
 With weight: 4
 
 On point:    location: 1.75 1.75 0.75
+   is located on boundary: 0
    idx:     (7,7,5)
 pt[0]:    location: 1.75 1.75 0.75
+   is located on boundary: 0
    idx:     (7,7,5)
 With weight: -24
 pt[1]:    location: 1.75 1.75 0.25
+   is located on boundary: 0
    idx:     (7,7,4)
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.75
+   is located on boundary: 0
    idx:     (7,6,5)
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.75
+   is located on boundary: 0
    idx:     (6,7,5)
 With weight: 4
 pt[4]:    location: 2.25 1.75 0.75
+   is located on boundary: 0
    idx:     (8,7,5)
 With weight: 4
 pt[5]:    location: 1.75 2.25 0.75
+   is located on boundary: 0
    idx:     (7,8,5)
 With weight: 4
 pt[6]:    location: 1.75 1.75 1.25
+   is located on boundary: 0
    idx:     (7,7,6)
 With weight: 4
 
 On point:    location: -1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (0,0,6)
 pt[0]:    location: -1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (0,0,6)
 With weight: -24
 pt[1]:    location: -1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (0,0,5)
 With weight: 4
 pt[2]:    location: -1.75 -2.25  1.25
+   is located on boundary: 0
    idx:     (0,-1,6)
 With weight: 4
 pt[3]:    location: -2.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (-1,0,6)
 With weight: 4
 pt[4]:    location: -1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (1,0,6)
 With weight: 4
 pt[5]:    location: -1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (0,1,6)
 With weight: 4
 pt[6]:    location: -1.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (0,0,7)
 With weight: 4
 
 On point:    location: -1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (1,0,6)
 pt[0]:    location: -1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (1,0,6)
 With weight: -24
 pt[1]:    location: -1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (1,0,5)
 With weight: 4
 pt[2]:    location: -1.25 -2.25  1.25
+   is located on boundary: 0
    idx:     (1,-1,6)
 With weight: 4
 pt[3]:    location: -1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (0,0,6)
 With weight: 4
 pt[4]:    location: -0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (2,0,6)
 With weight: 4
 pt[5]:    location: -1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (1,1,6)
 With weight: 4
 pt[6]:    location: -1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (1,0,7)
 With weight: 4
 
 On point:    location: -0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (2,0,6)
 pt[0]:    location: -0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (2,0,6)
 With weight: -24
 pt[1]:    location: -0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (2,0,5)
 With weight: 4
 pt[2]:    location: -0.75 -2.25  1.25
+   is located on boundary: 0
    idx:     (2,-1,6)
 With weight: 4
 pt[3]:    location: -1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (1,0,6)
 With weight: 4
 pt[4]:    location: -0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (3,0,6)
 With weight: 4
 pt[5]:    location: -0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (2,1,6)
 With weight: 4
 pt[6]:    location: -0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (2,0,7)
 With weight: 4
 
 On point:    location: -0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (3,0,6)
 pt[0]:    location: -0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (3,0,6)
 With weight: -24
 pt[1]:    location: -0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (3,0,5)
 With weight: 4
 pt[2]:    location: -0.25 -2.25  1.25
+   is located on boundary: 0
    idx:     (3,-1,6)
 With weight: 4
 pt[3]:    location: -0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (2,0,6)
 With weight: 4
 pt[4]:    location:  0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (4,0,6)
 With weight: 4
 pt[5]:    location: -0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (3,1,6)
 With weight: 4
 pt[6]:    location: -0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (3,0,7)
 With weight: 4
 
 On point:    location:  0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (4,0,6)
 pt[0]:    location:  0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (4,0,6)
 With weight: -24
 pt[1]:    location:  0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (4,0,5)
 With weight: 4
 pt[2]:    location:  0.25 -2.25  1.25
+   is located on boundary: 0
    idx:     (4,-1,6)
 With weight: 4
 pt[3]:    location: -0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (3,0,6)
 With weight: 4
 pt[4]:    location:  0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (5,0,6)
 With weight: 4
 pt[5]:    location:  0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (4,1,6)
 With weight: 4
 pt[6]:    location:  0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (4,0,7)
 With weight: 4
 
 On point:    location:  0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (5,0,6)
 pt[0]:    location:  0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (5,0,6)
 With weight: -24
 pt[1]:    location:  0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (5,0,5)
 With weight: 4
 pt[2]:    location:  0.75 -2.25  1.25
+   is located on boundary: 0
    idx:     (5,-1,6)
 With weight: 4
 pt[3]:    location:  0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (4,0,6)
 With weight: 4
 pt[4]:    location:  1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (6,0,6)
 With weight: 4
 pt[5]:    location:  0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (5,1,6)
 With weight: 4
 pt[6]:    location:  0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (5,0,7)
 With weight: 4
 
 On point:    location:  1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (6,0,6)
 pt[0]:    location:  1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (6,0,6)
 With weight: -24
 pt[1]:    location:  1.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (6,0,5)
 With weight: 4
 pt[2]:    location:  1.25 -2.25  1.25
+   is located on boundary: 0
    idx:     (6,-1,6)
 With weight: 4
 pt[3]:    location:  0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (5,0,6)
 With weight: 4
 pt[4]:    location:  1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (7,0,6)
 With weight: 4
 pt[5]:    location:  1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (6,1,6)
 With weight: 4
 pt[6]:    location:  1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (6,0,7)
 With weight: 4
 
 On point:    location:  1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (7,0,6)
 pt[0]:    location:  1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (7,0,6)
 With weight: -24
 pt[1]:    location:  1.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (7,0,5)
 With weight: 4
 pt[2]:    location:  1.75 -2.25  1.25
+   is located on boundary: 0
    idx:     (7,-1,6)
 With weight: 4
 pt[3]:    location:  1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (6,0,6)
 With weight: 4
 pt[4]:    location:  2.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (8,0,6)
 With weight: 4
 pt[5]:    location:  1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (7,1,6)
 With weight: 4
 pt[6]:    location:  1.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (7,0,7)
 With weight: 4
 
 On point:    location: -1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (0,1,6)
 pt[0]:    location: -1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (0,1,6)
 With weight: -24
 pt[1]:    location: -1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (0,1,5)
 With weight: 4
 pt[2]:    location: -1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (0,0,6)
 With weight: 4
 pt[3]:    location: -2.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (-1,1,6)
 With weight: 4
 pt[4]:    location: -1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (1,1,6)
 With weight: 4
 pt[5]:    location: -1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (0,2,6)
 With weight: 4
 pt[6]:    location: -1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (0,1,7)
 With weight: 4
 
 On point:    location: -1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (1,1,6)
 pt[0]:    location: -1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (1,1,6)
 With weight: -24
 pt[1]:    location: -1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (1,1,5)
 With weight: 4
 pt[2]:    location: -1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (1,0,6)
 With weight: 4
 pt[3]:    location: -1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (0,1,6)
 With weight: 4
 pt[4]:    location: -0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (2,1,6)
 With weight: 4
 pt[5]:    location: -1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (1,2,6)
 With weight: 4
 pt[6]:    location: -1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (1,1,7)
 With weight: 4
 
 On point:    location: -0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (2,1,6)
 pt[0]:    location: -0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (2,1,6)
 With weight: -13.9608
 pt[1]:    location: -0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (2,0,6)
 With weight: 0.784314
 pt[2]:    location: -1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (1,1,6)
 With weight: 4
 pt[3]:    location: -0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (3,1,6)
 With weight: 4
 pt[4]:    location: -0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (2,1,7)
 With weight: 3.29412
 pt[5]:    location: -0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (2,0,5)
 With weight: 1.88235
 pt[6]:    location: -0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (3,0,6)
-With weight: 2.56923e-16
+With weight: 6.38308e-16
 
 On point:    location: -0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (3,1,6)
 pt[0]:    location: -0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (3,1,6)
 With weight: -13.9608
 pt[1]:    location: -0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (3,0,6)
 With weight: 0.784314
 pt[2]:    location: -0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (2,1,6)
 With weight: 4
 pt[3]:    location:  0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (4,1,6)
 With weight: 4
 pt[4]:    location: -0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (3,1,7)
 With weight: 3.29412
 pt[5]:    location: -0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (3,0,5)
 With weight: 1.88235
 pt[6]:    location: -0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (2,0,6)
-With weight: -1.01969e-15
+With weight: -7.72689e-16
 
 On point:    location:  0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (4,1,6)
 pt[0]:    location:  0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (4,1,6)
 With weight: -13.9608
 pt[1]:    location:  0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (4,0,6)
 With weight: 0.784314
 pt[2]:    location: -0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (3,1,6)
 With weight: 4
 pt[3]:    location:  0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (5,1,6)
 With weight: 4
 pt[4]:    location:  0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (4,1,7)
 With weight: 3.29412
 pt[5]:    location:  0.25 -1.75  0.75
+   is located on boundary: 0
    idx:     (4,0,5)
 With weight: 1.88235
 pt[6]:    location:  0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (5,0,6)
-With weight: 2.56923e-16
+With weight: 6.38308e-16
 
 On point:    location:  0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (5,1,6)
 pt[0]:    location:  0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (5,1,6)
 With weight: -14.1867
 pt[1]:    location:  0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (5,0,6)
 With weight: 1.38667
 pt[2]:    location:  0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (4,1,6)
 With weight: 4
 pt[3]:    location:  1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (6,1,6)
 With weight: 2.72
 pt[4]:    location:  0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (5,1,7)
 With weight: 3.52
 pt[5]:    location:  0.75 -1.75  0.75
+   is located on boundary: 0
    idx:     (5,0,5)
 With weight: 1.28
 pt[6]:    location:  1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (6,1,5)
 With weight: 1.28
 
 On point:    location:  1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (6,1,6)
 pt[0]:    location:  1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (6,1,6)
 With weight: -24
 pt[1]:    location:  1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (6,1,5)
 With weight: 4
 pt[2]:    location:  1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (6,0,6)
 With weight: 4
 pt[3]:    location:  0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (5,1,6)
 With weight: 4
 pt[4]:    location:  1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (7,1,6)
 With weight: 4
 pt[5]:    location:  1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (6,2,6)
 With weight: 4
 pt[6]:    location:  1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (6,1,7)
 With weight: 4
 
 On point:    location:  1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (7,1,6)
 pt[0]:    location:  1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (7,1,6)
 With weight: -24
 pt[1]:    location:  1.75 -1.25  0.75
+   is located on boundary: 0
    idx:     (7,1,5)
 With weight: 4
 pt[2]:    location:  1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (7,0,6)
 With weight: 4
 pt[3]:    location:  1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (6,1,6)
 With weight: 4
 pt[4]:    location:  2.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (8,1,6)
 With weight: 4
 pt[5]:    location:  1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (7,2,6)
 With weight: 4
 pt[6]:    location:  1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (7,1,7)
 With weight: 4
 
 On point:    location: -1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (0,2,6)
 pt[0]:    location: -1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (0,2,6)
 With weight: -24
 pt[1]:    location: -1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (0,2,5)
 With weight: 4
 pt[2]:    location: -1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (0,1,6)
 With weight: 4
 pt[3]:    location: -2.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (-1,2,6)
 With weight: 4
 pt[4]:    location: -1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (1,2,6)
 With weight: 4
 pt[5]:    location: -1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (0,3,6)
 With weight: 4
 pt[6]:    location: -1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (0,2,7)
 With weight: 4
 
 On point:    location: -1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (1,2,6)
 pt[0]:    location: -1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (1,2,6)
 With weight: -13.9608
 pt[1]:    location: -1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (1,1,6)
 With weight: 4
 pt[2]:    location: -1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (0,2,6)
 With weight: 0.784314
 pt[3]:    location: -1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (1,3,6)
 With weight: 4
 pt[4]:    location: -1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (1,2,7)
 With weight: 3.29412
 pt[5]:    location: -1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (0,2,5)
 With weight: 1.88235
 pt[6]:    location: -1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (0,3,6)
-With weight: 5.53518e-17
+With weight: 4.70333e-16
 
 On point:    location:  1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (6,2,6)
 pt[0]:    location:  1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (6,2,6)
 With weight: -14.1867
 pt[1]:    location:  1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (6,1,6)
 With weight: 2.72
 pt[2]:    location:  1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (7,2,6)
 With weight: 1.38667
 pt[3]:    location:  1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (6,3,6)
 With weight: 4
 pt[4]:    location:  1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (6,2,7)
 With weight: 3.52
 pt[5]:    location:  1.25 -1.25  0.75
+   is located on boundary: 0
    idx:     (6,1,5)
 With weight: 1.28
 pt[6]:    location:  1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (7,2,5)
 With weight: 1.28
 
 On point:    location:  1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (7,2,6)
 pt[0]:    location:  1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (7,2,6)
 With weight: -24
 pt[1]:    location:  1.75 -0.75  0.75
+   is located on boundary: 0
    idx:     (7,2,5)
 With weight: 4
 pt[2]:    location:  1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (7,1,6)
 With weight: 4
 pt[3]:    location:  1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (6,2,6)
 With weight: 4
 pt[4]:    location:  2.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (8,2,6)
 With weight: 4
 pt[5]:    location:  1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (7,3,6)
 With weight: 4
 pt[6]:    location:  1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (7,2,7)
 With weight: 4
 
 On point:    location: -1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (0,3,6)
 pt[0]:    location: -1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (0,3,6)
 With weight: -24
 pt[1]:    location: -1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (0,3,5)
 With weight: 4
 pt[2]:    location: -1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (0,2,6)
 With weight: 4
 pt[3]:    location: -2.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (-1,3,6)
 With weight: 4
 pt[4]:    location: -1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (1,3,6)
 With weight: 4
 pt[5]:    location: -1.75  0.25  1.25
+   is located on boundary: 0
    idx:     (0,4,6)
 With weight: 4
 pt[6]:    location: -1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (0,3,7)
 With weight: 4
 
 On point:    location: -1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (1,3,6)
 pt[0]:    location: -1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (1,3,6)
 With weight: -13.9608
 pt[1]:    location: -1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (1,2,6)
 With weight: 4
 pt[2]:    location: -1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (0,3,6)
 With weight: 0.784314
 pt[3]:    location: -1.25  0.25  1.25
+   is located on boundary: 0
    idx:     (1,4,6)
 With weight: 4
 pt[4]:    location: -1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (1,3,7)
 With weight: 3.29412
 pt[5]:    location: -1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (0,3,5)
 With weight: 1.88235
 pt[6]:    location: -1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (0,2,6)
-With weight: -1.62633e-15
+With weight: -6.71904e-16
 
 On point:    location:  1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (6,3,6)
 pt[0]:    location:  1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (6,3,6)
 With weight: -13.9608
 pt[1]:    location:  1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (6,2,6)
 With weight: 4
 pt[2]:    location:  1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (7,3,6)
 With weight: 0.784314
 pt[3]:    location: 1.25 0.25 1.25
+   is located on boundary: 0
    idx:     (6,4,6)
 With weight: 4
 pt[4]:    location:  1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (6,3,7)
 With weight: 3.29412
 pt[5]:    location:  1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (7,3,5)
 With weight: 1.88235
 pt[6]:    location:  1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (7,2,6)
-With weight: -1.62633e-15
+With weight: -6.71904e-16
 
 On point:    location:  1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (7,3,6)
 pt[0]:    location:  1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (7,3,6)
 With weight: -24
 pt[1]:    location:  1.75 -0.25  0.75
+   is located on boundary: 0
    idx:     (7,3,5)
 With weight: 4
 pt[2]:    location:  1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (7,2,6)
 With weight: 4
 pt[3]:    location:  1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (6,3,6)
 With weight: 4
 pt[4]:    location:  2.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (8,3,6)
 With weight: 4
 pt[5]:    location: 1.75 0.25 1.25
+   is located on boundary: 0
    idx:     (7,4,6)
 With weight: 4
 pt[6]:    location:  1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (7,3,7)
 With weight: 4
 
 On point:    location: -1.75  0.25  1.25
+   is located on boundary: 0
    idx:     (0,4,6)
 pt[0]:    location: -1.75  0.25  1.25
+   is located on boundary: 0
    idx:     (0,4,6)
 With weight: -24
 pt[1]:    location: -1.75  0.25  0.75
+   is located on boundary: 0
    idx:     (0,4,5)
 With weight: 4
 pt[2]:    location: -1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (0,3,6)
 With weight: 4
 pt[3]:    location: -2.25  0.25  1.25
+   is located on boundary: 0
    idx:     (-1,4,6)
 With weight: 4
 pt[4]:    location: -1.25  0.25  1.25
+   is located on boundary: 0
    idx:     (1,4,6)
 With weight: 4
 pt[5]:    location: -1.75  0.75  1.25
+   is located on boundary: 0
    idx:     (0,5,6)
 With weight: 4
 pt[6]:    location: -1.75  0.25  1.75
+   is located on boundary: 0
    idx:     (0,4,7)
 With weight: 4
 
 On point:    location: -1.25  0.25  1.25
+   is located on boundary: 0
    idx:     (1,4,6)
 pt[0]:    location: -1.25  0.25  1.25
+   is located on boundary: 0
    idx:     (1,4,6)
 With weight: -13.9608
 pt[1]:    location: -1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (1,3,6)
 With weight: 4
 pt[2]:    location: -1.75  0.25  1.25
+   is located on boundary: 0
    idx:     (0,4,6)
 With weight: 0.784314
 pt[3]:    location: -1.25  0.75  1.25
+   is located on boundary: 0
    idx:     (1,5,6)
 With weight: 4
 pt[4]:    location: -1.25  0.25  1.75
+   is located on boundary: 0
    idx:     (1,4,7)
 With weight: 3.29412
 pt[5]:    location: -1.75  0.25  0.75
+   is located on boundary: 0
    idx:     (0,4,5)
 With weight: 1.88235
 pt[6]:    location: -1.75  0.75  1.25
+   is located on boundary: 0
    idx:     (0,5,6)
-With weight: 5.53518e-17
+With weight: 4.70333e-16
 
 On point:    location: 1.25 0.25 1.25
+   is located on boundary: 0
    idx:     (6,4,6)
 pt[0]:    location: 1.25 0.25 1.25
+   is located on boundary: 0
    idx:     (6,4,6)
 With weight: -14.8571
 pt[1]:    location:  1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (6,3,6)
 With weight: 4
 pt[2]:    location: 1.75 0.25 1.25
+   is located on boundary: 0
    idx:     (7,4,6)
 With weight: 1.14286
 pt[3]:    location: 1.25 0.75 1.25
+   is located on boundary: 0
    idx:     (6,5,6)
 With weight: 4
 pt[4]:    location: 1.25 0.25 1.75
+   is located on boundary: 0
    idx:     (6,4,7)
 With weight: 1.14286
 pt[5]:    location: 1.75 0.25 0.75
+   is located on boundary: 0
    idx:     (7,4,5)
 With weight: 2.28571
 pt[6]:    location: 0.75 0.25 1.75
+   is located on boundary: 0
    idx:     (5,4,7)
 With weight: 2.28571
 
 On point:    location: 1.75 0.25 1.25
+   is located on boundary: 0
    idx:     (7,4,6)
 pt[0]:    location: 1.75 0.25 1.25
+   is located on boundary: 0
    idx:     (7,4,6)
 With weight: -24
 pt[1]:    location: 1.75 0.25 0.75
+   is located on boundary: 0
    idx:     (7,4,5)
 With weight: 4
 pt[2]:    location:  1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (7,3,6)
 With weight: 4
 pt[3]:    location: 1.25 0.25 1.25
+   is located on boundary: 0
    idx:     (6,4,6)
 With weight: 4
 pt[4]:    location: 2.25 0.25 1.25
+   is located on boundary: 0
    idx:     (8,4,6)
 With weight: 4
 pt[5]:    location: 1.75 0.75 1.25
+   is located on boundary: 0
    idx:     (7,5,6)
 With weight: 4
 pt[6]:    location: 1.75 0.25 1.75
+   is located on boundary: 0
    idx:     (7,4,7)
 With weight: 4
 
 On point:    location: -1.75  0.75  1.25
+   is located on boundary: 0
    idx:     (0,5,6)
 pt[0]:    location: -1.75  0.75  1.25
+   is located on boundary: 0
    idx:     (0,5,6)
 With weight: -24
 pt[1]:    location: -1.75  0.75  0.75
+   is located on boundary: 0
    idx:     (0,5,5)
 With weight: 4
 pt[2]:    location: -1.75  0.25  1.25
+   is located on boundary: 0
    idx:     (0,4,6)
 With weight: 4
 pt[3]:    location: -2.25  0.75  1.25
+   is located on boundary: 0
    idx:     (-1,5,6)
 With weight: 4
 pt[4]:    location: -1.25  0.75  1.25
+   is located on boundary: 0
    idx:     (1,5,6)
 With weight: 4
 pt[5]:    location: -1.75  1.25  1.25
+   is located on boundary: 0
    idx:     (0,6,6)
 With weight: 4
 pt[6]:    location: -1.75  0.75  1.75
+   is located on boundary: 0
    idx:     (0,5,7)
 With weight: 4
 
 On point:    location: -1.25  0.75  1.25
+   is located on boundary: 0
    idx:     (1,5,6)
 pt[0]:    location: -1.25  0.75  1.25
+   is located on boundary: 0
    idx:     (1,5,6)
 With weight: -13.9608
 pt[1]:    location: -1.25  0.25  1.25
+   is located on boundary: 0
    idx:     (1,4,6)
 With weight: 4
 pt[2]:    location: -1.75  0.75  1.25
+   is located on boundary: 0
    idx:     (0,5,6)
 With weight: 0.784314
 pt[3]:    location: -1.25  1.25  1.25
+   is located on boundary: 0
    idx:     (1,6,6)
 With weight: 4
 pt[4]:    location: -1.25  0.75  1.75
+   is located on boundary: 0
    idx:     (1,5,7)
 With weight: 3.29412
 pt[5]:    location: -1.75  0.75  0.75
+   is located on boundary: 0
    idx:     (0,5,5)
 With weight: 1.88235
 pt[6]:    location: -1.75  0.25  1.25
+   is located on boundary: 0
    idx:     (0,4,6)
-With weight: -1.62633e-15
+With weight: -6.71904e-16
 
 On point:    location: 1.25 0.75 1.25
+   is located on boundary: 0
    idx:     (6,5,6)
 pt[0]:    location: 1.25 0.75 1.25
+   is located on boundary: 0
    idx:     (6,5,6)
 With weight: -14.1867
 pt[1]:    location: 1.25 0.25 1.25
+   is located on boundary: 0
    idx:     (6,4,6)
 With weight: 4
 pt[2]:    location: 1.75 0.75 1.25
+   is located on boundary: 0
    idx:     (7,5,6)
 With weight: 1.38667
 pt[3]:    location: 1.25 1.25 1.25
+   is located on boundary: 0
    idx:     (6,6,6)
 With weight: 2.72
 pt[4]:    location: 1.25 0.75 1.75
+   is located on boundary: 0
    idx:     (6,5,7)
 With weight: 3.52
 pt[5]:    location: 1.75 0.75 0.75
+   is located on boundary: 0
    idx:     (7,5,5)
 With weight: 1.28
 pt[6]:    location: 1.25 1.25 0.75
+   is located on boundary: 0
    idx:     (6,6,5)
 With weight: 1.28
 
 On point:    location: 1.75 0.75 1.25
+   is located on boundary: 0
    idx:     (7,5,6)
 pt[0]:    location: 1.75 0.75 1.25
+   is located on boundary: 0
    idx:     (7,5,6)
 With weight: -24
 pt[1]:    location: 1.75 0.75 0.75
+   is located on boundary: 0
    idx:     (7,5,5)
 With weight: 4
 pt[2]:    location: 1.75 0.25 1.25
+   is located on boundary: 0
    idx:     (7,4,6)
 With weight: 4
 pt[3]:    location: 1.25 0.75 1.25
+   is located on boundary: 0
    idx:     (6,5,6)
 With weight: 4
 pt[4]:    location: 2.25 0.75 1.25
+   is located on boundary: 0
    idx:     (8,5,6)
 With weight: 4
 pt[5]:    location: 1.75 1.25 1.25
+   is located on boundary: 0
    idx:     (7,6,6)
 With weight: 4
 pt[6]:    location: 1.75 0.75 1.75
+   is located on boundary: 0
    idx:     (7,5,7)
 With weight: 4
 
 On point:    location: -1.75  1.25  1.25
+   is located on boundary: 0
    idx:     (0,6,6)
 pt[0]:    location: -1.75  1.25  1.25
+   is located on boundary: 0
    idx:     (0,6,6)
 With weight: -24
 pt[1]:    location: -1.75  1.25  0.75
+   is located on boundary: 0
    idx:     (0,6,5)
 With weight: 4
 pt[2]:    location: -1.75  0.75  1.25
+   is located on boundary: 0
    idx:     (0,5,6)
 With weight: 4
 pt[3]:    location: -2.25  1.25  1.25
+   is located on boundary: 0
    idx:     (-1,6,6)
 With weight: 4
 pt[4]:    location: -1.25  1.25  1.25
+   is located on boundary: 0
    idx:     (1,6,6)
 With weight: 4
 pt[5]:    location: -1.75  1.75  1.25
+   is located on boundary: 0
    idx:     (0,7,6)
 With weight: 4
 pt[6]:    location: -1.75  1.25  1.75
+   is located on boundary: 0
    idx:     (0,6,7)
 With weight: 4
 
 On point:    location: -1.25  1.25  1.25
+   is located on boundary: 0
    idx:     (1,6,6)
 pt[0]:    location: -1.25  1.25  1.25
+   is located on boundary: 0
    idx:     (1,6,6)
 With weight: -24
 pt[1]:    location: -1.25  1.25  0.75
+   is located on boundary: 0
    idx:     (1,6,5)
 With weight: 4
 pt[2]:    location: -1.25  0.75  1.25
+   is located on boundary: 0
    idx:     (1,5,6)
 With weight: 4
 pt[3]:    location: -1.75  1.25  1.25
+   is located on boundary: 0
    idx:     (0,6,6)
 With weight: 4
 pt[4]:    location: -0.75  1.25  1.25
+   is located on boundary: 0
    idx:     (2,6,6)
 With weight: 4
 pt[5]:    location: -1.25  1.75  1.25
+   is located on boundary: 0
    idx:     (1,7,6)
 With weight: 4
 pt[6]:    location: -1.25  1.25  1.75
+   is located on boundary: 0
    idx:     (1,6,7)
 With weight: 4
 
 On point:    location: -0.75  1.25  1.25
+   is located on boundary: 0
    idx:     (2,6,6)
 pt[0]:    location: -0.75  1.25  1.25
+   is located on boundary: 0
    idx:     (2,6,6)
 With weight: -13.9608
 pt[1]:    location: -1.25  1.25  1.25
+   is located on boundary: 0
    idx:     (1,6,6)
 With weight: 4
 pt[2]:    location: -0.25  1.25  1.25
+   is located on boundary: 0
    idx:     (3,6,6)
 With weight: 4
 pt[3]:    location: -0.75  1.75  1.25
+   is located on boundary: 0
    idx:     (2,7,6)
 With weight: 0.784314
 pt[4]:    location: -0.75  1.25  1.75
+   is located on boundary: 0
    idx:     (2,6,7)
 With weight: 3.29412
 pt[5]:    location: -0.75  1.75  0.75
+   is located on boundary: 0
    idx:     (2,7,5)
 With weight: 1.88235
 pt[6]:    location: -0.25  1.75  1.25
+   is located on boundary: 0
    idx:     (3,7,6)
-With weight: 1.00786e-16
+With weight: -1.27662e-15
 
 On point:    location: -0.25  1.25  1.25
+   is located on boundary: 0
    idx:     (3,6,6)
 pt[0]:    location: -0.25  1.25  1.25
+   is located on boundary: 0
    idx:     (3,6,6)
 With weight: -13.9608
 pt[1]:    location: -0.75  1.25  1.25
+   is located on boundary: 0
    idx:     (2,6,6)
 With weight: 4
 pt[2]:    location: 0.25 1.25 1.25
+   is located on boundary: 0
    idx:     (4,6,6)
 With weight: 4
 pt[3]:    location: -0.25  1.75  1.25
+   is located on boundary: 0
    idx:     (3,7,6)
 With weight: 0.784314
 pt[4]:    location: -0.25  1.25  1.75
+   is located on boundary: 0
    idx:     (3,6,7)
 With weight: 3.29412
 pt[5]:    location: -0.25  1.75  0.75
+   is located on boundary: 0
    idx:     (3,7,5)
 With weight: 1.88235
 pt[6]:    location: -0.75  1.75  1.25
+   is located on boundary: 0
    idx:     (2,7,6)
-With weight: -4.30818e-16
+With weight: 0
 
 On point:    location: 0.25 1.25 1.25
+   is located on boundary: 0
    idx:     (4,6,6)
 pt[0]:    location: 0.25 1.25 1.25
+   is located on boundary: 0
    idx:     (4,6,6)
 With weight: -13.9608
 pt[1]:    location: -0.25  1.25  1.25
+   is located on boundary: 0
    idx:     (3,6,6)
 With weight: 4
 pt[2]:    location: 0.75 1.25 1.25
+   is located on boundary: 0
    idx:     (5,6,6)
 With weight: 4
 pt[3]:    location: 0.25 1.75 1.25
+   is located on boundary: 0
    idx:     (4,7,6)
 With weight: 3.29412
 pt[4]:    location: 0.25 1.25 1.75
+   is located on boundary: 0
    idx:     (4,6,7)
 With weight: 0.784314
 pt[5]:    location: 0.75 1.75 1.25
+   is located on boundary: 0
    idx:     (5,7,6)
-With weight: -2.42903e-15
+With weight: -6.31835e-16
 pt[6]:    location: 0.25 0.75 1.75
+   is located on boundary: 0
    idx:     (4,5,7)
 With weight: 1.88235
 
 On point:    location: 0.75 1.25 1.25
+   is located on boundary: 0
    idx:     (5,6,6)
 pt[0]:    location: 0.75 1.25 1.25
+   is located on boundary: 0
    idx:     (5,6,6)
 With weight: -13.9608
 pt[1]:    location: 0.25 1.25 1.25
+   is located on boundary: 0
    idx:     (4,6,6)
 With weight: 4
 pt[2]:    location: 1.25 1.25 1.25
+   is located on boundary: 0
    idx:     (6,6,6)
 With weight: 2.11765
 pt[3]:    location: 0.75 1.75 1.25
+   is located on boundary: 0
    idx:     (5,7,6)
 With weight: 2.66667
 pt[4]:    location: 0.75 1.25 1.75
+   is located on boundary: 0
    idx:     (5,6,7)
 With weight: 3.29412
 pt[5]:    location: 1.25 1.25 0.75
+   is located on boundary: 0
    idx:     (6,6,5)
 With weight: 1.88235
 pt[6]:    location: 0.25 1.75 1.25
+   is located on boundary: 0
    idx:     (4,7,6)
-With weight: 1.12515e-16
+With weight: -9.72009e-16
 
 On point:    location: 1.25 1.25 1.25
+   is located on boundary: 0
    idx:     (6,6,6)
 pt[0]:    location: 1.25 1.25 1.25
+   is located on boundary: 0
    idx:     (6,6,6)
 With weight: -24
 pt[1]:    location: 1.25 1.25 0.75
+   is located on boundary: 0
    idx:     (6,6,5)
 With weight: 4
 pt[2]:    location: 1.25 0.75 1.25
+   is located on boundary: 0
    idx:     (6,5,6)
 With weight: 4
 pt[3]:    location: 0.75 1.25 1.25
+   is located on boundary: 0
    idx:     (5,6,6)
 With weight: 4
 pt[4]:    location: 1.75 1.25 1.25
+   is located on boundary: 0
    idx:     (7,6,6)
 With weight: 4
 pt[5]:    location: 1.25 1.75 1.25
+   is located on boundary: 0
    idx:     (6,7,6)
 With weight: 4
 pt[6]:    location: 1.25 1.25 1.75
+   is located on boundary: 0
    idx:     (6,6,7)
 With weight: 4
 
 On point:    location: 1.75 1.25 1.25
+   is located on boundary: 0
    idx:     (7,6,6)
 pt[0]:    location: 1.75 1.25 1.25
+   is located on boundary: 0
    idx:     (7,6,6)
 With weight: -24
 pt[1]:    location: 1.75 1.25 0.75
+   is located on boundary: 0
    idx:     (7,6,5)
 With weight: 4
 pt[2]:    location: 1.75 0.75 1.25
+   is located on boundary: 0
    idx:     (7,5,6)
 With weight: 4
 pt[3]:    location: 1.25 1.25 1.25
+   is located on boundary: 0
    idx:     (6,6,6)
 With weight: 4
 pt[4]:    location: 2.25 1.25 1.25
+   is located on boundary: 0
    idx:     (8,6,6)
 With weight: 4
 pt[5]:    location: 1.75 1.75 1.25
+   is located on boundary: 0
    idx:     (7,7,6)
 With weight: 4
 pt[6]:    location: 1.75 1.25 1.75
+   is located on boundary: 0
    idx:     (7,6,7)
 With weight: 4
 
 On point:    location: -1.75  1.75  1.25
+   is located on boundary: 0
    idx:     (0,7,6)
 pt[0]:    location: -1.75  1.75  1.25
+   is located on boundary: 0
    idx:     (0,7,6)
 With weight: -24
 pt[1]:    location: -1.75  1.75  0.75
+   is located on boundary: 0
    idx:     (0,7,5)
 With weight: 4
 pt[2]:    location: -1.75  1.25  1.25
+   is located on boundary: 0
    idx:     (0,6,6)
 With weight: 4
 pt[3]:    location: -2.25  1.75  1.25
+   is located on boundary: 0
    idx:     (-1,7,6)
 With weight: 4
 pt[4]:    location: -1.25  1.75  1.25
+   is located on boundary: 0
    idx:     (1,7,6)
 With weight: 4
 pt[5]:    location: -1.75  2.25  1.25
+   is located on boundary: 0
    idx:     (0,8,6)
 With weight: 4
 pt[6]:    location: -1.75  1.75  1.75
+   is located on boundary: 0
    idx:     (0,7,7)
 With weight: 4
 
 On point:    location: -1.25  1.75  1.25
+   is located on boundary: 0
    idx:     (1,7,6)
 pt[0]:    location: -1.25  1.75  1.25
+   is located on boundary: 0
    idx:     (1,7,6)
 With weight: -24
 pt[1]:    location: -1.25  1.75  0.75
+   is located on boundary: 0
    idx:     (1,7,5)
 With weight: 4
 pt[2]:    location: -1.25  1.25  1.25
+   is located on boundary: 0
    idx:     (1,6,6)
 With weight: 4
 pt[3]:    location: -1.75  1.75  1.25
+   is located on boundary: 0
    idx:     (0,7,6)
 With weight: 4
 pt[4]:    location: -0.75  1.75  1.25
+   is located on boundary: 0
    idx:     (2,7,6)
 With weight: 4
 pt[5]:    location: -1.25  2.25  1.25
+   is located on boundary: 0
    idx:     (1,8,6)
 With weight: 4
 pt[6]:    location: -1.25  1.75  1.75
+   is located on boundary: 0
    idx:     (1,7,7)
 With weight: 4
 
 On point:    location: -0.75  1.75  1.25
+   is located on boundary: 0
    idx:     (2,7,6)
 pt[0]:    location: -0.75  1.75  1.25
+   is located on boundary: 0
    idx:     (2,7,6)
 With weight: -24
 pt[1]:    location: -0.75  1.75  0.75
+   is located on boundary: 0
    idx:     (2,7,5)
 With weight: 4
 pt[2]:    location: -0.75  1.25  1.25
+   is located on boundary: 0
    idx:     (2,6,6)
 With weight: 4
 pt[3]:    location: -1.25  1.75  1.25
+   is located on boundary: 0
    idx:     (1,7,6)
 With weight: 4
 pt[4]:    location: -0.25  1.75  1.25
+   is located on boundary: 0
    idx:     (3,7,6)
 With weight: 4
 pt[5]:    location: -0.75  2.25  1.25
+   is located on boundary: 0
    idx:     (2,8,6)
 With weight: 4
 pt[6]:    location: -0.75  1.75  1.75
+   is located on boundary: 0
    idx:     (2,7,7)
 With weight: 4
 
 On point:    location: -0.25  1.75  1.25
+   is located on boundary: 0
    idx:     (3,7,6)
 pt[0]:    location: -0.25  1.75  1.25
+   is located on boundary: 0
    idx:     (3,7,6)
 With weight: -24
 pt[1]:    location: -0.25  1.75  0.75
+   is located on boundary: 0
    idx:     (3,7,5)
 With weight: 4
 pt[2]:    location: -0.25  1.25  1.25
+   is located on boundary: 0
    idx:     (3,6,6)
 With weight: 4
 pt[3]:    location: -0.75  1.75  1.25
+   is located on boundary: 0
    idx:     (2,7,6)
 With weight: 4
 pt[4]:    location: 0.25 1.75 1.25
+   is located on boundary: 0
    idx:     (4,7,6)
 With weight: 4
 pt[5]:    location: -0.25  2.25  1.25
+   is located on boundary: 0
    idx:     (3,8,6)
 With weight: 4
 pt[6]:    location: -0.25  1.75  1.75
+   is located on boundary: 0
    idx:     (3,7,7)
 With weight: 4
 
 On point:    location: 0.25 1.75 1.25
+   is located on boundary: 0
    idx:     (4,7,6)
 pt[0]:    location: 0.25 1.75 1.25
+   is located on boundary: 0
    idx:     (4,7,6)
 With weight: -24
 pt[1]:    location: 0.25 1.75 0.75
+   is located on boundary: 0
    idx:     (4,7,5)
 With weight: 4
 pt[2]:    location: 0.25 1.25 1.25
+   is located on boundary: 0
    idx:     (4,6,6)
 With weight: 4
 pt[3]:    location: -0.25  1.75  1.25
+   is located on boundary: 0
    idx:     (3,7,6)
 With weight: 4
 pt[4]:    location: 0.75 1.75 1.25
+   is located on boundary: 0
    idx:     (5,7,6)
 With weight: 4
 pt[5]:    location: 0.25 2.25 1.25
+   is located on boundary: 0
    idx:     (4,8,6)
 With weight: 4
 pt[6]:    location: 0.25 1.75 1.75
+   is located on boundary: 0
    idx:     (4,7,7)
 With weight: 4
 
 On point:    location: 0.75 1.75 1.25
+   is located on boundary: 0
    idx:     (5,7,6)
 pt[0]:    location: 0.75 1.75 1.25
+   is located on boundary: 0
    idx:     (5,7,6)
 With weight: -24
 pt[1]:    location: 0.75 1.75 0.75
+   is located on boundary: 0
    idx:     (5,7,5)
 With weight: 4
 pt[2]:    location: 0.75 1.25 1.25
+   is located on boundary: 0
    idx:     (5,6,6)
 With weight: 4
 pt[3]:    location: 0.25 1.75 1.25
+   is located on boundary: 0
    idx:     (4,7,6)
 With weight: 4
 pt[4]:    location: 1.25 1.75 1.25
+   is located on boundary: 0
    idx:     (6,7,6)
 With weight: 4
 pt[5]:    location: 0.75 2.25 1.25
+   is located on boundary: 0
    idx:     (5,8,6)
 With weight: 4
 pt[6]:    location: 0.75 1.75 1.75
+   is located on boundary: 0
    idx:     (5,7,7)
 With weight: 4
 
 On point:    location: 1.25 1.75 1.25
+   is located on boundary: 0
    idx:     (6,7,6)
 pt[0]:    location: 1.25 1.75 1.25
+   is located on boundary: 0
    idx:     (6,7,6)
 With weight: -24
 pt[1]:    location: 1.25 1.75 0.75
+   is located on boundary: 0
    idx:     (6,7,5)
 With weight: 4
 pt[2]:    location: 1.25 1.25 1.25
+   is located on boundary: 0
    idx:     (6,6,6)
 With weight: 4
 pt[3]:    location: 0.75 1.75 1.25
+   is located on boundary: 0
    idx:     (5,7,6)
 With weight: 4
 pt[4]:    location: 1.75 1.75 1.25
+   is located on boundary: 0
    idx:     (7,7,6)
 With weight: 4
 pt[5]:    location: 1.25 2.25 1.25
+   is located on boundary: 0
    idx:     (6,8,6)
 With weight: 4
 pt[6]:    location: 1.25 1.75 1.75
+   is located on boundary: 0
    idx:     (6,7,7)
 With weight: 4
 
 On point:    location: 1.75 1.75 1.25
+   is located on boundary: 0
    idx:     (7,7,6)
 pt[0]:    location: 1.75 1.75 1.25
+   is located on boundary: 0
    idx:     (7,7,6)
 With weight: -24
 pt[1]:    location: 1.75 1.75 0.75
+   is located on boundary: 0
    idx:     (7,7,5)
 With weight: 4
 pt[2]:    location: 1.75 1.25 1.25
+   is located on boundary: 0
    idx:     (7,6,6)
 With weight: 4
 pt[3]:    location: 1.25 1.75 1.25
+   is located on boundary: 0
    idx:     (6,7,6)
 With weight: 4
 pt[4]:    location: 2.25 1.75 1.25
+   is located on boundary: 0
    idx:     (8,7,6)
 With weight: 4
 pt[5]:    location: 1.75 2.25 1.25
+   is located on boundary: 0
    idx:     (7,8,6)
 With weight: 4
 pt[6]:    location: 1.75 1.75 1.75
+   is located on boundary: 0
    idx:     (7,7,7)
 With weight: 4
 
 On point:    location: -1.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (0,0,7)
 pt[0]:    location: -1.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (0,0,7)
 With weight: -24
 pt[1]:    location: -1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (0,0,6)
 With weight: 4
 pt[2]:    location: -1.75 -2.25  1.75
+   is located on boundary: 0
    idx:     (0,-1,7)
 With weight: 4
 pt[3]:    location: -2.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (-1,0,7)
 With weight: 4
 pt[4]:    location: -1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (1,0,7)
 With weight: 4
 pt[5]:    location: -1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (0,1,7)
 With weight: 4
 pt[6]:    location: -1.75 -1.75  2.25
+   is located on boundary: 0
    idx:     (0,0,8)
 With weight: 4
 
 On point:    location: -1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (1,0,7)
 pt[0]:    location: -1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (1,0,7)
 With weight: -24
 pt[1]:    location: -1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (1,0,6)
 With weight: 4
 pt[2]:    location: -1.25 -2.25  1.75
+   is located on boundary: 0
    idx:     (1,-1,7)
 With weight: 4
 pt[3]:    location: -1.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (0,0,7)
 With weight: 4
 pt[4]:    location: -0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (2,0,7)
 With weight: 4
 pt[5]:    location: -1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (1,1,7)
 With weight: 4
 pt[6]:    location: -1.25 -1.75  2.25
+   is located on boundary: 0
    idx:     (1,0,8)
 With weight: 4
 
 On point:    location: -0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (2,0,7)
 pt[0]:    location: -0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (2,0,7)
 With weight: -24
 pt[1]:    location: -0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (2,0,6)
 With weight: 4
 pt[2]:    location: -0.75 -2.25  1.75
+   is located on boundary: 0
    idx:     (2,-1,7)
 With weight: 4
 pt[3]:    location: -1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (1,0,7)
 With weight: 4
 pt[4]:    location: -0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (3,0,7)
 With weight: 4
 pt[5]:    location: -0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (2,1,7)
 With weight: 4
 pt[6]:    location: -0.75 -1.75  2.25
+   is located on boundary: 0
    idx:     (2,0,8)
 With weight: 4
 
 On point:    location: -0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (3,0,7)
 pt[0]:    location: -0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (3,0,7)
 With weight: -24
 pt[1]:    location: -0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (3,0,6)
 With weight: 4
 pt[2]:    location: -0.25 -2.25  1.75
+   is located on boundary: 0
    idx:     (3,-1,7)
 With weight: 4
 pt[3]:    location: -0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (2,0,7)
 With weight: 4
 pt[4]:    location:  0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (4,0,7)
 With weight: 4
 pt[5]:    location: -0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (3,1,7)
 With weight: 4
 pt[6]:    location: -0.25 -1.75  2.25
+   is located on boundary: 0
    idx:     (3,0,8)
 With weight: 4
 
 On point:    location:  0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (4,0,7)
 pt[0]:    location:  0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (4,0,7)
 With weight: -24
 pt[1]:    location:  0.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (4,0,6)
 With weight: 4
 pt[2]:    location:  0.25 -2.25  1.75
+   is located on boundary: 0
    idx:     (4,-1,7)
 With weight: 4
 pt[3]:    location: -0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (3,0,7)
 With weight: 4
 pt[4]:    location:  0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (5,0,7)
 With weight: 4
 pt[5]:    location:  0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (4,1,7)
 With weight: 4
 pt[6]:    location:  0.25 -1.75  2.25
+   is located on boundary: 0
    idx:     (4,0,8)
 With weight: 4
 
 On point:    location:  0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (5,0,7)
 pt[0]:    location:  0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (5,0,7)
 With weight: -24
 pt[1]:    location:  0.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (5,0,6)
 With weight: 4
 pt[2]:    location:  0.75 -2.25  1.75
+   is located on boundary: 0
    idx:     (5,-1,7)
 With weight: 4
 pt[3]:    location:  0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (4,0,7)
 With weight: 4
 pt[4]:    location:  1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (6,0,7)
 With weight: 4
 pt[5]:    location:  0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (5,1,7)
 With weight: 4
 pt[6]:    location:  0.75 -1.75  2.25
+   is located on boundary: 0
    idx:     (5,0,8)
 With weight: 4
 
 On point:    location:  1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (6,0,7)
 pt[0]:    location:  1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (6,0,7)
 With weight: -24
 pt[1]:    location:  1.25 -1.75  1.25
+   is located on boundary: 0
    idx:     (6,0,6)
 With weight: 4
 pt[2]:    location:  1.25 -2.25  1.75
+   is located on boundary: 0
    idx:     (6,-1,7)
 With weight: 4
 pt[3]:    location:  0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (5,0,7)
 With weight: 4
 pt[4]:    location:  1.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (7,0,7)
 With weight: 4
 pt[5]:    location:  1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (6,1,7)
 With weight: 4
 pt[6]:    location:  1.25 -1.75  2.25
+   is located on boundary: 0
    idx:     (6,0,8)
 With weight: 4
 
 On point:    location:  1.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (7,0,7)
 pt[0]:    location:  1.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (7,0,7)
 With weight: -24
 pt[1]:    location:  1.75 -1.75  1.25
+   is located on boundary: 0
    idx:     (7,0,6)
 With weight: 4
 pt[2]:    location:  1.75 -2.25  1.75
+   is located on boundary: 0
    idx:     (7,-1,7)
 With weight: 4
 pt[3]:    location:  1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (6,0,7)
 With weight: 4
 pt[4]:    location:  2.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (8,0,7)
 With weight: 4
 pt[5]:    location:  1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (7,1,7)
 With weight: 4
 pt[6]:    location:  1.75 -1.75  2.25
+   is located on boundary: 0
    idx:     (7,0,8)
 With weight: 4
 
 On point:    location: -1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (0,1,7)
 pt[0]:    location: -1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (0,1,7)
 With weight: -24
 pt[1]:    location: -1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (0,1,6)
 With weight: 4
 pt[2]:    location: -1.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (0,0,7)
 With weight: 4
 pt[3]:    location: -2.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (-1,1,7)
 With weight: 4
 pt[4]:    location: -1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (1,1,7)
 With weight: 4
 pt[5]:    location: -1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (0,2,7)
 With weight: 4
 pt[6]:    location: -1.75 -1.25  2.25
+   is located on boundary: 0
    idx:     (0,1,8)
 With weight: 4
 
 On point:    location: -1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (1,1,7)
 pt[0]:    location: -1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (1,1,7)
 With weight: -24
 pt[1]:    location: -1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (1,1,6)
 With weight: 4
 pt[2]:    location: -1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (1,0,7)
 With weight: 4
 pt[3]:    location: -1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (0,1,7)
 With weight: 4
 pt[4]:    location: -0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (2,1,7)
 With weight: 4
 pt[5]:    location: -1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (1,2,7)
 With weight: 4
 pt[6]:    location: -1.25 -1.25  2.25
+   is located on boundary: 0
    idx:     (1,1,8)
 With weight: 4
 
 On point:    location: -0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (2,1,7)
 pt[0]:    location: -0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (2,1,7)
 With weight: -24
 pt[1]:    location: -0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (2,1,6)
 With weight: 4
 pt[2]:    location: -0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (2,0,7)
 With weight: 4
 pt[3]:    location: -1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (1,1,7)
 With weight: 4
 pt[4]:    location: -0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (3,1,7)
 With weight: 4
 pt[5]:    location: -0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (2,2,7)
 With weight: 4
 pt[6]:    location: -0.75 -1.25  2.25
+   is located on boundary: 0
    idx:     (2,1,8)
 With weight: 4
 
 On point:    location: -0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (3,1,7)
 pt[0]:    location: -0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (3,1,7)
 With weight: -24
 pt[1]:    location: -0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (3,1,6)
 With weight: 4
 pt[2]:    location: -0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (3,0,7)
 With weight: 4
 pt[3]:    location: -0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (2,1,7)
 With weight: 4
 pt[4]:    location:  0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (4,1,7)
 With weight: 4
 pt[5]:    location: -0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (3,2,7)
 With weight: 4
 pt[6]:    location: -0.25 -1.25  2.25
+   is located on boundary: 0
    idx:     (3,1,8)
 With weight: 4
 
 On point:    location:  0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (4,1,7)
 pt[0]:    location:  0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (4,1,7)
 With weight: -24
 pt[1]:    location:  0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (4,1,6)
 With weight: 4
 pt[2]:    location:  0.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (4,0,7)
 With weight: 4
 pt[3]:    location: -0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (3,1,7)
 With weight: 4
 pt[4]:    location:  0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (5,1,7)
 With weight: 4
 pt[5]:    location:  0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (4,2,7)
 With weight: 4
 pt[6]:    location:  0.25 -1.25  2.25
+   is located on boundary: 0
    idx:     (4,1,8)
 With weight: 4
 
 On point:    location:  0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (5,1,7)
 pt[0]:    location:  0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (5,1,7)
 With weight: -24
 pt[1]:    location:  0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (5,1,6)
 With weight: 4
 pt[2]:    location:  0.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (5,0,7)
 With weight: 4
 pt[3]:    location:  0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (4,1,7)
 With weight: 4
 pt[4]:    location:  1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (6,1,7)
 With weight: 4
 pt[5]:    location:  0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (5,2,7)
 With weight: 4
 pt[6]:    location:  0.75 -1.25  2.25
+   is located on boundary: 0
    idx:     (5,1,8)
 With weight: 4
 
 On point:    location:  1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (6,1,7)
 pt[0]:    location:  1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (6,1,7)
 With weight: -24
 pt[1]:    location:  1.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (6,1,6)
 With weight: 4
 pt[2]:    location:  1.25 -1.75  1.75
+   is located on boundary: 0
    idx:     (6,0,7)
 With weight: 4
 pt[3]:    location:  0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (5,1,7)
 With weight: 4
 pt[4]:    location:  1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (7,1,7)
 With weight: 4
 pt[5]:    location:  1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (6,2,7)
 With weight: 4
 pt[6]:    location:  1.25 -1.25  2.25
+   is located on boundary: 0
    idx:     (6,1,8)
 With weight: 4
 
 On point:    location:  1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (7,1,7)
 pt[0]:    location:  1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (7,1,7)
 With weight: -24
 pt[1]:    location:  1.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (7,1,6)
 With weight: 4
 pt[2]:    location:  1.75 -1.75  1.75
+   is located on boundary: 0
    idx:     (7,0,7)
 With weight: 4
 pt[3]:    location:  1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (6,1,7)
 With weight: 4
 pt[4]:    location:  2.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (8,1,7)
 With weight: 4
 pt[5]:    location:  1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (7,2,7)
 With weight: 4
 pt[6]:    location:  1.75 -1.25  2.25
+   is located on boundary: 0
    idx:     (7,1,8)
 With weight: 4
 
 On point:    location: -1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (0,2,7)
 pt[0]:    location: -1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (0,2,7)
 With weight: -24
 pt[1]:    location: -1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (0,2,6)
 With weight: 4
 pt[2]:    location: -1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (0,1,7)
 With weight: 4
 pt[3]:    location: -2.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (-1,2,7)
 With weight: 4
 pt[4]:    location: -1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (1,2,7)
 With weight: 4
 pt[5]:    location: -1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (0,3,7)
 With weight: 4
 pt[6]:    location: -1.75 -0.75  2.25
+   is located on boundary: 0
    idx:     (0,2,8)
 With weight: 4
 
 On point:    location: -1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (1,2,7)
 pt[0]:    location: -1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (1,2,7)
 With weight: -24
 pt[1]:    location: -1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (1,2,6)
 With weight: 4
 pt[2]:    location: -1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (1,1,7)
 With weight: 4
 pt[3]:    location: -1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (0,2,7)
 With weight: 4
 pt[4]:    location: -0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (2,2,7)
 With weight: 4
 pt[5]:    location: -1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (1,3,7)
 With weight: 4
 pt[6]:    location: -1.25 -0.75  2.25
+   is located on boundary: 0
    idx:     (1,2,8)
 With weight: 4
 
 On point:    location: -0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (2,2,7)
 pt[0]:    location: -0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (2,2,7)
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (2,1,7)
 With weight: 4
 pt[2]:    location: -1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (1,2,7)
 With weight: 4
 pt[3]:    location: -0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (3,2,7)
 With weight: 4
 pt[4]:    location: -0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (2,3,7)
 With weight: 4
 pt[5]:    location: -0.75 -0.75  2.25
+   is located on boundary: 0
    idx:     (2,2,8)
 With weight: 2.66667
 pt[6]:    location: -0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (3,1,7)
-With weight: 8.54259e-16
+With weight: 1.65992e-15
 
 On point:    location: -0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (3,2,7)
 pt[0]:    location: -0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (3,2,7)
 With weight: -19.2941
 pt[1]:    location: -0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (3,1,7)
 With weight: 2.11765
 pt[2]:    location: -0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (2,2,7)
 With weight: 4
 pt[3]:    location:  0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (4,2,7)
 With weight: 4
 pt[4]:    location: -0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (3,3,7)
 With weight: 4
 pt[5]:    location: -0.25 -0.75  2.25
+   is located on boundary: 0
    idx:     (3,2,8)
 With weight: 3.29412
 pt[6]:    location: -0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (3,1,6)
 With weight: 1.88235
 
 On point:    location:  0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (4,2,7)
 pt[0]:    location:  0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (4,2,7)
 With weight: -19.2941
 pt[1]:    location:  0.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (4,1,7)
 With weight: 2.11765
 pt[2]:    location: -0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (3,2,7)
 With weight: 4
 pt[3]:    location:  0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (5,2,7)
 With weight: 4
 pt[4]:    location:  0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (4,3,7)
 With weight: 4
 pt[5]:    location:  0.25 -0.75  2.25
+   is located on boundary: 0
    idx:     (4,2,8)
 With weight: 3.29412
 pt[6]:    location:  0.25 -1.25  1.25
+   is located on boundary: 0
    idx:     (4,1,6)
 With weight: 1.88235
 
 On point:    location:  0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (5,2,7)
 pt[0]:    location:  0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (5,2,7)
 With weight: -19.2941
 pt[1]:    location:  0.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (5,1,7)
 With weight: 2.11765
 pt[2]:    location:  0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (4,2,7)
 With weight: 4
 pt[3]:    location:  1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (6,2,7)
 With weight: 4
 pt[4]:    location:  0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (5,3,7)
 With weight: 4
 pt[5]:    location:  0.75 -0.75  2.25
+   is located on boundary: 0
    idx:     (5,2,8)
 With weight: 3.29412
 pt[6]:    location:  0.75 -1.25  1.25
+   is located on boundary: 0
    idx:     (5,1,6)
 With weight: 1.88235
 
 On point:    location:  1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (6,2,7)
 pt[0]:    location:  1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (6,2,7)
 With weight: -24
 pt[1]:    location:  1.25 -0.75  1.25
+   is located on boundary: 0
    idx:     (6,2,6)
 With weight: 4
 pt[2]:    location:  1.25 -1.25  1.75
+   is located on boundary: 0
    idx:     (6,1,7)
 With weight: 4
 pt[3]:    location:  0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (5,2,7)
 With weight: 4
 pt[4]:    location:  1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (7,2,7)
 With weight: 4
 pt[5]:    location:  1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (6,3,7)
 With weight: 4
 pt[6]:    location:  1.25 -0.75  2.25
+   is located on boundary: 0
    idx:     (6,2,8)
 With weight: 4
 
 On point:    location:  1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (7,2,7)
 pt[0]:    location:  1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (7,2,7)
 With weight: -24
 pt[1]:    location:  1.75 -0.75  1.25
+   is located on boundary: 0
    idx:     (7,2,6)
 With weight: 4
 pt[2]:    location:  1.75 -1.25  1.75
+   is located on boundary: 0
    idx:     (7,1,7)
 With weight: 4
 pt[3]:    location:  1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (6,2,7)
 With weight: 4
 pt[4]:    location:  2.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (8,2,7)
 With weight: 4
 pt[5]:    location:  1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (7,3,7)
 With weight: 4
 pt[6]:    location:  1.75 -0.75  2.25
+   is located on boundary: 0
    idx:     (7,2,8)
 With weight: 4
 
 On point:    location: -1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (0,3,7)
 pt[0]:    location: -1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (0,3,7)
 With weight: -24
 pt[1]:    location: -1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (0,3,6)
 With weight: 4
 pt[2]:    location: -1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (0,2,7)
 With weight: 4
 pt[3]:    location: -2.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (-1,3,7)
 With weight: 4
 pt[4]:    location: -1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (1,3,7)
 With weight: 4
 pt[5]:    location: -1.75  0.25  1.75
+   is located on boundary: 0
    idx:     (0,4,7)
 With weight: 4
 pt[6]:    location: -1.75 -0.25  2.25
+   is located on boundary: 0
    idx:     (0,3,8)
 With weight: 4
 
 On point:    location: -1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (1,3,7)
 pt[0]:    location: -1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (1,3,7)
 With weight: -24
 pt[1]:    location: -1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (1,3,6)
 With weight: 4
 pt[2]:    location: -1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (1,2,7)
 With weight: 4
 pt[3]:    location: -1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (0,3,7)
 With weight: 4
 pt[4]:    location: -0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (2,3,7)
 With weight: 4
 pt[5]:    location: -1.25  0.25  1.75
+   is located on boundary: 0
    idx:     (1,4,7)
 With weight: 4
 pt[6]:    location: -1.25 -0.25  2.25
+   is located on boundary: 0
    idx:     (1,3,8)
 With weight: 4
 
 On point:    location: -0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (2,3,7)
 pt[0]:    location: -0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (2,3,7)
 With weight: -19.2941
 pt[1]:    location: -0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (2,2,7)
 With weight: 4
 pt[2]:    location: -1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (1,3,7)
 With weight: 2.11765
 pt[3]:    location: -0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (3,3,7)
 With weight: 4
 pt[4]:    location: -0.75  0.25  1.75
+   is located on boundary: 0
    idx:     (2,4,7)
 With weight: 4
 pt[5]:    location: -0.75 -0.25  2.25
+   is located on boundary: 0
    idx:     (2,3,8)
 With weight: 3.29412
 pt[6]:    location: -1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (1,3,6)
 With weight: 1.88235
 
 On point:    location: -0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (3,3,7)
 pt[0]:    location: -0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (3,3,7)
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (3,2,7)
 With weight: 4
 pt[2]:    location: -0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (2,3,7)
 With weight: 4
 pt[3]:    location:  0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (4,3,7)
 With weight: 4
 pt[4]:    location: -0.25  0.25  1.75
+   is located on boundary: 0
    idx:     (3,4,7)
 With weight: 4
 pt[5]:    location: -0.25 -0.25  2.25
+   is located on boundary: 0
    idx:     (3,3,8)
 With weight: 2.66667
 pt[6]:    location: -0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (2,2,7)
-With weight: 1.04632e-15
+With weight: 1.70108e-15
 
 On point:    location:  0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (4,3,7)
 pt[0]:    location:  0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (4,3,7)
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (4,2,7)
 With weight: 4
 pt[2]:    location: -0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (3,3,7)
 With weight: 4
 pt[3]:    location:  0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (5,3,7)
 With weight: 4
 pt[4]:    location: 0.25 0.25 1.75
+   is located on boundary: 0
    idx:     (4,4,7)
 With weight: 4
 pt[5]:    location:  0.25 -0.25  2.25
+   is located on boundary: 0
    idx:     (4,3,8)
 With weight: 2.66667
 pt[6]:    location:  0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (5,2,7)
-With weight: 8.54259e-16
+With weight: 1.65992e-15
 
 On point:    location:  0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (5,3,7)
 pt[0]:    location:  0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (5,3,7)
 With weight: -19.2941
 pt[1]:    location:  0.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (5,2,7)
 With weight: 4
 pt[2]:    location:  0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (4,3,7)
 With weight: 4
 pt[3]:    location:  1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (6,3,7)
 With weight: 2.11765
 pt[4]:    location: 0.75 0.25 1.75
+   is located on boundary: 0
    idx:     (5,4,7)
 With weight: 4
 pt[5]:    location:  0.75 -0.25  2.25
+   is located on boundary: 0
    idx:     (5,3,8)
 With weight: 3.29412
 pt[6]:    location:  1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (6,3,6)
 With weight: 1.88235
 
 On point:    location:  1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (6,3,7)
 pt[0]:    location:  1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (6,3,7)
 With weight: -24
 pt[1]:    location:  1.25 -0.25  1.25
+   is located on boundary: 0
    idx:     (6,3,6)
 With weight: 4
 pt[2]:    location:  1.25 -0.75  1.75
+   is located on boundary: 0
    idx:     (6,2,7)
 With weight: 4
 pt[3]:    location:  0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (5,3,7)
 With weight: 4
 pt[4]:    location:  1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (7,3,7)
 With weight: 4
 pt[5]:    location: 1.25 0.25 1.75
+   is located on boundary: 0
    idx:     (6,4,7)
 With weight: 4
 pt[6]:    location:  1.25 -0.25  2.25
+   is located on boundary: 0
    idx:     (6,3,8)
 With weight: 4
 
 On point:    location:  1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (7,3,7)
 pt[0]:    location:  1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (7,3,7)
 With weight: -24
 pt[1]:    location:  1.75 -0.25  1.25
+   is located on boundary: 0
    idx:     (7,3,6)
 With weight: 4
 pt[2]:    location:  1.75 -0.75  1.75
+   is located on boundary: 0
    idx:     (7,2,7)
 With weight: 4
 pt[3]:    location:  1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (6,3,7)
 With weight: 4
 pt[4]:    location:  2.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (8,3,7)
 With weight: 4
 pt[5]:    location: 1.75 0.25 1.75
+   is located on boundary: 0
    idx:     (7,4,7)
 With weight: 4
 pt[6]:    location:  1.75 -0.25  2.25
+   is located on boundary: 0
    idx:     (7,3,8)
 With weight: 4
 
 On point:    location: -1.75  0.25  1.75
+   is located on boundary: 0
    idx:     (0,4,7)
 pt[0]:    location: -1.75  0.25  1.75
+   is located on boundary: 0
    idx:     (0,4,7)
 With weight: -24
 pt[1]:    location: -1.75  0.25  1.25
+   is located on boundary: 0
    idx:     (0,4,6)
 With weight: 4
 pt[2]:    location: -1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (0,3,7)
 With weight: 4
 pt[3]:    location: -2.25  0.25  1.75
+   is located on boundary: 0
    idx:     (-1,4,7)
 With weight: 4
 pt[4]:    location: -1.25  0.25  1.75
+   is located on boundary: 0
    idx:     (1,4,7)
 With weight: 4
 pt[5]:    location: -1.75  0.75  1.75
+   is located on boundary: 0
    idx:     (0,5,7)
 With weight: 4
 pt[6]:    location: -1.75  0.25  2.25
+   is located on boundary: 0
    idx:     (0,4,8)
 With weight: 4
 
 On point:    location: -1.25  0.25  1.75
+   is located on boundary: 0
    idx:     (1,4,7)
 pt[0]:    location: -1.25  0.25  1.75
+   is located on boundary: 0
    idx:     (1,4,7)
 With weight: -24
 pt[1]:    location: -1.25  0.25  1.25
+   is located on boundary: 0
    idx:     (1,4,6)
 With weight: 4
 pt[2]:    location: -1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (1,3,7)
 With weight: 4
 pt[3]:    location: -1.75  0.25  1.75
+   is located on boundary: 0
    idx:     (0,4,7)
 With weight: 4
 pt[4]:    location: -0.75  0.25  1.75
+   is located on boundary: 0
    idx:     (2,4,7)
 With weight: 4
 pt[5]:    location: -1.25  0.75  1.75
+   is located on boundary: 0
    idx:     (1,5,7)
 With weight: 4
 pt[6]:    location: -1.25  0.25  2.25
+   is located on boundary: 0
    idx:     (1,4,8)
 With weight: 4
 
 On point:    location: -0.75  0.25  1.75
+   is located on boundary: 0
    idx:     (2,4,7)
 pt[0]:    location: -0.75  0.25  1.75
+   is located on boundary: 0
    idx:     (2,4,7)
 With weight: -19.2941
 pt[1]:    location: -0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (2,3,7)
 With weight: 4
 pt[2]:    location: -1.25  0.25  1.75
+   is located on boundary: 0
    idx:     (1,4,7)
 With weight: 2.11765
 pt[3]:    location: -0.25  0.25  1.75
+   is located on boundary: 0
    idx:     (3,4,7)
 With weight: 4
 pt[4]:    location: -0.75  0.75  1.75
+   is located on boundary: 0
    idx:     (2,5,7)
 With weight: 4
 pt[5]:    location: -0.75  0.25  2.25
+   is located on boundary: 0
    idx:     (2,4,8)
 With weight: 3.29412
 pt[6]:    location: -1.25  0.25  1.25
+   is located on boundary: 0
    idx:     (1,4,6)
 With weight: 1.88235
 
 On point:    location: -0.25  0.25  1.75
+   is located on boundary: 0
    idx:     (3,4,7)
 pt[0]:    location: -0.25  0.25  1.75
+   is located on boundary: 0
    idx:     (3,4,7)
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (3,3,7)
 With weight: 4
 pt[2]:    location: -0.75  0.25  1.75
+   is located on boundary: 0
    idx:     (2,4,7)
 With weight: 4
 pt[3]:    location: 0.25 0.25 1.75
+   is located on boundary: 0
    idx:     (4,4,7)
 With weight: 4
 pt[4]:    location: -0.25  0.75  1.75
+   is located on boundary: 0
    idx:     (3,5,7)
 With weight: 4
 pt[5]:    location: -0.25  0.25  2.25
+   is located on boundary: 0
    idx:     (3,4,8)
 With weight: 2.66667
 pt[6]:    location: -0.75  0.75  1.75
+   is located on boundary: 0
    idx:     (2,5,7)
-With weight: 1.12863e-15
+With weight: -5.76172e-16
 
 On point:    location: 0.25 0.25 1.75
+   is located on boundary: 0
    idx:     (4,4,7)
 pt[0]:    location: 0.25 0.25 1.75
+   is located on boundary: 0
    idx:     (4,4,7)
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (4,3,7)
 With weight: 4
 pt[2]:    location: -0.25  0.25  1.75
+   is located on boundary: 0
    idx:     (3,4,7)
 With weight: 4
 pt[3]:    location: 0.75 0.25 1.75
+   is located on boundary: 0
    idx:     (5,4,7)
 With weight: 4
 pt[4]:    location: 0.25 0.75 1.75
+   is located on boundary: 0
    idx:     (4,5,7)
 With weight: 4
 pt[5]:    location: 0.25 0.25 2.25
+   is located on boundary: 0
    idx:     (4,4,8)
 With weight: 2.66667
 pt[6]:    location: 0.75 0.75 1.75
+   is located on boundary: 0
    idx:     (5,5,7)
-With weight: -1.10003e-15
+With weight: -0
 
 On point:    location: 0.75 0.25 1.75
+   is located on boundary: 0
    idx:     (5,4,7)
 pt[0]:    location: 0.75 0.25 1.75
+   is located on boundary: 0
    idx:     (5,4,7)
 With weight: -19.2941
 pt[1]:    location:  0.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (5,3,7)
 With weight: 4
 pt[2]:    location: 0.25 0.25 1.75
+   is located on boundary: 0
    idx:     (4,4,7)
 With weight: 4
 pt[3]:    location: 1.25 0.25 1.75
+   is located on boundary: 0
    idx:     (6,4,7)
 With weight: 2.11765
 pt[4]:    location: 0.75 0.75 1.75
+   is located on boundary: 0
    idx:     (5,5,7)
 With weight: 4
 pt[5]:    location: 0.75 0.25 2.25
+   is located on boundary: 0
    idx:     (5,4,8)
 With weight: 3.29412
 pt[6]:    location: 1.25 0.25 1.25
+   is located on boundary: 0
    idx:     (6,4,6)
 With weight: 1.88235
 
 On point:    location: 1.25 0.25 1.75
+   is located on boundary: 0
    idx:     (6,4,7)
 pt[0]:    location: 1.25 0.25 1.75
+   is located on boundary: 0
    idx:     (6,4,7)
 With weight: -24
 pt[1]:    location: 1.25 0.25 1.25
+   is located on boundary: 0
    idx:     (6,4,6)
 With weight: 4
 pt[2]:    location:  1.25 -0.25  1.75
+   is located on boundary: 0
    idx:     (6,3,7)
 With weight: 4
 pt[3]:    location: 0.75 0.25 1.75
+   is located on boundary: 0
    idx:     (5,4,7)
 With weight: 4
 pt[4]:    location: 1.75 0.25 1.75
+   is located on boundary: 0
    idx:     (7,4,7)
 With weight: 4
 pt[5]:    location: 1.25 0.75 1.75
+   is located on boundary: 0
    idx:     (6,5,7)
 With weight: 4
 pt[6]:    location: 1.25 0.25 2.25
+   is located on boundary: 0
    idx:     (6,4,8)
 With weight: 4
 
 On point:    location: 1.75 0.25 1.75
+   is located on boundary: 0
    idx:     (7,4,7)
 pt[0]:    location: 1.75 0.25 1.75
+   is located on boundary: 0
    idx:     (7,4,7)
 With weight: -24
 pt[1]:    location: 1.75 0.25 1.25
+   is located on boundary: 0
    idx:     (7,4,6)
 With weight: 4
 pt[2]:    location:  1.75 -0.25  1.75
+   is located on boundary: 0
    idx:     (7,3,7)
 With weight: 4
 pt[3]:    location: 1.25 0.25 1.75
+   is located on boundary: 0
    idx:     (6,4,7)
 With weight: 4
 pt[4]:    location: 2.25 0.25 1.75
+   is located on boundary: 0
    idx:     (8,4,7)
 With weight: 4
 pt[5]:    location: 1.75 0.75 1.75
+   is located on boundary: 0
    idx:     (7,5,7)
 With weight: 4
 pt[6]:    location: 1.75 0.25 2.25
+   is located on boundary: 0
    idx:     (7,4,8)
 With weight: 4
 
 On point:    location: -1.75  0.75  1.75
+   is located on boundary: 0
    idx:     (0,5,7)
 pt[0]:    location: -1.75  0.75  1.75
+   is located on boundary: 0
    idx:     (0,5,7)
 With weight: -24
 pt[1]:    location: -1.75  0.75  1.25
+   is located on boundary: 0
    idx:     (0,5,6)
 With weight: 4
 pt[2]:    location: -1.75  0.25  1.75
+   is located on boundary: 0
    idx:     (0,4,7)
 With weight: 4
 pt[3]:    location: -2.25  0.75  1.75
+   is located on boundary: 0
    idx:     (-1,5,7)
 With weight: 4
 pt[4]:    location: -1.25  0.75  1.75
+   is located on boundary: 0
    idx:     (1,5,7)
 With weight: 4
 pt[5]:    location: -1.75  1.25  1.75
+   is located on boundary: 0
    idx:     (0,6,7)
 With weight: 4
 pt[6]:    location: -1.75  0.75  2.25
+   is located on boundary: 0
    idx:     (0,5,8)
 With weight: 4
 
 On point:    location: -1.25  0.75  1.75
+   is located on boundary: 0
    idx:     (1,5,7)
 pt[0]:    location: -1.25  0.75  1.75
+   is located on boundary: 0
    idx:     (1,5,7)
 With weight: -24
 pt[1]:    location: -1.25  0.75  1.25
+   is located on boundary: 0
    idx:     (1,5,6)
 With weight: 4
 pt[2]:    location: -1.25  0.25  1.75
+   is located on boundary: 0
    idx:     (1,4,7)
 With weight: 4
 pt[3]:    location: -1.75  0.75  1.75
+   is located on boundary: 0
    idx:     (0,5,7)
 With weight: 4
 pt[4]:    location: -0.75  0.75  1.75
+   is located on boundary: 0
    idx:     (2,5,7)
 With weight: 4
 pt[5]:    location: -1.25  1.25  1.75
+   is located on boundary: 0
    idx:     (1,6,7)
 With weight: 4
 pt[6]:    location: -1.25  0.75  2.25
+   is located on boundary: 0
    idx:     (1,5,8)
 With weight: 4
 
 On point:    location: -0.75  0.75  1.75
+   is located on boundary: 0
    idx:     (2,5,7)
 pt[0]:    location: -0.75  0.75  1.75
+   is located on boundary: 0
    idx:     (2,5,7)
 With weight: -19.2941
 pt[1]:    location: -0.75  0.25  1.75
+   is located on boundary: 0
    idx:     (2,4,7)
 With weight: 4
 pt[2]:    location: -1.25  0.75  1.75
+   is located on boundary: 0
    idx:     (1,5,7)
 With weight: 4
 pt[3]:    location: -0.25  0.75  1.75
+   is located on boundary: 0
    idx:     (3,5,7)
 With weight: 4
 pt[4]:    location: -0.75  1.25  1.75
+   is located on boundary: 0
    idx:     (2,6,7)
 With weight: 2.11765
 pt[5]:    location: -0.75  0.75  2.25
+   is located on boundary: 0
    idx:     (2,5,8)
 With weight: 3.29412
 pt[6]:    location: -0.75  1.25  1.25
+   is located on boundary: 0
    idx:     (2,6,6)
 With weight: 1.88235
 
 On point:    location: -0.25  0.75  1.75
+   is located on boundary: 0
    idx:     (3,5,7)
 pt[0]:    location: -0.25  0.75  1.75
+   is located on boundary: 0
    idx:     (3,5,7)
 With weight: -19.2941
 pt[1]:    location: -0.25  0.25  1.75
+   is located on boundary: 0
    idx:     (3,4,7)
 With weight: 4
 pt[2]:    location: -0.75  0.75  1.75
+   is located on boundary: 0
    idx:     (2,5,7)
 With weight: 4
 pt[3]:    location: 0.25 0.75 1.75
+   is located on boundary: 0
    idx:     (4,5,7)
 With weight: 4
 pt[4]:    location: -0.25  1.25  1.75
+   is located on boundary: 0
    idx:     (3,6,7)
 With weight: 2.11765
 pt[5]:    location: -0.25  0.75  2.25
+   is located on boundary: 0
    idx:     (3,5,8)
 With weight: 3.29412
 pt[6]:    location: -0.25  1.25  1.25
+   is located on boundary: 0
    idx:     (3,6,6)
 With weight: 1.88235
 
 On point:    location: 0.25 0.75 1.75
+   is located on boundary: 0
    idx:     (4,5,7)
 pt[0]:    location: 0.25 0.75 1.75
+   is located on boundary: 0
    idx:     (4,5,7)
 With weight: -19.2941
 pt[1]:    location: 0.25 0.25 1.75
+   is located on boundary: 0
    idx:     (4,4,7)
 With weight: 4
 pt[2]:    location: -0.25  0.75  1.75
+   is located on boundary: 0
    idx:     (3,5,7)
 With weight: 4
 pt[3]:    location: 0.75 0.75 1.75
+   is located on boundary: 0
    idx:     (5,5,7)
 With weight: 4
 pt[4]:    location: 0.25 1.25 1.75
+   is located on boundary: 0
    idx:     (4,6,7)
 With weight: 2.11765
 pt[5]:    location: 0.25 0.75 2.25
+   is located on boundary: 0
    idx:     (4,5,8)
 With weight: 3.29412
 pt[6]:    location: 0.25 1.25 1.25
+   is located on boundary: 0
    idx:     (4,6,6)
 With weight: 1.88235
 
 On point:    location: 0.75 0.75 1.75
+   is located on boundary: 0
    idx:     (5,5,7)
 pt[0]:    location: 0.75 0.75 1.75
+   is located on boundary: 0
    idx:     (5,5,7)
 With weight: -19.2941
 pt[1]:    location: 0.75 0.25 1.75
+   is located on boundary: 0
    idx:     (5,4,7)
 With weight: 4
 pt[2]:    location: 0.25 0.75 1.75
+   is located on boundary: 0
    idx:     (4,5,7)
 With weight: 4
 pt[3]:    location: 1.25 0.75 1.75
+   is located on boundary: 0
    idx:     (6,5,7)
 With weight: 4
 pt[4]:    location: 0.75 1.25 1.75
+   is located on boundary: 0
    idx:     (5,6,7)
 With weight: 2.11765
 pt[5]:    location: 0.75 0.75 2.25
+   is located on boundary: 0
    idx:     (5,5,8)
 With weight: 3.29412
 pt[6]:    location: 0.75 1.25 1.25
+   is located on boundary: 0
    idx:     (5,6,6)
 With weight: 1.88235
 
 On point:    location: 1.25 0.75 1.75
+   is located on boundary: 0
    idx:     (6,5,7)
 pt[0]:    location: 1.25 0.75 1.75
+   is located on boundary: 0
    idx:     (6,5,7)
 With weight: -24
 pt[1]:    location: 1.25 0.75 1.25
+   is located on boundary: 0
    idx:     (6,5,6)
 With weight: 4
 pt[2]:    location: 1.25 0.25 1.75
+   is located on boundary: 0
    idx:     (6,4,7)
 With weight: 4
 pt[3]:    location: 0.75 0.75 1.75
+   is located on boundary: 0
    idx:     (5,5,7)
 With weight: 4
 pt[4]:    location: 1.75 0.75 1.75
+   is located on boundary: 0
    idx:     (7,5,7)
 With weight: 4
 pt[5]:    location: 1.25 1.25 1.75
+   is located on boundary: 0
    idx:     (6,6,7)
 With weight: 4
 pt[6]:    location: 1.25 0.75 2.25
+   is located on boundary: 0
    idx:     (6,5,8)
 With weight: 4
 
 On point:    location: 1.75 0.75 1.75
+   is located on boundary: 0
    idx:     (7,5,7)
 pt[0]:    location: 1.75 0.75 1.75
+   is located on boundary: 0
    idx:     (7,5,7)
 With weight: -24
 pt[1]:    location: 1.75 0.75 1.25
+   is located on boundary: 0
    idx:     (7,5,6)
 With weight: 4
 pt[2]:    location: 1.75 0.25 1.75
+   is located on boundary: 0
    idx:     (7,4,7)
 With weight: 4
 pt[3]:    location: 1.25 0.75 1.75
+   is located on boundary: 0
    idx:     (6,5,7)
 With weight: 4
 pt[4]:    location: 2.25 0.75 1.75
+   is located on boundary: 0
    idx:     (8,5,7)
 With weight: 4
 pt[5]:    location: 1.75 1.25 1.75
+   is located on boundary: 0
    idx:     (7,6,7)
 With weight: 4
 pt[6]:    location: 1.75 0.75 2.25
+   is located on boundary: 0
    idx:     (7,5,8)
 With weight: 4
 
 On point:    location: -1.75  1.25  1.75
+   is located on boundary: 0
    idx:     (0,6,7)
 pt[0]:    location: -1.75  1.25  1.75
+   is located on boundary: 0
    idx:     (0,6,7)
 With weight: -24
 pt[1]:    location: -1.75  1.25  1.25
+   is located on boundary: 0
    idx:     (0,6,6)
 With weight: 4
 pt[2]:    location: -1.75  0.75  1.75
+   is located on boundary: 0
    idx:     (0,5,7)
 With weight: 4
 pt[3]:    location: -2.25  1.25  1.75
+   is located on boundary: 0
    idx:     (-1,6,7)
 With weight: 4
 pt[4]:    location: -1.25  1.25  1.75
+   is located on boundary: 0
    idx:     (1,6,7)
 With weight: 4
 pt[5]:    location: -1.75  1.75  1.75
+   is located on boundary: 0
    idx:     (0,7,7)
 With weight: 4
 pt[6]:    location: -1.75  1.25  2.25
+   is located on boundary: 0
    idx:     (0,6,8)
 With weight: 4
 
 On point:    location: -1.25  1.25  1.75
+   is located on boundary: 0
    idx:     (1,6,7)
 pt[0]:    location: -1.25  1.25  1.75
+   is located on boundary: 0
    idx:     (1,6,7)
 With weight: -24
 pt[1]:    location: -1.25  1.25  1.25
+   is located on boundary: 0
    idx:     (1,6,6)
 With weight: 4
 pt[2]:    location: -1.25  0.75  1.75
+   is located on boundary: 0
    idx:     (1,5,7)
 With weight: 4
 pt[3]:    location: -1.75  1.25  1.75
+   is located on boundary: 0
    idx:     (0,6,7)
 With weight: 4
 pt[4]:    location: -0.75  1.25  1.75
+   is located on boundary: 0
    idx:     (2,6,7)
 With weight: 4
 pt[5]:    location: -1.25  1.75  1.75
+   is located on boundary: 0
    idx:     (1,7,7)
 With weight: 4
 pt[6]:    location: -1.25  1.25  2.25
+   is located on boundary: 0
    idx:     (1,6,8)
 With weight: 4
 
 On point:    location: -0.75  1.25  1.75
+   is located on boundary: 0
    idx:     (2,6,7)
 pt[0]:    location: -0.75  1.25  1.75
+   is located on boundary: 0
    idx:     (2,6,7)
 With weight: -24
 pt[1]:    location: -0.75  1.25  1.25
+   is located on boundary: 0
    idx:     (2,6,6)
 With weight: 4
 pt[2]:    location: -0.75  0.75  1.75
+   is located on boundary: 0
    idx:     (2,5,7)
 With weight: 4
 pt[3]:    location: -1.25  1.25  1.75
+   is located on boundary: 0
    idx:     (1,6,7)
 With weight: 4
 pt[4]:    location: -0.25  1.25  1.75
+   is located on boundary: 0
    idx:     (3,6,7)
 With weight: 4
 pt[5]:    location: -0.75  1.75  1.75
+   is located on boundary: 0
    idx:     (2,7,7)
 With weight: 4
 pt[6]:    location: -0.75  1.25  2.25
+   is located on boundary: 0
    idx:     (2,6,8)
 With weight: 4
 
 On point:    location: -0.25  1.25  1.75
+   is located on boundary: 0
    idx:     (3,6,7)
 pt[0]:    location: -0.25  1.25  1.75
+   is located on boundary: 0
    idx:     (3,6,7)
 With weight: -24
 pt[1]:    location: -0.25  1.25  1.25
+   is located on boundary: 0
    idx:     (3,6,6)
 With weight: 4
 pt[2]:    location: -0.25  0.75  1.75
+   is located on boundary: 0
    idx:     (3,5,7)
 With weight: 4
 pt[3]:    location: -0.75  1.25  1.75
+   is located on boundary: 0
    idx:     (2,6,7)
 With weight: 4
 pt[4]:    location: 0.25 1.25 1.75
+   is located on boundary: 0
    idx:     (4,6,7)
 With weight: 4
 pt[5]:    location: -0.25  1.75  1.75
+   is located on boundary: 0
    idx:     (3,7,7)
 With weight: 4
 pt[6]:    location: -0.25  1.25  2.25
+   is located on boundary: 0
    idx:     (3,6,8)
 With weight: 4
 
 On point:    location: 0.25 1.25 1.75
+   is located on boundary: 0
    idx:     (4,6,7)
 pt[0]:    location: 0.25 1.25 1.75
+   is located on boundary: 0
    idx:     (4,6,7)
 With weight: -24
 pt[1]:    location: 0.25 1.25 1.25
+   is located on boundary: 0
    idx:     (4,6,6)
 With weight: 4
 pt[2]:    location: 0.25 0.75 1.75
+   is located on boundary: 0
    idx:     (4,5,7)
 With weight: 4
 pt[3]:    location: -0.25  1.25  1.75
+   is located on boundary: 0
    idx:     (3,6,7)
 With weight: 4
 pt[4]:    location: 0.75 1.25 1.75
+   is located on boundary: 0
    idx:     (5,6,7)
 With weight: 4
 pt[5]:    location: 0.25 1.75 1.75
+   is located on boundary: 0
    idx:     (4,7,7)
 With weight: 4
 pt[6]:    location: 0.25 1.25 2.25
+   is located on boundary: 0
    idx:     (4,6,8)
 With weight: 4
 
 On point:    location: 0.75 1.25 1.75
+   is located on boundary: 0
    idx:     (5,6,7)
 pt[0]:    location: 0.75 1.25 1.75
+   is located on boundary: 0
    idx:     (5,6,7)
 With weight: -24
 pt[1]:    location: 0.75 1.25 1.25
+   is located on boundary: 0
    idx:     (5,6,6)
 With weight: 4
 pt[2]:    location: 0.75 0.75 1.75
+   is located on boundary: 0
    idx:     (5,5,7)
 With weight: 4
 pt[3]:    location: 0.25 1.25 1.75
+   is located on boundary: 0
    idx:     (4,6,7)
 With weight: 4
 pt[4]:    location: 1.25 1.25 1.75
+   is located on boundary: 0
    idx:     (6,6,7)
 With weight: 4
 pt[5]:    location: 0.75 1.75 1.75
+   is located on boundary: 0
    idx:     (5,7,7)
 With weight: 4
 pt[6]:    location: 0.75 1.25 2.25
+   is located on boundary: 0
    idx:     (5,6,8)
 With weight: 4
 
 On point:    location: 1.25 1.25 1.75
+   is located on boundary: 0
    idx:     (6,6,7)
 pt[0]:    location: 1.25 1.25 1.75
+   is located on boundary: 0
    idx:     (6,6,7)
 With weight: -24
 pt[1]:    location: 1.25 1.25 1.25
+   is located on boundary: 0
    idx:     (6,6,6)
 With weight: 4
 pt[2]:    location: 1.25 0.75 1.75
+   is located on boundary: 0
    idx:     (6,5,7)
 With weight: 4
 pt[3]:    location: 0.75 1.25 1.75
+   is located on boundary: 0
    idx:     (5,6,7)
 With weight: 4
 pt[4]:    location: 1.75 1.25 1.75
+   is located on boundary: 0
    idx:     (7,6,7)
 With weight: 4
 pt[5]:    location: 1.25 1.75 1.75
+   is located on boundary: 0
    idx:     (6,7,7)
 With weight: 4
 pt[6]:    location: 1.25 1.25 2.25
+   is located on boundary: 0
    idx:     (6,6,8)
 With weight: 4
 
 On point:    location: 1.75 1.25 1.75
+   is located on boundary: 0
    idx:     (7,6,7)
 pt[0]:    location: 1.75 1.25 1.75
+   is located on boundary: 0
    idx:     (7,6,7)
 With weight: -24
 pt[1]:    location: 1.75 1.25 1.25
+   is located on boundary: 0
    idx:     (7,6,6)
 With weight: 4
 pt[2]:    location: 1.75 0.75 1.75
+   is located on boundary: 0
    idx:     (7,5,7)
 With weight: 4
 pt[3]:    location: 1.25 1.25 1.75
+   is located on boundary: 0
    idx:     (6,6,7)
 With weight: 4
 pt[4]:    location: 2.25 1.25 1.75
+   is located on boundary: 0
    idx:     (8,6,7)
 With weight: 4
 pt[5]:    location: 1.75 1.75 1.75
+   is located on boundary: 0
    idx:     (7,7,7)
 With weight: 4
 pt[6]:    location: 1.75 1.25 2.25
+   is located on boundary: 0
    idx:     (7,6,8)
 With weight: 4
 
 On point:    location: -1.75  1.75  1.75
+   is located on boundary: 0
    idx:     (0,7,7)
 pt[0]:    location: -1.75  1.75  1.75
+   is located on boundary: 0
    idx:     (0,7,7)
 With weight: -24
 pt[1]:    location: -1.75  1.75  1.25
+   is located on boundary: 0
    idx:     (0,7,6)
 With weight: 4
 pt[2]:    location: -1.75  1.25  1.75
+   is located on boundary: 0
    idx:     (0,6,7)
 With weight: 4
 pt[3]:    location: -2.25  1.75  1.75
+   is located on boundary: 0
    idx:     (-1,7,7)
 With weight: 4
 pt[4]:    location: -1.25  1.75  1.75
+   is located on boundary: 0
    idx:     (1,7,7)
 With weight: 4
 pt[5]:    location: -1.75  2.25  1.75
+   is located on boundary: 0
    idx:     (0,8,7)
 With weight: 4
 pt[6]:    location: -1.75  1.75  2.25
+   is located on boundary: 0
    idx:     (0,7,8)
 With weight: 4
 
 On point:    location: -1.25  1.75  1.75
+   is located on boundary: 0
    idx:     (1,7,7)
 pt[0]:    location: -1.25  1.75  1.75
+   is located on boundary: 0
    idx:     (1,7,7)
 With weight: -24
 pt[1]:    location: -1.25  1.75  1.25
+   is located on boundary: 0
    idx:     (1,7,6)
 With weight: 4
 pt[2]:    location: -1.25  1.25  1.75
+   is located on boundary: 0
    idx:     (1,6,7)
 With weight: 4
 pt[3]:    location: -1.75  1.75  1.75
+   is located on boundary: 0
    idx:     (0,7,7)
 With weight: 4
 pt[4]:    location: -0.75  1.75  1.75
+   is located on boundary: 0
    idx:     (2,7,7)
 With weight: 4
 pt[5]:    location: -1.25  2.25  1.75
+   is located on boundary: 0
    idx:     (1,8,7)
 With weight: 4
 pt[6]:    location: -1.25  1.75  2.25
+   is located on boundary: 0
    idx:     (1,7,8)
 With weight: 4
 
 On point:    location: -0.75  1.75  1.75
+   is located on boundary: 0
    idx:     (2,7,7)
 pt[0]:    location: -0.75  1.75  1.75
+   is located on boundary: 0
    idx:     (2,7,7)
 With weight: -24
 pt[1]:    location: -0.75  1.75  1.25
+   is located on boundary: 0
    idx:     (2,7,6)
 With weight: 4
 pt[2]:    location: -0.75  1.25  1.75
+   is located on boundary: 0
    idx:     (2,6,7)
 With weight: 4
 pt[3]:    location: -1.25  1.75  1.75
+   is located on boundary: 0
    idx:     (1,7,7)
 With weight: 4
 pt[4]:    location: -0.25  1.75  1.75
+   is located on boundary: 0
    idx:     (3,7,7)
 With weight: 4
 pt[5]:    location: -0.75  2.25  1.75
+   is located on boundary: 0
    idx:     (2,8,7)
 With weight: 4
 pt[6]:    location: -0.75  1.75  2.25
+   is located on boundary: 0
    idx:     (2,7,8)
 With weight: 4
 
 On point:    location: -0.25  1.75  1.75
+   is located on boundary: 0
    idx:     (3,7,7)
 pt[0]:    location: -0.25  1.75  1.75
+   is located on boundary: 0
    idx:     (3,7,7)
 With weight: -24
 pt[1]:    location: -0.25  1.75  1.25
+   is located on boundary: 0
    idx:     (3,7,6)
 With weight: 4
 pt[2]:    location: -0.25  1.25  1.75
+   is located on boundary: 0
    idx:     (3,6,7)
 With weight: 4
 pt[3]:    location: -0.75  1.75  1.75
+   is located on boundary: 0
    idx:     (2,7,7)
 With weight: 4
 pt[4]:    location: 0.25 1.75 1.75
+   is located on boundary: 0
    idx:     (4,7,7)
 With weight: 4
 pt[5]:    location: -0.25  2.25  1.75
+   is located on boundary: 0
    idx:     (3,8,7)
 With weight: 4
 pt[6]:    location: -0.25  1.75  2.25
+   is located on boundary: 0
    idx:     (3,7,8)
 With weight: 4
 
 On point:    location: 0.25 1.75 1.75
+   is located on boundary: 0
    idx:     (4,7,7)
 pt[0]:    location: 0.25 1.75 1.75
+   is located on boundary: 0
    idx:     (4,7,7)
 With weight: -24
 pt[1]:    location: 0.25 1.75 1.25
+   is located on boundary: 0
    idx:     (4,7,6)
 With weight: 4
 pt[2]:    location: 0.25 1.25 1.75
+   is located on boundary: 0
    idx:     (4,6,7)
 With weight: 4
 pt[3]:    location: -0.25  1.75  1.75
+   is located on boundary: 0
    idx:     (3,7,7)
 With weight: 4
 pt[4]:    location: 0.75 1.75 1.75
+   is located on boundary: 0
    idx:     (5,7,7)
 With weight: 4
 pt[5]:    location: 0.25 2.25 1.75
+   is located on boundary: 0
    idx:     (4,8,7)
 With weight: 4
 pt[6]:    location: 0.25 1.75 2.25
+   is located on boundary: 0
    idx:     (4,7,8)
 With weight: 4
 
 On point:    location: 0.75 1.75 1.75
+   is located on boundary: 0
    idx:     (5,7,7)
 pt[0]:    location: 0.75 1.75 1.75
+   is located on boundary: 0
    idx:     (5,7,7)
 With weight: -24
 pt[1]:    location: 0.75 1.75 1.25
+   is located on boundary: 0
    idx:     (5,7,6)
 With weight: 4
 pt[2]:    location: 0.75 1.25 1.75
+   is located on boundary: 0
    idx:     (5,6,7)
 With weight: 4
 pt[3]:    location: 0.25 1.75 1.75
+   is located on boundary: 0
    idx:     (4,7,7)
 With weight: 4
 pt[4]:    location: 1.25 1.75 1.75
+   is located on boundary: 0
    idx:     (6,7,7)
 With weight: 4
 pt[5]:    location: 0.75 2.25 1.75
+   is located on boundary: 0
    idx:     (5,8,7)
 With weight: 4
 pt[6]:    location: 0.75 1.75 2.25
+   is located on boundary: 0
    idx:     (5,7,8)
 With weight: 4
 
 On point:    location: 1.25 1.75 1.75
+   is located on boundary: 0
    idx:     (6,7,7)
 pt[0]:    location: 1.25 1.75 1.75
+   is located on boundary: 0
    idx:     (6,7,7)
 With weight: -24
 pt[1]:    location: 1.25 1.75 1.25
+   is located on boundary: 0
    idx:     (6,7,6)
 With weight: 4
 pt[2]:    location: 1.25 1.25 1.75
+   is located on boundary: 0
    idx:     (6,6,7)
 With weight: 4
 pt[3]:    location: 0.75 1.75 1.75
+   is located on boundary: 0
    idx:     (5,7,7)
 With weight: 4
 pt[4]:    location: 1.75 1.75 1.75
+   is located on boundary: 0
    idx:     (7,7,7)
 With weight: 4
 pt[5]:    location: 1.25 2.25 1.75
+   is located on boundary: 0
    idx:     (6,8,7)
 With weight: 4
 pt[6]:    location: 1.25 1.75 2.25
+   is located on boundary: 0
    idx:     (6,7,8)
 With weight: 4
 
 On point:    location: 1.75 1.75 1.75
+   is located on boundary: 0
    idx:     (7,7,7)
 pt[0]:    location: 1.75 1.75 1.75
+   is located on boundary: 0
    idx:     (7,7,7)
 With weight: -24
 pt[1]:    location: 1.75 1.75 1.25
+   is located on boundary: 0
    idx:     (7,7,6)
 With weight: 4
 pt[2]:    location: 1.75 1.25 1.75
+   is located on boundary: 0
    idx:     (7,6,7)
 With weight: 4
 pt[3]:    location: 1.25 1.75 1.75
+   is located on boundary: 0
    idx:     (6,7,7)
 With weight: 4
 pt[4]:    location: 2.25 1.75 1.75
+   is located on boundary: 0
    idx:     (8,7,7)
 With weight: 4
 pt[5]:    location: 1.75 2.25 1.75
+   is located on boundary: 0
    idx:     (7,8,7)
 With weight: 4
 pt[6]:    location: 1.75 1.75 2.25
+   is located on boundary: 0
    idx:     (7,7,8)
 With weight: 4
 


### PR DESCRIPTION
`RBFFDWeights` computes weights at all points. We need a more general interface that stores weights so we can compute different stencils at different points.