### PR TITLE
Add ghost points

### DIFF
--- a/include/ADS/FDPoint.h
+++ b/include/ADS/FDPoint.h
@@ -5,9 +5,9 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
-#include <ADS/GhostPoints.h>
-
 #include <ibtk/config.h>
+
+#include <ADS/GhostPoints.h>
 
 #include <ibtk/ibtk_utilities.h>
 
@@ -28,15 +28,15 @@ namespace ADS
 /*
  * Helper function to get the physical location of a patch and cell index pair.
  */
-inline IBTK::VectorNd getPt(const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch, const SAMRAI::pdat::CellIndex<NDIM>& idx)
+inline IBTK::VectorNd
+getPt(const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch, const SAMRAI::pdat::CellIndex<NDIM>& idx)
 {
     SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
     const double* const dx = pgeom->getDx();
     const double* const xlow = pgeom->getXLower();
     const SAMRAI::hier::Index<NDIM>& idx_low = patch->getBox().lower();
     IBTK::VectorNd x;
-    for (int d = 0; d < NDIM; ++d)
-        x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
+    for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
     return x;
 }
 
@@ -146,13 +146,13 @@ public:
     {
         out << "   location: " << pt.d_pt.transpose() << "\n";
         if (pt.isNode())
-            out << "   node id: " << pt.d_node->id() << "\n";
+            out << "   node id: " << pt.d_node->id();
         else if (pt.isIdx())
-            out << "   idx:     " << pt.d_idx << "\n";
+            out << "   idx:     " << pt.d_idx;
         else if (pt.isGhost())
-            out << "   ghost id: " << pt.d_ghost_point->getId() << "\n";
+            out << "   ghost id: " << pt.d_ghost_point->getId();
         else
-            out << "   pt is neither node nor index\n";
+            out << "   pt is neither node nor index";
         return out;
     }
 
@@ -293,5 +293,5 @@ private:
     std::array<int, NDIM - 1> d_max_idx;
     bool d_empty = false;
 };
-} // namespace
+} // namespace ADS
 #endif

--- a/include/ADS/FDPoint.h
+++ b/include/ADS/FDPoint.h
@@ -5,6 +5,8 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include <ADS/GhostPoints.h>
+
 #include <ibtk/config.h>
 
 #include <ibtk/ibtk_utilities.h>
@@ -20,6 +22,24 @@
 
 #include <string>
 #include <vector>
+
+namespace ADS
+{
+/*
+ * Helper function to get the physical location of a patch and cell index pair.
+ */
+inline IBTK::VectorNd getPt(const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch, const SAMRAI::pdat::CellIndex<NDIM>& idx)
+{
+    SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
+    const double* const dx = pgeom->getDx();
+    const double* const xlow = pgeom->getXLower();
+    const SAMRAI::hier::Index<NDIM>& idx_low = patch->getBox().lower();
+    IBTK::VectorNd x;
+    for (int d = 0; d < NDIM; ++d)
+        x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
+    return x;
+}
+
 /*!
  * The class FDPoint generalizes the notion of a degree of freedom. It is either a SAMRAI index, a libMesh Node, or a
  * boundary Node. This allows for efficient caching of points, and quick lookups of individual points.
@@ -46,7 +66,15 @@ public:
     /*!
      * \brief Constructor that makes either a libmesh or boundary point.
      */
-    FDPoint(const IBTK::VectorNd& pt, libMesh::Node* node, bool bdry_pt) : d_pt(pt), d_node(node), d_bdry_pt(bdry_pt)
+    FDPoint(const IBTK::VectorNd& pt, libMesh::Node* node) : d_pt(pt), d_node(node)
+    {
+        // intentionally blank
+    }
+
+    /*!
+     * \brief Constructor that makes a ghost point.
+     */
+    FDPoint(GhostPoint* ghost_point) : d_pt(ghost_point->getX()), d_ghost_point(ghost_point)
     {
         // intentionally blank
     }
@@ -72,7 +100,7 @@ public:
     }
 
     /*!
-     * \brief Compute the distance between a point and the cached point.
+     * \brief Compute the distance between a point and this FDPoint.
      */
     double dist(const IBTK::VectorNd& x) const
     {
@@ -80,7 +108,7 @@ public:
     }
 
     /*!
-     * \brief Compute the distance between another cached point and this point.
+     * \brief Compute the distance between another FDPoint and this FDPoint.
      */
     double dist(const FDPoint& pt) const
     {
@@ -88,9 +116,17 @@ public:
     }
 
     /*!
-     * \brief Return a copy of the ith point of the point.
+     * \brief Return a copy of the ith point of the FDPoint.
      */
     double operator()(const size_t i) const
+    {
+        return d_pt(i);
+    }
+
+    /*!
+     * \brief Return a reference of the ith point of the FDPoint.
+     */
+    double& operator()(const size_t i)
     {
         return d_pt(i);
     }
@@ -109,13 +145,14 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const FDPoint& pt)
     {
         out << "   location: " << pt.d_pt.transpose() << "\n";
-        out << "   is located on boundary: " << pt.d_bdry_pt << "\n";
         if (pt.isNode())
-            out << "   node id: " << pt.d_node->id();
-        else if (!pt.isEmpty())
-            out << "   idx:     " << pt.d_idx;
+            out << "   node id: " << pt.d_node->id() << "\n";
+        else if (pt.isIdx())
+            out << "   idx:     " << pt.d_idx << "\n";
+        else if (pt.isGhost())
+            out << "   ghost id: " << pt.d_ghost_point->getId() << "\n";
         else
-            out << "   pt is neither node nor index";
+            out << "   pt is neither node nor index\n";
         return out;
     }
 
@@ -126,11 +163,15 @@ public:
     {
         if (lhs.isNode() && rhs.isNode())
         {
-            return (lhs.d_bdry_pt == rhs.d_bdry_pt) && (lhs.d_node == rhs.d_node);
+            return lhs.d_node == rhs.d_node;
         }
         else if (lhs.isIdx() && rhs.isIdx())
         {
             return lhs.d_idx == rhs.d_idx;
+        }
+        else if (lhs.isGhost() && rhs.isGhost())
+        {
+            return lhs.d_ghost_point == rhs.d_ghost_point;
         }
         else
         {
@@ -142,7 +183,7 @@ public:
      * \brief Comparison operator. Used for compatibility with STL containers.
      *
      * The order of indexes is as follows:
-     * SAMRAI < libMesh < bdry < empty
+     * SAMRAI < libMesh < ghost < empty
      */
     friend bool operator<(const FDPoint& lhs, const FDPoint& rhs)
     {
@@ -165,14 +206,14 @@ public:
         {
             if (rhs.isEmpty()) return true;
             if (rhs.isIdx()) return false;
-            if (rhs.isBdry()) return true;
+            if (rhs.isGhost()) return true;
             return lhs.d_node->id() < rhs.d_node->id();
         }
-        else if (lhs.isBdry())
+        else if (lhs.isGhost())
         {
             if (rhs.isEmpty()) return true;
-            if (!rhs.isBdry()) return false;
-            return lhs.d_node->id() < rhs.d_node->id();
+            if (!rhs.isGhost()) return false;
+            return lhs.d_ghost_point->getId() < rhs.d_ghost_point->getId();
         }
         return false;
     }
@@ -190,7 +231,7 @@ public:
      */
     bool isNode() const
     {
-        return !d_bdry_pt && d_node != nullptr;
+        return d_node != nullptr;
     }
 
     /*!
@@ -198,15 +239,15 @@ public:
      */
     bool isIdx() const
     {
-        return !isNode() && !isEmpty();
+        return !isNode() && !isGhost() && !isEmpty();
     }
 
     /*!
      * \brief Is this point a boundary node?
      */
-    bool isBdry() const
+    bool isGhost() const
     {
-        return d_bdry_pt;
+        return d_ghost_point != nullptr;
     }
 
     /*!
@@ -214,7 +255,7 @@ public:
      */
     const libMesh::Node* const getNode() const
     {
-        if (d_bdry_pt || !isNode()) TBOX_ERROR("Not at a node\n");
+        if (!isNode()) TBOX_ERROR("Not at a node\n");
         return d_node;
     }
 
@@ -223,9 +264,17 @@ public:
      */
     const SAMRAI::pdat::CellIndex<NDIM>& getIndex() const
     {
-        if (isNode()) TBOX_ERROR("At at node\n");
-        if (d_empty) TBOX_ERROR("Not a point\n");
+        if (!isIdx()) TBOX_ERROR("Not an index\n");
         return d_idx;
+    }
+
+    /*!
+     * \brief Get the ghost point
+     */
+    const GhostPoint* getGhostPoint() const
+    {
+        if (!isGhost()) TBOX_ERROR("Not a ghost point!\n");
+        return d_ghost_point;
     }
 
     /*!
@@ -239,9 +288,10 @@ public:
 private:
     IBTK::VectorNd d_pt;
     libMesh::Node* d_node = nullptr;
+    GhostPoint* d_ghost_point = nullptr;
     SAMRAI::pdat::CellIndex<NDIM> d_idx;
     std::array<int, NDIM - 1> d_max_idx;
     bool d_empty = false;
-    bool d_bdry_pt = false;
 };
+} // namespace
 #endif

--- a/include/ADS/GhostPoints.h
+++ b/include/ADS/GhostPoints.h
@@ -13,13 +13,13 @@
 namespace ADS
 {
 /*!
- * GhostPoint is a point that lies outside the physical domain. Ghost points can contain knowledge of the "parent node" which is either the libMesh node or SAMRAI index that this ghost point is generated from.
+ * GhostPoint is a point that lies outside the physical domain. Ghost points can contain knowledge of the "parent node"
+ * which is either the libMesh node or SAMRAI index that this ghost point is generated from.
  */
 class GhostPoint
 {
 public:
-    GhostPoint(const IBTK::VectorNd& x, size_t id)
-: d_x(x), d_id(id)
+    GhostPoint(const IBTK::VectorNd& x, size_t id) : d_x(x), d_id(id)
     {
         // intentionally blank
     }
@@ -45,7 +45,6 @@ private:
     IBTK::VectorNd d_x;
     size_t d_id;
 };
-
 
 /*!
  * GhostPoints maintains a list of ghost nodes useful in solving RBF-FD discretized linear systems. It maintains ghost

--- a/include/ADS/GhostPoints.h
+++ b/include/ADS/GhostPoints.h
@@ -13,6 +13,41 @@
 namespace ADS
 {
 /*!
+ * GhostPoint is a point that lies outside the physical domain. Ghost points can contain knowledge of the "parent node" which is either the libMesh node or SAMRAI index that this ghost point is generated from.
+ */
+class GhostPoint
+{
+public:
+    GhostPoint(const IBTK::VectorNd& x, size_t id)
+: d_x(x), d_id(id)
+    {
+        // intentionally blank
+    }
+
+    ~GhostPoint() = default;
+
+    inline const IBTK::VectorNd& getX() const
+    {
+        return d_x;
+    }
+
+    inline size_t getId() const
+    {
+        return d_id;
+    }
+
+    inline double operator()(unsigned int d) const
+    {
+        return d_x(d);
+    }
+
+private:
+    IBTK::VectorNd d_x;
+    size_t d_id;
+};
+
+
+/*!
  * GhostPoints maintains a list of ghost nodes useful in solving RBF-FD discretized linear systems. It maintains ghost
  * points outside the SAMRAI domain as well as inside the finite element mesh. The width of ghost cells is given in the
  * constructor.
@@ -86,7 +121,7 @@ public:
     /*!
      * \brief Return the Eulerian ghost nodes.
      */
-    inline const std::vector<std::unique_ptr<libMesh::Node>>& getEulerianGhostNodes()
+    inline const std::vector<GhostPoint>& getEulerianGhostNodes()
     {
         return d_eul_ghost_nodes;
     };
@@ -94,7 +129,7 @@ public:
     /*!
      * \brief Return the Lagrangian ghost nodes.
      */
-    inline const std::vector<std::unique_ptr<libMesh::Node>>& getLagrangianGhostNodes()
+    inline const std::vector<GhostPoint>& getLagrangianGhostNodes()
     {
         return d_lag_ghost_nodes;
     };
@@ -121,7 +156,7 @@ protected:
 
     std::shared_ptr<FEMeshPartitioner> d_fe_mesh_partitioner;
 
-    std::vector<std::unique_ptr<libMesh::Node>> d_eul_ghost_nodes, d_lag_ghost_nodes;
+    std::vector<GhostPoint> d_eul_ghost_nodes, d_lag_ghost_nodes;
 
     std::string d_normal_sys_name = "normal";
     double d_ds = std::numeric_limits<double>::quiet_NaN();

--- a/src/GlobalIndexing.cpp
+++ b/src/GlobalIndexing.cpp
@@ -144,16 +144,16 @@ GlobalIndexing::setupDOFs()
     std::vector<int> ghost_dofs(tot_ghost_dofs, 0);
     petsc_dofs.resize(tot_ghost_dofs, 0);
     size_t ghost_counter = ghost_offset;
-    const std::vector<std::unique_ptr<Node>>& eul_ghost_nodes = d_ghost_pts->getEulerianGhostNodes();
-    const std::vector<std::unique_ptr<Node>>& lag_ghost_nodes = d_ghost_pts->getLagrangianGhostNodes();
+    const std::vector<GhostPoint>& eul_ghost_nodes = d_ghost_pts->getEulerianGhostNodes();
+    const std::vector<GhostPoint>& lag_ghost_nodes = d_ghost_pts->getLagrangianGhostNodes();
     for (const auto& eul_ghost_node : eul_ghost_nodes)
     {
-        ghost_dofs[ghost_counter] = eul_ghost_node->id();
+        ghost_dofs[ghost_counter] = eul_ghost_node.getId();
         petsc_dofs[ghost_counter++] = counter++;
     }
     for (const auto& lag_ghost_node : lag_ghost_nodes)
     {
-        ghost_dofs[ghost_counter] = lag_ghost_node->id();
+        ghost_dofs[ghost_counter] = lag_ghost_node.getId();
         petsc_dofs[ghost_counter++] = counter++;
     }
 

--- a/src/RBFFDWeightsCache.cpp
+++ b/src/RBFFDWeightsCache.cpp
@@ -173,7 +173,7 @@ RBFFDWeightsCache::sortLagDOFsToCells()
                 dof_map.dof_indices(node, dofs, d);
                 node_pt[d] = (*X_vec)(dofs[0]);
             }
-            pts.push_back(FDPoint(node_pt, node, false));
+            pts.push_back(FDPoint(node_pt, node));
         }
 
         // Now create KD tree
@@ -218,10 +218,10 @@ RBFFDWeightsCache::sortLagDOFsToCells()
             }
             std::vector<int> idx_vec;
             std::vector<double> distance_vec;
-            FDPoint base_pt(node_pt, node, false);
+            FDPoint base_pt(node_pt, node);
             d_base_pt_set[patch.getPointer()].insert(base_pt);
             d_pair_pt_map[patch.getPointer()][base_pt].reserve(d_stencil_size);
-            tree.knnSearch(FDPoint(node_pt, node, false), d_stencil_size, idx_vec, distance_vec);
+            tree.knnSearch(FDPoint(node_pt, node), d_stencil_size, idx_vec, distance_vec);
             // Add these points to the vector
             for (const auto& idx_in_pts : idx_vec)
                 d_pair_pt_map[patch.getPointer()][base_pt].push_back(pts[idx_in_pts]);

--- a/tests/operators/rbf_fd_weights_2d.output
+++ b/tests/operators/rbf_fd_weights_2d.output
@@ -1,4224 +1,4224 @@
 On point:    location: -1.875 -1.875
-   is located on boundary: 0
    idx:     (0,0)
+
 pt[0]:    location: -1.875 -1.875
-   is located on boundary: 0
    idx:     (0,0)
+
 With weight: -64
 pt[1]:    location: -1.875 -2.125
-   is located on boundary: 0
    idx:     (0,-1)
+
 With weight: 16
 pt[2]:    location: -2.125 -1.875
-   is located on boundary: 0
    idx:     (-1,0)
+
 With weight: 16
 pt[3]:    location: -1.625 -1.875
-   is located on boundary: 0
    idx:     (1,0)
+
 With weight: 16
 pt[4]:    location: -1.875 -1.625
-   is located on boundary: 0
    idx:     (0,1)
+
 With weight: 16
 
 On point:    location: -1.625 -1.875
-   is located on boundary: 0
    idx:     (1,0)
+
 pt[0]:    location: -1.625 -1.875
-   is located on boundary: 0
    idx:     (1,0)
+
 With weight: -64
 pt[1]:    location: -1.625 -2.125
-   is located on boundary: 0
    idx:     (1,-1)
+
 With weight: 16
 pt[2]:    location: -1.875 -1.875
-   is located on boundary: 0
    idx:     (0,0)
+
 With weight: 16
 pt[3]:    location: -1.375 -1.875
-   is located on boundary: 0
    idx:     (2,0)
+
 With weight: 16
 pt[4]:    location: -1.625 -1.625
-   is located on boundary: 0
    idx:     (1,1)
+
 With weight: 16
 
 On point:    location: -1.375 -1.875
-   is located on boundary: 0
    idx:     (2,0)
+
 pt[0]:    location: -1.375 -1.875
-   is located on boundary: 0
    idx:     (2,0)
+
 With weight: -64
 pt[1]:    location: -1.375 -2.125
-   is located on boundary: 0
    idx:     (2,-1)
+
 With weight: 16
 pt[2]:    location: -1.625 -1.875
-   is located on boundary: 0
    idx:     (1,0)
+
 With weight: 16
 pt[3]:    location: -1.125 -1.875
-   is located on boundary: 0
    idx:     (3,0)
+
 With weight: 16
 pt[4]:    location: -1.375 -1.625
-   is located on boundary: 0
    idx:     (2,1)
+
 With weight: 16
 
 On point:    location: -1.125 -1.875
-   is located on boundary: 0
    idx:     (3,0)
+
 pt[0]:    location: -1.125 -1.875
-   is located on boundary: 0
    idx:     (3,0)
+
 With weight: -64
 pt[1]:    location: -1.125 -2.125
-   is located on boundary: 0
    idx:     (3,-1)
+
 With weight: 16
 pt[2]:    location: -1.375 -1.875
-   is located on boundary: 0
    idx:     (2,0)
+
 With weight: 16
 pt[3]:    location: -0.875 -1.875
-   is located on boundary: 0
    idx:     (4,0)
+
 With weight: 16
 pt[4]:    location: -1.125 -1.625
-   is located on boundary: 0
    idx:     (3,1)
+
 With weight: 16
 
 On point:    location: -0.875 -1.875
-   is located on boundary: 0
    idx:     (4,0)
+
 pt[0]:    location: -0.875 -1.875
-   is located on boundary: 0
    idx:     (4,0)
+
 With weight: -64
 pt[1]:    location: -0.875 -2.125
-   is located on boundary: 0
    idx:     (4,-1)
+
 With weight: 16
 pt[2]:    location: -1.125 -1.875
-   is located on boundary: 0
    idx:     (3,0)
+
 With weight: 16
 pt[3]:    location: -0.625 -1.875
-   is located on boundary: 0
    idx:     (5,0)
+
 With weight: 16
 pt[4]:    location: -0.875 -1.625
-   is located on boundary: 0
    idx:     (4,1)
+
 With weight: 16
 
 On point:    location: -0.625 -1.875
-   is located on boundary: 0
    idx:     (5,0)
+
 pt[0]:    location: -0.625 -1.875
-   is located on boundary: 0
    idx:     (5,0)
+
 With weight: -64
 pt[1]:    location: -0.625 -2.125
-   is located on boundary: 0
    idx:     (5,-1)
+
 With weight: 16
 pt[2]:    location: -0.875 -1.875
-   is located on boundary: 0
    idx:     (4,0)
+
 With weight: 16
 pt[3]:    location: -0.375 -1.875
-   is located on boundary: 0
    idx:     (6,0)
+
 With weight: 16
 pt[4]:    location: -0.625 -1.625
-   is located on boundary: 0
    idx:     (5,1)
+
 With weight: 16
 
 On point:    location: -0.375 -1.875
-   is located on boundary: 0
    idx:     (6,0)
+
 pt[0]:    location: -0.375 -1.875
-   is located on boundary: 0
    idx:     (6,0)
+
 With weight: -64
 pt[1]:    location: -0.375 -2.125
-   is located on boundary: 0
    idx:     (6,-1)
+
 With weight: 16
 pt[2]:    location: -0.625 -1.875
-   is located on boundary: 0
    idx:     (5,0)
+
 With weight: 16
 pt[3]:    location: -0.125 -1.875
-   is located on boundary: 0
    idx:     (7,0)
+
 With weight: 16
 pt[4]:    location: -0.375 -1.625
-   is located on boundary: 0
    idx:     (6,1)
+
 With weight: 16
 
 On point:    location: -0.125 -1.875
-   is located on boundary: 0
    idx:     (7,0)
+
 pt[0]:    location: -0.125 -1.875
-   is located on boundary: 0
    idx:     (7,0)
+
 With weight: -64
 pt[1]:    location: -0.125 -2.125
-   is located on boundary: 0
    idx:     (7,-1)
+
 With weight: 16
 pt[2]:    location: -0.375 -1.875
-   is located on boundary: 0
    idx:     (6,0)
+
 With weight: 16
 pt[3]:    location:  0.125 -1.875
-   is located on boundary: 0
    idx:     (8,0)
+
 With weight: 16
 pt[4]:    location: -0.125 -1.625
-   is located on boundary: 0
    idx:     (7,1)
+
 With weight: 16
 
 On point:    location:  0.125 -1.875
-   is located on boundary: 0
    idx:     (8,0)
+
 pt[0]:    location:  0.125 -1.875
-   is located on boundary: 0
    idx:     (8,0)
+
 With weight: -64
 pt[1]:    location:  0.125 -2.125
-   is located on boundary: 0
    idx:     (8,-1)
+
 With weight: 16
 pt[2]:    location: -0.125 -1.875
-   is located on boundary: 0
    idx:     (7,0)
+
 With weight: 16
 pt[3]:    location:  0.375 -1.875
-   is located on boundary: 0
    idx:     (9,0)
+
 With weight: 16
 pt[4]:    location:  0.125 -1.625
-   is located on boundary: 0
    idx:     (8,1)
+
 With weight: 16
 
 On point:    location:  0.375 -1.875
-   is located on boundary: 0
    idx:     (9,0)
+
 pt[0]:    location:  0.375 -1.875
-   is located on boundary: 0
    idx:     (9,0)
+
 With weight: -64
 pt[1]:    location:  0.375 -2.125
-   is located on boundary: 0
    idx:     (9,-1)
+
 With weight: 16
 pt[2]:    location:  0.125 -1.875
-   is located on boundary: 0
    idx:     (8,0)
+
 With weight: 16
 pt[3]:    location:  0.625 -1.875
-   is located on boundary: 0
    idx:     (10,0)
+
 With weight: 16
 pt[4]:    location:  0.375 -1.625
-   is located on boundary: 0
    idx:     (9,1)
+
 With weight: 16
 
 On point:    location:  0.625 -1.875
-   is located on boundary: 0
    idx:     (10,0)
+
 pt[0]:    location:  0.625 -1.875
-   is located on boundary: 0
    idx:     (10,0)
+
 With weight: -64
 pt[1]:    location:  0.625 -2.125
-   is located on boundary: 0
    idx:     (10,-1)
+
 With weight: 16
 pt[2]:    location:  0.375 -1.875
-   is located on boundary: 0
    idx:     (9,0)
+
 With weight: 16
 pt[3]:    location:  0.875 -1.875
-   is located on boundary: 0
    idx:     (11,0)
+
 With weight: 16
 pt[4]:    location:  0.625 -1.625
-   is located on boundary: 0
    idx:     (10,1)
+
 With weight: 16
 
 On point:    location:  0.875 -1.875
-   is located on boundary: 0
    idx:     (11,0)
+
 pt[0]:    location:  0.875 -1.875
-   is located on boundary: 0
    idx:     (11,0)
+
 With weight: -64
 pt[1]:    location:  0.875 -2.125
-   is located on boundary: 0
    idx:     (11,-1)
+
 With weight: 16
 pt[2]:    location:  0.625 -1.875
-   is located on boundary: 0
    idx:     (10,0)
+
 With weight: 16
 pt[3]:    location:  1.125 -1.875
-   is located on boundary: 0
    idx:     (12,0)
+
 With weight: 16
 pt[4]:    location:  0.875 -1.625
-   is located on boundary: 0
    idx:     (11,1)
+
 With weight: 16
 
 On point:    location:  1.125 -1.875
-   is located on boundary: 0
    idx:     (12,0)
+
 pt[0]:    location:  1.125 -1.875
-   is located on boundary: 0
    idx:     (12,0)
+
 With weight: -64
 pt[1]:    location:  1.125 -2.125
-   is located on boundary: 0
    idx:     (12,-1)
+
 With weight: 16
 pt[2]:    location:  0.875 -1.875
-   is located on boundary: 0
    idx:     (11,0)
+
 With weight: 16
 pt[3]:    location:  1.375 -1.875
-   is located on boundary: 0
    idx:     (13,0)
+
 With weight: 16
 pt[4]:    location:  1.125 -1.625
-   is located on boundary: 0
    idx:     (12,1)
+
 With weight: 16
 
 On point:    location:  1.375 -1.875
-   is located on boundary: 0
    idx:     (13,0)
+
 pt[0]:    location:  1.375 -1.875
-   is located on boundary: 0
    idx:     (13,0)
+
 With weight: -64
 pt[1]:    location:  1.375 -2.125
-   is located on boundary: 0
    idx:     (13,-1)
+
 With weight: 16
 pt[2]:    location:  1.125 -1.875
-   is located on boundary: 0
    idx:     (12,0)
+
 With weight: 16
 pt[3]:    location:  1.625 -1.875
-   is located on boundary: 0
    idx:     (14,0)
+
 With weight: 16
 pt[4]:    location:  1.375 -1.625
-   is located on boundary: 0
    idx:     (13,1)
+
 With weight: 16
 
 On point:    location:  1.625 -1.875
-   is located on boundary: 0
    idx:     (14,0)
+
 pt[0]:    location:  1.625 -1.875
-   is located on boundary: 0
    idx:     (14,0)
+
 With weight: -64
 pt[1]:    location:  1.625 -2.125
-   is located on boundary: 0
    idx:     (14,-1)
+
 With weight: 16
 pt[2]:    location:  1.375 -1.875
-   is located on boundary: 0
    idx:     (13,0)
+
 With weight: 16
 pt[3]:    location:  1.875 -1.875
-   is located on boundary: 0
    idx:     (15,0)
+
 With weight: 16
 pt[4]:    location:  1.625 -1.625
-   is located on boundary: 0
    idx:     (14,1)
+
 With weight: 16
 
 On point:    location:  1.875 -1.875
-   is located on boundary: 0
    idx:     (15,0)
+
 pt[0]:    location:  1.875 -1.875
-   is located on boundary: 0
    idx:     (15,0)
+
 With weight: -64
 pt[1]:    location:  1.875 -2.125
-   is located on boundary: 0
    idx:     (15,-1)
+
 With weight: 16
 pt[2]:    location:  1.625 -1.875
-   is located on boundary: 0
    idx:     (14,0)
+
 With weight: 16
 pt[3]:    location:  2.125 -1.875
-   is located on boundary: 0
    idx:     (16,0)
+
 With weight: 16
 pt[4]:    location:  1.875 -1.625
-   is located on boundary: 0
    idx:     (15,1)
+
 With weight: 16
 
 On point:    location: -1.875 -1.625
-   is located on boundary: 0
    idx:     (0,1)
+
 pt[0]:    location: -1.875 -1.625
-   is located on boundary: 0
    idx:     (0,1)
+
 With weight: -64
 pt[1]:    location: -1.875 -1.875
-   is located on boundary: 0
    idx:     (0,0)
+
 With weight: 16
 pt[2]:    location: -2.125 -1.625
-   is located on boundary: 0
    idx:     (-1,1)
+
 With weight: 16
 pt[3]:    location: -1.625 -1.625
-   is located on boundary: 0
    idx:     (1,1)
+
 With weight: 16
 pt[4]:    location: -1.875 -1.375
-   is located on boundary: 0
    idx:     (0,2)
+
 With weight: 16
 
 On point:    location: -1.625 -1.625
-   is located on boundary: 0
    idx:     (1,1)
+
 pt[0]:    location: -1.625 -1.625
-   is located on boundary: 0
    idx:     (1,1)
+
 With weight: -64
 pt[1]:    location: -1.625 -1.875
-   is located on boundary: 0
    idx:     (1,0)
+
 With weight: 16
 pt[2]:    location: -1.875 -1.625
-   is located on boundary: 0
    idx:     (0,1)
+
 With weight: 16
 pt[3]:    location: -1.375 -1.625
-   is located on boundary: 0
    idx:     (2,1)
+
 With weight: 16
 pt[4]:    location: -1.625 -1.375
-   is located on boundary: 0
    idx:     (1,2)
+
 With weight: 16
 
 On point:    location: -1.375 -1.625
-   is located on boundary: 0
    idx:     (2,1)
+
 pt[0]:    location: -1.375 -1.625
-   is located on boundary: 0
    idx:     (2,1)
+
 With weight: -64
 pt[1]:    location: -1.375 -1.875
-   is located on boundary: 0
    idx:     (2,0)
+
 With weight: 16
 pt[2]:    location: -1.625 -1.625
-   is located on boundary: 0
    idx:     (1,1)
+
 With weight: 16
 pt[3]:    location: -1.125 -1.625
-   is located on boundary: 0
    idx:     (3,1)
+
 With weight: 16
 pt[4]:    location: -1.375 -1.375
-   is located on boundary: 0
    idx:     (2,2)
+
 With weight: 16
 
 On point:    location: -1.125 -1.625
-   is located on boundary: 0
    idx:     (3,1)
+
 pt[0]:    location: -1.125 -1.625
-   is located on boundary: 0
    idx:     (3,1)
+
 With weight: -64
 pt[1]:    location: -1.125 -1.875
-   is located on boundary: 0
    idx:     (3,0)
+
 With weight: 16
 pt[2]:    location: -1.375 -1.625
-   is located on boundary: 0
    idx:     (2,1)
+
 With weight: 16
 pt[3]:    location: -0.875 -1.625
-   is located on boundary: 0
    idx:     (4,1)
+
 With weight: 16
 pt[4]:    location: -1.125 -1.375
-   is located on boundary: 0
    idx:     (3,2)
+
 With weight: 16
 
 On point:    location: -0.875 -1.625
-   is located on boundary: 0
    idx:     (4,1)
+
 pt[0]:    location: -0.875 -1.625
-   is located on boundary: 0
    idx:     (4,1)
+
 With weight: -64
 pt[1]:    location: -0.875 -1.875
-   is located on boundary: 0
    idx:     (4,0)
+
 With weight: 16
 pt[2]:    location: -1.125 -1.625
-   is located on boundary: 0
    idx:     (3,1)
+
 With weight: 16
 pt[3]:    location: -0.625 -1.625
-   is located on boundary: 0
    idx:     (5,1)
+
 With weight: 16
 pt[4]:    location: -0.875 -1.375
-   is located on boundary: 0
    idx:     (4,2)
+
 With weight: 16
 
 On point:    location: -0.625 -1.625
-   is located on boundary: 0
    idx:     (5,1)
+
 pt[0]:    location: -0.625 -1.625
-   is located on boundary: 0
    idx:     (5,1)
+
 With weight: -64
 pt[1]:    location: -0.625 -1.875
-   is located on boundary: 0
    idx:     (5,0)
+
 With weight: 16
 pt[2]:    location: -0.875 -1.625
-   is located on boundary: 0
    idx:     (4,1)
+
 With weight: 16
 pt[3]:    location: -0.375 -1.625
-   is located on boundary: 0
    idx:     (6,1)
+
 With weight: 16
 pt[4]:    location: -0.625 -1.375
-   is located on boundary: 0
    idx:     (5,2)
+
 With weight: 16
 
 On point:    location: -0.375 -1.625
-   is located on boundary: 0
    idx:     (6,1)
+
 pt[0]:    location: -0.375 -1.625
-   is located on boundary: 0
    idx:     (6,1)
+
 With weight: -64
 pt[1]:    location: -0.375 -1.875
-   is located on boundary: 0
    idx:     (6,0)
+
 With weight: 16
 pt[2]:    location: -0.625 -1.625
-   is located on boundary: 0
    idx:     (5,1)
+
 With weight: 16
 pt[3]:    location: -0.125 -1.625
-   is located on boundary: 0
    idx:     (7,1)
+
 With weight: 16
 pt[4]:    location: -0.375 -1.375
-   is located on boundary: 0
    idx:     (6,2)
+
 With weight: 16
 
 On point:    location: -0.125 -1.625
-   is located on boundary: 0
    idx:     (7,1)
+
 pt[0]:    location: -0.125 -1.625
-   is located on boundary: 0
    idx:     (7,1)
+
 With weight: -64
 pt[1]:    location: -0.125 -1.875
-   is located on boundary: 0
    idx:     (7,0)
+
 With weight: 16
 pt[2]:    location: -0.375 -1.625
-   is located on boundary: 0
    idx:     (6,1)
+
 With weight: 16
 pt[3]:    location:  0.125 -1.625
-   is located on boundary: 0
    idx:     (8,1)
+
 With weight: 16
 pt[4]:    location: -0.125 -1.375
-   is located on boundary: 0
    idx:     (7,2)
+
 With weight: 16
 
 On point:    location:  0.125 -1.625
-   is located on boundary: 0
    idx:     (8,1)
+
 pt[0]:    location:  0.125 -1.625
-   is located on boundary: 0
    idx:     (8,1)
+
 With weight: -64
 pt[1]:    location:  0.125 -1.875
-   is located on boundary: 0
    idx:     (8,0)
+
 With weight: 16
 pt[2]:    location: -0.125 -1.625
-   is located on boundary: 0
    idx:     (7,1)
+
 With weight: 16
 pt[3]:    location:  0.375 -1.625
-   is located on boundary: 0
    idx:     (9,1)
+
 With weight: 16
 pt[4]:    location:  0.125 -1.375
-   is located on boundary: 0
    idx:     (8,2)
+
 With weight: 16
 
 On point:    location:  0.375 -1.625
-   is located on boundary: 0
    idx:     (9,1)
+
 pt[0]:    location:  0.375 -1.625
-   is located on boundary: 0
    idx:     (9,1)
+
 With weight: -64
 pt[1]:    location:  0.375 -1.875
-   is located on boundary: 0
    idx:     (9,0)
+
 With weight: 16
 pt[2]:    location:  0.125 -1.625
-   is located on boundary: 0
    idx:     (8,1)
+
 With weight: 16
 pt[3]:    location:  0.625 -1.625
-   is located on boundary: 0
    idx:     (10,1)
+
 With weight: 16
 pt[4]:    location:  0.375 -1.375
-   is located on boundary: 0
    idx:     (9,2)
+
 With weight: 16
 
 On point:    location:  0.625 -1.625
-   is located on boundary: 0
    idx:     (10,1)
+
 pt[0]:    location:  0.625 -1.625
-   is located on boundary: 0
    idx:     (10,1)
+
 With weight: -64
 pt[1]:    location:  0.625 -1.875
-   is located on boundary: 0
    idx:     (10,0)
+
 With weight: 16
 pt[2]:    location:  0.375 -1.625
-   is located on boundary: 0
    idx:     (9,1)
+
 With weight: 16
 pt[3]:    location:  0.875 -1.625
-   is located on boundary: 0
    idx:     (11,1)
+
 With weight: 16
 pt[4]:    location:  0.625 -1.375
-   is located on boundary: 0
    idx:     (10,2)
+
 With weight: 16
 
 On point:    location:  0.875 -1.625
-   is located on boundary: 0
    idx:     (11,1)
+
 pt[0]:    location:  0.875 -1.625
-   is located on boundary: 0
    idx:     (11,1)
+
 With weight: -64
 pt[1]:    location:  0.875 -1.875
-   is located on boundary: 0
    idx:     (11,0)
+
 With weight: 16
 pt[2]:    location:  0.625 -1.625
-   is located on boundary: 0
    idx:     (10,1)
+
 With weight: 16
 pt[3]:    location:  1.125 -1.625
-   is located on boundary: 0
    idx:     (12,1)
+
 With weight: 16
 pt[4]:    location:  0.875 -1.375
-   is located on boundary: 0
    idx:     (11,2)
+
 With weight: 16
 
 On point:    location:  1.125 -1.625
-   is located on boundary: 0
    idx:     (12,1)
+
 pt[0]:    location:  1.125 -1.625
-   is located on boundary: 0
    idx:     (12,1)
+
 With weight: -64
 pt[1]:    location:  1.125 -1.875
-   is located on boundary: 0
    idx:     (12,0)
+
 With weight: 16
 pt[2]:    location:  0.875 -1.625
-   is located on boundary: 0
    idx:     (11,1)
+
 With weight: 16
 pt[3]:    location:  1.375 -1.625
-   is located on boundary: 0
    idx:     (13,1)
+
 With weight: 16
 pt[4]:    location:  1.125 -1.375
-   is located on boundary: 0
    idx:     (12,2)
+
 With weight: 16
 
 On point:    location:  1.375 -1.625
-   is located on boundary: 0
    idx:     (13,1)
+
 pt[0]:    location:  1.375 -1.625
-   is located on boundary: 0
    idx:     (13,1)
+
 With weight: -64
 pt[1]:    location:  1.375 -1.875
-   is located on boundary: 0
    idx:     (13,0)
+
 With weight: 16
 pt[2]:    location:  1.125 -1.625
-   is located on boundary: 0
    idx:     (12,1)
+
 With weight: 16
 pt[3]:    location:  1.625 -1.625
-   is located on boundary: 0
    idx:     (14,1)
+
 With weight: 16
 pt[4]:    location:  1.375 -1.375
-   is located on boundary: 0
    idx:     (13,2)
+
 With weight: 16
 
 On point:    location:  1.625 -1.625
-   is located on boundary: 0
    idx:     (14,1)
+
 pt[0]:    location:  1.625 -1.625
-   is located on boundary: 0
    idx:     (14,1)
+
 With weight: -64
 pt[1]:    location:  1.625 -1.875
-   is located on boundary: 0
    idx:     (14,0)
+
 With weight: 16
 pt[2]:    location:  1.375 -1.625
-   is located on boundary: 0
    idx:     (13,1)
+
 With weight: 16
 pt[3]:    location:  1.875 -1.625
-   is located on boundary: 0
    idx:     (15,1)
+
 With weight: 16
 pt[4]:    location:  1.625 -1.375
-   is located on boundary: 0
    idx:     (14,2)
+
 With weight: 16
 
 On point:    location:  1.875 -1.625
-   is located on boundary: 0
    idx:     (15,1)
+
 pt[0]:    location:  1.875 -1.625
-   is located on boundary: 0
    idx:     (15,1)
+
 With weight: -64
 pt[1]:    location:  1.875 -1.875
-   is located on boundary: 0
    idx:     (15,0)
+
 With weight: 16
 pt[2]:    location:  1.625 -1.625
-   is located on boundary: 0
    idx:     (14,1)
+
 With weight: 16
 pt[3]:    location:  2.125 -1.625
-   is located on boundary: 0
    idx:     (16,1)
+
 With weight: 16
 pt[4]:    location:  1.875 -1.375
-   is located on boundary: 0
    idx:     (15,2)
+
 With weight: 16
 
 On point:    location: -1.875 -1.375
-   is located on boundary: 0
    idx:     (0,2)
+
 pt[0]:    location: -1.875 -1.375
-   is located on boundary: 0
    idx:     (0,2)
+
 With weight: -64
 pt[1]:    location: -1.875 -1.625
-   is located on boundary: 0
    idx:     (0,1)
+
 With weight: 16
 pt[2]:    location: -2.125 -1.375
-   is located on boundary: 0
    idx:     (-1,2)
+
 With weight: 16
 pt[3]:    location: -1.625 -1.375
-   is located on boundary: 0
    idx:     (1,2)
+
 With weight: 16
 pt[4]:    location: -1.875 -1.125
-   is located on boundary: 0
    idx:     (0,3)
+
 With weight: 16
 
 On point:    location: -1.625 -1.375
-   is located on boundary: 0
    idx:     (1,2)
+
 pt[0]:    location: -1.625 -1.375
-   is located on boundary: 0
    idx:     (1,2)
+
 With weight: -64
 pt[1]:    location: -1.625 -1.625
-   is located on boundary: 0
    idx:     (1,1)
+
 With weight: 16
 pt[2]:    location: -1.875 -1.375
-   is located on boundary: 0
    idx:     (0,2)
+
 With weight: 16
 pt[3]:    location: -1.375 -1.375
-   is located on boundary: 0
    idx:     (2,2)
+
 With weight: 16
 pt[4]:    location: -1.625 -1.125
-   is located on boundary: 0
    idx:     (1,3)
+
 With weight: 16
 
 On point:    location: -1.375 -1.375
-   is located on boundary: 0
    idx:     (2,2)
+
 pt[0]:    location: -1.375 -1.375
-   is located on boundary: 0
    idx:     (2,2)
+
 With weight: -64
 pt[1]:    location: -1.375 -1.625
-   is located on boundary: 0
    idx:     (2,1)
+
 With weight: 16
 pt[2]:    location: -1.625 -1.375
-   is located on boundary: 0
    idx:     (1,2)
+
 With weight: 16
 pt[3]:    location: -1.125 -1.375
-   is located on boundary: 0
    idx:     (3,2)
+
 With weight: 16
 pt[4]:    location: -1.375 -1.125
-   is located on boundary: 0
    idx:     (2,3)
+
 With weight: 16
 
 On point:    location: -1.125 -1.375
-   is located on boundary: 0
    idx:     (3,2)
+
 pt[0]:    location: -1.125 -1.375
-   is located on boundary: 0
    idx:     (3,2)
+
 With weight: -64
 pt[1]:    location: -1.125 -1.625
-   is located on boundary: 0
    idx:     (3,1)
+
 With weight: 16
 pt[2]:    location: -1.375 -1.375
-   is located on boundary: 0
    idx:     (2,2)
+
 With weight: 16
 pt[3]:    location: -0.875 -1.375
-   is located on boundary: 0
    idx:     (4,2)
+
 With weight: 16
 pt[4]:    location: -1.125 -1.125
-   is located on boundary: 0
    idx:     (3,3)
+
 With weight: 16
 
 On point:    location: -0.875 -1.375
-   is located on boundary: 0
    idx:     (4,2)
+
 pt[0]:    location: -0.875 -1.375
-   is located on boundary: 0
    idx:     (4,2)
+
 With weight: -64
 pt[1]:    location: -0.875 -1.625
-   is located on boundary: 0
    idx:     (4,1)
+
 With weight: 16
 pt[2]:    location: -1.125 -1.375
-   is located on boundary: 0
    idx:     (3,2)
+
 With weight: 16
 pt[3]:    location: -0.625 -1.375
-   is located on boundary: 0
    idx:     (5,2)
+
 With weight: 16
 pt[4]:    location: -0.875 -1.125
-   is located on boundary: 0
    idx:     (4,3)
+
 With weight: 16
 
 On point:    location: -0.625 -1.375
-   is located on boundary: 0
    idx:     (5,2)
+
 pt[0]:    location: -0.625 -1.375
-   is located on boundary: 0
    idx:     (5,2)
+
 With weight: -64
 pt[1]:    location: -0.625 -1.625
-   is located on boundary: 0
    idx:     (5,1)
+
 With weight: 16
 pt[2]:    location: -0.875 -1.375
-   is located on boundary: 0
    idx:     (4,2)
+
 With weight: 16
 pt[3]:    location: -0.375 -1.375
-   is located on boundary: 0
    idx:     (6,2)
+
 With weight: 16
 pt[4]:    location: -0.625 -1.125
-   is located on boundary: 0
    idx:     (5,3)
+
 With weight: 16
 
 On point:    location: -0.375 -1.375
-   is located on boundary: 0
    idx:     (6,2)
+
 pt[0]:    location: -0.375 -1.375
-   is located on boundary: 0
    idx:     (6,2)
+
 With weight: -42.6667
 pt[1]:    location: -0.375 -1.625
-   is located on boundary: 0
    idx:     (6,1)
+
 With weight: 10.6667
 pt[2]:    location: -0.625 -1.375
-   is located on boundary: 0
    idx:     (5,2)
+
 With weight: 16
 pt[3]:    location: -0.125 -1.375
-   is located on boundary: 0
    idx:     (7,2)
+
 With weight: 16
 pt[4]:    location: -0.625 -1.625
-   is located on boundary: 0
    idx:     (5,1)
+
 With weight: -2.03742e-15
 
 On point:    location: -0.125 -1.375
-   is located on boundary: 0
    idx:     (7,2)
+
 pt[0]:    location: -0.125 -1.375
-   is located on boundary: 0
    idx:     (7,2)
+
 With weight: -42.6667
 pt[1]:    location: -0.125 -1.625
-   is located on boundary: 0
    idx:     (7,1)
+
 With weight: 10.6667
 pt[2]:    location: -0.375 -1.375
-   is located on boundary: 0
    idx:     (6,2)
+
 With weight: 16
 pt[3]:    location:  0.125 -1.375
-   is located on boundary: 0
    idx:     (8,2)
+
 With weight: 16
 pt[4]:    location: -0.375 -1.625
-   is located on boundary: 0
    idx:     (6,1)
+
 With weight: -2.03742e-15
 
 On point:    location:  0.125 -1.375
-   is located on boundary: 0
    idx:     (8,2)
+
 pt[0]:    location:  0.125 -1.375
-   is located on boundary: 0
    idx:     (8,2)
+
 With weight: -42.6667
 pt[1]:    location:  0.125 -1.625
-   is located on boundary: 0
    idx:     (8,1)
+
 With weight: 10.6667
 pt[2]:    location: -0.125 -1.375
-   is located on boundary: 0
    idx:     (7,2)
+
 With weight: 16
 pt[3]:    location:  0.375 -1.375
-   is located on boundary: 0
    idx:     (9,2)
+
 With weight: 16
 pt[4]:    location: -0.125 -1.625
-   is located on boundary: 0
    idx:     (7,1)
+
 With weight: -2.03742e-15
 
 On point:    location:  0.375 -1.375
-   is located on boundary: 0
    idx:     (9,2)
+
 pt[0]:    location:  0.375 -1.375
-   is located on boundary: 0
    idx:     (9,2)
+
 With weight: -42.6667
 pt[1]:    location:  0.375 -1.625
-   is located on boundary: 0
    idx:     (9,1)
+
 With weight: 10.6667
 pt[2]:    location:  0.125 -1.375
-   is located on boundary: 0
    idx:     (8,2)
+
 With weight: 16
 pt[3]:    location:  0.625 -1.375
-   is located on boundary: 0
    idx:     (10,2)
+
 With weight: 16
 pt[4]:    location:  0.125 -1.625
-   is located on boundary: 0
    idx:     (8,1)
+
 With weight: -2.03742e-15
 
 On point:    location:  0.625 -1.375
-   is located on boundary: 0
    idx:     (10,2)
+
 pt[0]:    location:  0.625 -1.375
-   is located on boundary: 0
    idx:     (10,2)
+
 With weight: -64
 pt[1]:    location:  0.625 -1.625
-   is located on boundary: 0
    idx:     (10,1)
+
 With weight: 16
 pt[2]:    location:  0.375 -1.375
-   is located on boundary: 0
    idx:     (9,2)
+
 With weight: 16
 pt[3]:    location:  0.875 -1.375
-   is located on boundary: 0
    idx:     (11,2)
+
 With weight: 16
 pt[4]:    location:  0.625 -1.125
-   is located on boundary: 0
    idx:     (10,3)
+
 With weight: 16
 
 On point:    location:  0.875 -1.375
-   is located on boundary: 0
    idx:     (11,2)
+
 pt[0]:    location:  0.875 -1.375
-   is located on boundary: 0
    idx:     (11,2)
+
 With weight: -64
 pt[1]:    location:  0.875 -1.625
-   is located on boundary: 0
    idx:     (11,1)
+
 With weight: 16
 pt[2]:    location:  0.625 -1.375
-   is located on boundary: 0
    idx:     (10,2)
+
 With weight: 16
 pt[3]:    location:  1.125 -1.375
-   is located on boundary: 0
    idx:     (12,2)
+
 With weight: 16
 pt[4]:    location:  0.875 -1.125
-   is located on boundary: 0
    idx:     (11,3)
+
 With weight: 16
 
 On point:    location:  1.125 -1.375
-   is located on boundary: 0
    idx:     (12,2)
+
 pt[0]:    location:  1.125 -1.375
-   is located on boundary: 0
    idx:     (12,2)
+
 With weight: -64
 pt[1]:    location:  1.125 -1.625
-   is located on boundary: 0
    idx:     (12,1)
+
 With weight: 16
 pt[2]:    location:  0.875 -1.375
-   is located on boundary: 0
    idx:     (11,2)
+
 With weight: 16
 pt[3]:    location:  1.375 -1.375
-   is located on boundary: 0
    idx:     (13,2)
+
 With weight: 16
 pt[4]:    location:  1.125 -1.125
-   is located on boundary: 0
    idx:     (12,3)
+
 With weight: 16
 
 On point:    location:  1.375 -1.375
-   is located on boundary: 0
    idx:     (13,2)
+
 pt[0]:    location:  1.375 -1.375
-   is located on boundary: 0
    idx:     (13,2)
+
 With weight: -64
 pt[1]:    location:  1.375 -1.625
-   is located on boundary: 0
    idx:     (13,1)
+
 With weight: 16
 pt[2]:    location:  1.125 -1.375
-   is located on boundary: 0
    idx:     (12,2)
+
 With weight: 16
 pt[3]:    location:  1.625 -1.375
-   is located on boundary: 0
    idx:     (14,2)
+
 With weight: 16
 pt[4]:    location:  1.375 -1.125
-   is located on boundary: 0
    idx:     (13,3)
+
 With weight: 16
 
 On point:    location:  1.625 -1.375
-   is located on boundary: 0
    idx:     (14,2)
+
 pt[0]:    location:  1.625 -1.375
-   is located on boundary: 0
    idx:     (14,2)
+
 With weight: -64
 pt[1]:    location:  1.625 -1.625
-   is located on boundary: 0
    idx:     (14,1)
+
 With weight: 16
 pt[2]:    location:  1.375 -1.375
-   is located on boundary: 0
    idx:     (13,2)
+
 With weight: 16
 pt[3]:    location:  1.875 -1.375
-   is located on boundary: 0
    idx:     (15,2)
+
 With weight: 16
 pt[4]:    location:  1.625 -1.125
-   is located on boundary: 0
    idx:     (14,3)
+
 With weight: 16
 
 On point:    location:  1.875 -1.375
-   is located on boundary: 0
    idx:     (15,2)
+
 pt[0]:    location:  1.875 -1.375
-   is located on boundary: 0
    idx:     (15,2)
+
 With weight: -64
 pt[1]:    location:  1.875 -1.625
-   is located on boundary: 0
    idx:     (15,1)
+
 With weight: 16
 pt[2]:    location:  1.625 -1.375
-   is located on boundary: 0
    idx:     (14,2)
+
 With weight: 16
 pt[3]:    location:  2.125 -1.375
-   is located on boundary: 0
    idx:     (16,2)
+
 With weight: 16
 pt[4]:    location:  1.875 -1.125
-   is located on boundary: 0
    idx:     (15,3)
+
 With weight: 16
 
 On point:    location: -1.875 -1.125
-   is located on boundary: 0
    idx:     (0,3)
+
 pt[0]:    location: -1.875 -1.125
-   is located on boundary: 0
    idx:     (0,3)
+
 With weight: -64
 pt[1]:    location: -1.875 -1.375
-   is located on boundary: 0
    idx:     (0,2)
+
 With weight: 16
 pt[2]:    location: -2.125 -1.125
-   is located on boundary: 0
    idx:     (-1,3)
+
 With weight: 16
 pt[3]:    location: -1.625 -1.125
-   is located on boundary: 0
    idx:     (1,3)
+
 With weight: 16
 pt[4]:    location: -1.875 -0.875
-   is located on boundary: 0
    idx:     (0,4)
+
 With weight: 16
 
 On point:    location: -1.625 -1.125
-   is located on boundary: 0
    idx:     (1,3)
+
 pt[0]:    location: -1.625 -1.125
-   is located on boundary: 0
    idx:     (1,3)
+
 With weight: -64
 pt[1]:    location: -1.625 -1.375
-   is located on boundary: 0
    idx:     (1,2)
+
 With weight: 16
 pt[2]:    location: -1.875 -1.125
-   is located on boundary: 0
    idx:     (0,3)
+
 With weight: 16
 pt[3]:    location: -1.375 -1.125
-   is located on boundary: 0
    idx:     (2,3)
+
 With weight: 16
 pt[4]:    location: -1.625 -0.875
-   is located on boundary: 0
    idx:     (1,4)
+
 With weight: 16
 
 On point:    location: -1.375 -1.125
-   is located on boundary: 0
    idx:     (2,3)
+
 pt[0]:    location: -1.375 -1.125
-   is located on boundary: 0
    idx:     (2,3)
+
 With weight: -64
 pt[1]:    location: -1.375 -1.375
-   is located on boundary: 0
    idx:     (2,2)
+
 With weight: 16
 pt[2]:    location: -1.625 -1.125
-   is located on boundary: 0
    idx:     (1,3)
+
 With weight: 16
 pt[3]:    location: -1.125 -1.125
-   is located on boundary: 0
    idx:     (3,3)
+
 With weight: 16
 pt[4]:    location: -1.375 -0.875
-   is located on boundary: 0
    idx:     (2,4)
+
 With weight: 16
 
 On point:    location: -1.125 -1.125
-   is located on boundary: 0
    idx:     (3,3)
+
 pt[0]:    location: -1.125 -1.125
-   is located on boundary: 0
    idx:     (3,3)
+
 With weight: -64
 pt[1]:    location: -1.125 -1.375
-   is located on boundary: 0
    idx:     (3,2)
+
 With weight: 16
 pt[2]:    location: -1.375 -1.125
-   is located on boundary: 0
    idx:     (2,3)
+
 With weight: 16
 pt[3]:    location: -0.875 -1.125
-   is located on boundary: 0
    idx:     (4,3)
+
 With weight: 16
 pt[4]:    location: -1.125 -0.875
-   is located on boundary: 0
    idx:     (3,4)
+
 With weight: 16
 
 On point:    location: -0.875 -1.125
-   is located on boundary: 0
    idx:     (4,3)
+
 pt[0]:    location: -0.875 -1.125
-   is located on boundary: 0
    idx:     (4,3)
+
 With weight: -45.1765
 pt[1]:    location: -0.875 -1.375
-   is located on boundary: 0
    idx:     (4,2)
+
 With weight: 13.1765
 pt[2]:    location: -1.125 -1.125
-   is located on boundary: 0
    idx:     (3,3)
+
 With weight: 8.47059
 pt[3]:    location: -0.625 -1.125
-   is located on boundary: 0
    idx:     (5,3)
+
 With weight: 16
 pt[4]:    location: -1.125 -0.875
-   is located on boundary: 0
    idx:     (3,4)
+
 With weight: 7.52941
 
 On point:    location: -0.625 -1.125
-   is located on boundary: 0
    idx:     (5,3)
+
 pt[0]:    location: -0.625 -1.125
-   is located on boundary: 0
    idx:     (5,3)
+
 With weight: -21.3333
 pt[1]:    location: -0.625 -1.375
-   is located on boundary: 0
    idx:     (5,2)
+
 With weight: 1.2191e-15
 pt[2]:    location: -0.875 -1.125
-   is located on boundary: 0
    idx:     (4,3)
+
 With weight: 10.6667
 pt[3]:    location: -0.875 -1.375
-   is located on boundary: 0
    idx:     (4,2)
+
 With weight: 2.66667
 pt[4]:    location: -0.375 -1.375
-   is located on boundary: 0
    idx:     (6,2)
+
 With weight: 8
 
 On point:    location:  0.625 -1.125
-   is located on boundary: 0
    idx:     (10,3)
+
 pt[0]:    location:  0.625 -1.125
-   is located on boundary: 0
    idx:     (10,3)
+
 With weight: -21.3333
 pt[1]:    location:  0.625 -1.375
-   is located on boundary: 0
    idx:     (10,2)
+
 With weight: 2.81359e-15
 pt[2]:    location:  0.875 -1.125
-   is located on boundary: 0
    idx:     (11,3)
+
 With weight: 10.6667
 pt[3]:    location:  0.375 -1.375
-   is located on boundary: 0
    idx:     (9,2)
+
 With weight: 8
 pt[4]:    location:  0.875 -1.375
-   is located on boundary: 0
    idx:     (11,2)
+
 With weight: 2.66667
 
 On point:    location:  0.875 -1.125
-   is located on boundary: 0
    idx:     (11,3)
+
 pt[0]:    location:  0.875 -1.125
-   is located on boundary: 0
    idx:     (11,3)
+
 With weight: -42.6667
 pt[1]:    location:  0.875 -1.375
-   is located on boundary: 0
    idx:     (11,2)
+
 With weight: 10.6667
 pt[2]:    location:  0.625 -1.125
-   is located on boundary: 0
    idx:     (10,3)
+
 With weight: 16
 pt[3]:    location:  1.125 -1.125
-   is located on boundary: 0
    idx:     (12,3)
+
 With weight: 16
 pt[4]:    location:  0.625 -1.375
-   is located on boundary: 0
    idx:     (10,2)
+
 With weight: -2.03742e-15
 
 On point:    location:  1.125 -1.125
-   is located on boundary: 0
    idx:     (12,3)
+
 pt[0]:    location:  1.125 -1.125
-   is located on boundary: 0
    idx:     (12,3)
+
 With weight: -64
 pt[1]:    location:  1.125 -1.375
-   is located on boundary: 0
    idx:     (12,2)
+
 With weight: 16
 pt[2]:    location:  0.875 -1.125
-   is located on boundary: 0
    idx:     (11,3)
+
 With weight: 16
 pt[3]:    location:  1.375 -1.125
-   is located on boundary: 0
    idx:     (13,3)
+
 With weight: 16
 pt[4]:    location:  1.125 -0.875
-   is located on boundary: 0
    idx:     (12,4)
+
 With weight: 16
 
 On point:    location:  1.375 -1.125
-   is located on boundary: 0
    idx:     (13,3)
+
 pt[0]:    location:  1.375 -1.125
-   is located on boundary: 0
    idx:     (13,3)
+
 With weight: -64
 pt[1]:    location:  1.375 -1.375
-   is located on boundary: 0
    idx:     (13,2)
+
 With weight: 16
 pt[2]:    location:  1.125 -1.125
-   is located on boundary: 0
    idx:     (12,3)
+
 With weight: 16
 pt[3]:    location:  1.625 -1.125
-   is located on boundary: 0
    idx:     (14,3)
+
 With weight: 16
 pt[4]:    location:  1.375 -0.875
-   is located on boundary: 0
    idx:     (13,4)
+
 With weight: 16
 
 On point:    location:  1.625 -1.125
-   is located on boundary: 0
    idx:     (14,3)
+
 pt[0]:    location:  1.625 -1.125
-   is located on boundary: 0
    idx:     (14,3)
+
 With weight: -64
 pt[1]:    location:  1.625 -1.375
-   is located on boundary: 0
    idx:     (14,2)
+
 With weight: 16
 pt[2]:    location:  1.375 -1.125
-   is located on boundary: 0
    idx:     (13,3)
+
 With weight: 16
 pt[3]:    location:  1.875 -1.125
-   is located on boundary: 0
    idx:     (15,3)
+
 With weight: 16
 pt[4]:    location:  1.625 -0.875
-   is located on boundary: 0
    idx:     (14,4)
+
 With weight: 16
 
 On point:    location:  1.875 -1.125
-   is located on boundary: 0
    idx:     (15,3)
+
 pt[0]:    location:  1.875 -1.125
-   is located on boundary: 0
    idx:     (15,3)
+
 With weight: -64
 pt[1]:    location:  1.875 -1.375
-   is located on boundary: 0
    idx:     (15,2)
+
 With weight: 16
 pt[2]:    location:  1.625 -1.125
-   is located on boundary: 0
    idx:     (14,3)
+
 With weight: 16
 pt[3]:    location:  2.125 -1.125
-   is located on boundary: 0
    idx:     (16,3)
+
 With weight: 16
 pt[4]:    location:  1.875 -0.875
-   is located on boundary: 0
    idx:     (15,4)
+
 With weight: 16
 
 On point:    location: -1.875 -0.875
-   is located on boundary: 0
    idx:     (0,4)
+
 pt[0]:    location: -1.875 -0.875
-   is located on boundary: 0
    idx:     (0,4)
+
 With weight: -64
 pt[1]:    location: -1.875 -1.125
-   is located on boundary: 0
    idx:     (0,3)
+
 With weight: 16
 pt[2]:    location: -2.125 -0.875
-   is located on boundary: 0
    idx:     (-1,4)
+
 With weight: 16
 pt[3]:    location: -1.625 -0.875
-   is located on boundary: 0
    idx:     (1,4)
+
 With weight: 16
 pt[4]:    location: -1.875 -0.625
-   is located on boundary: 0
    idx:     (0,5)
+
 With weight: 16
 
 On point:    location: -1.625 -0.875
-   is located on boundary: 0
    idx:     (1,4)
+
 pt[0]:    location: -1.625 -0.875
-   is located on boundary: 0
    idx:     (1,4)
+
 With weight: -64
 pt[1]:    location: -1.625 -1.125
-   is located on boundary: 0
    idx:     (1,3)
+
 With weight: 16
 pt[2]:    location: -1.875 -0.875
-   is located on boundary: 0
    idx:     (0,4)
+
 With weight: 16
 pt[3]:    location: -1.375 -0.875
-   is located on boundary: 0
    idx:     (2,4)
+
 With weight: 16
 pt[4]:    location: -1.625 -0.625
-   is located on boundary: 0
    idx:     (1,5)
+
 With weight: 16
 
 On point:    location: -1.375 -0.875
-   is located on boundary: 0
    idx:     (2,4)
+
 pt[0]:    location: -1.375 -0.875
-   is located on boundary: 0
    idx:     (2,4)
+
 With weight: -64
 pt[1]:    location: -1.375 -1.125
-   is located on boundary: 0
    idx:     (2,3)
+
 With weight: 16
 pt[2]:    location: -1.625 -0.875
-   is located on boundary: 0
    idx:     (1,4)
+
 With weight: 16
 pt[3]:    location: -1.125 -0.875
-   is located on boundary: 0
    idx:     (3,4)
+
 With weight: 16
 pt[4]:    location: -1.375 -0.625
-   is located on boundary: 0
    idx:     (2,5)
+
 With weight: 16
 
 On point:    location: -1.125 -0.875
-   is located on boundary: 0
    idx:     (3,4)
+
 pt[0]:    location: -1.125 -0.875
-   is located on boundary: 0
    idx:     (3,4)
+
 With weight: -42.6667
 pt[1]:    location: -1.125 -1.125
-   is located on boundary: 0
    idx:     (3,3)
+
 With weight: 16
 pt[2]:    location: -1.375 -0.875
-   is located on boundary: 0
    idx:     (2,4)
+
 With weight: 10.6667
 pt[3]:    location: -1.125 -0.625
-   is located on boundary: 0
    idx:     (3,5)
+
 With weight: 16
 pt[4]:    location: -1.375 -1.125
-   is located on boundary: 0
    idx:     (2,3)
+
 With weight: -3.3629e-16
 
 On point:    location:  1.125 -0.875
-   is located on boundary: 0
    idx:     (12,4)
+
 pt[0]:    location:  1.125 -0.875
-   is located on boundary: 0
    idx:     (12,4)
+
 With weight: -45.1765
 pt[1]:    location:  1.125 -1.125
-   is located on boundary: 0
    idx:     (12,3)
+
 With weight: 8.47059
 pt[2]:    location:  1.375 -0.875
-   is located on boundary: 0
    idx:     (13,4)
+
 With weight: 13.1765
 pt[3]:    location:  1.125 -0.625
-   is located on boundary: 0
    idx:     (12,5)
+
 With weight: 16
 pt[4]:    location:  0.875 -1.125
-   is located on boundary: 0
    idx:     (11,3)
+
 With weight: 7.52941
 
 On point:    location:  1.375 -0.875
-   is located on boundary: 0
    idx:     (13,4)
+
 pt[0]:    location:  1.375 -0.875
-   is located on boundary: 0
    idx:     (13,4)
+
 With weight: -64
 pt[1]:    location:  1.375 -1.125
-   is located on boundary: 0
    idx:     (13,3)
+
 With weight: 16
 pt[2]:    location:  1.125 -0.875
-   is located on boundary: 0
    idx:     (12,4)
+
 With weight: 16
 pt[3]:    location:  1.625 -0.875
-   is located on boundary: 0
    idx:     (14,4)
+
 With weight: 16
 pt[4]:    location:  1.375 -0.625
-   is located on boundary: 0
    idx:     (13,5)
+
 With weight: 16
 
 On point:    location:  1.625 -0.875
-   is located on boundary: 0
    idx:     (14,4)
+
 pt[0]:    location:  1.625 -0.875
-   is located on boundary: 0
    idx:     (14,4)
+
 With weight: -64
 pt[1]:    location:  1.625 -1.125
-   is located on boundary: 0
    idx:     (14,3)
+
 With weight: 16
 pt[2]:    location:  1.375 -0.875
-   is located on boundary: 0
    idx:     (13,4)
+
 With weight: 16
 pt[3]:    location:  1.875 -0.875
-   is located on boundary: 0
    idx:     (15,4)
+
 With weight: 16
 pt[4]:    location:  1.625 -0.625
-   is located on boundary: 0
    idx:     (14,5)
+
 With weight: 16
 
 On point:    location:  1.875 -0.875
-   is located on boundary: 0
    idx:     (15,4)
+
 pt[0]:    location:  1.875 -0.875
-   is located on boundary: 0
    idx:     (15,4)
+
 With weight: -64
 pt[1]:    location:  1.875 -1.125
-   is located on boundary: 0
    idx:     (15,3)
+
 With weight: 16
 pt[2]:    location:  1.625 -0.875
-   is located on boundary: 0
    idx:     (14,4)
+
 With weight: 16
 pt[3]:    location:  2.125 -0.875
-   is located on boundary: 0
    idx:     (16,4)
+
 With weight: 16
 pt[4]:    location:  1.875 -0.625
-   is located on boundary: 0
    idx:     (15,5)
+
 With weight: 16
 
 On point:    location: -1.875 -0.625
-   is located on boundary: 0
    idx:     (0,5)
+
 pt[0]:    location: -1.875 -0.625
-   is located on boundary: 0
    idx:     (0,5)
+
 With weight: -64
 pt[1]:    location: -1.875 -0.875
-   is located on boundary: 0
    idx:     (0,4)
+
 With weight: 16
 pt[2]:    location: -2.125 -0.625
-   is located on boundary: 0
    idx:     (-1,5)
+
 With weight: 16
 pt[3]:    location: -1.625 -0.625
-   is located on boundary: 0
    idx:     (1,5)
+
 With weight: 16
 pt[4]:    location: -1.875 -0.375
-   is located on boundary: 0
    idx:     (0,6)
+
 With weight: 16
 
 On point:    location: -1.625 -0.625
-   is located on boundary: 0
    idx:     (1,5)
+
 pt[0]:    location: -1.625 -0.625
-   is located on boundary: 0
    idx:     (1,5)
+
 With weight: -64
 pt[1]:    location: -1.625 -0.875
-   is located on boundary: 0
    idx:     (1,4)
+
 With weight: 16
 pt[2]:    location: -1.875 -0.625
-   is located on boundary: 0
    idx:     (0,5)
+
 With weight: 16
 pt[3]:    location: -1.375 -0.625
-   is located on boundary: 0
    idx:     (2,5)
+
 With weight: 16
 pt[4]:    location: -1.625 -0.375
-   is located on boundary: 0
    idx:     (1,6)
+
 With weight: 16
 
 On point:    location: -1.375 -0.625
-   is located on boundary: 0
    idx:     (2,5)
+
 pt[0]:    location: -1.375 -0.625
-   is located on boundary: 0
    idx:     (2,5)
+
 With weight: -64
 pt[1]:    location: -1.375 -0.875
-   is located on boundary: 0
    idx:     (2,4)
+
 With weight: 16
 pt[2]:    location: -1.625 -0.625
-   is located on boundary: 0
    idx:     (1,5)
+
 With weight: 16
 pt[3]:    location: -1.125 -0.625
-   is located on boundary: 0
    idx:     (3,5)
+
 With weight: 16
 pt[4]:    location: -1.375 -0.375
-   is located on boundary: 0
    idx:     (2,6)
+
 With weight: 16
 
 On point:    location: -1.125 -0.625
-   is located on boundary: 0
    idx:     (3,5)
+
 pt[0]:    location: -1.125 -0.625
-   is located on boundary: 0
    idx:     (3,5)
+
 With weight: -21.3333
 pt[1]:    location: -1.125 -0.875
-   is located on boundary: 0
    idx:     (3,4)
+
 With weight: 10.6667
 pt[2]:    location: -1.375 -0.625
-   is located on boundary: 0
    idx:     (2,5)
+
 With weight: -1.22853e-15
 pt[3]:    location: -1.375 -0.875
-   is located on boundary: 0
    idx:     (2,4)
+
 With weight: 2.66667
 pt[4]:    location: -1.375 -0.375
-   is located on boundary: 0
    idx:     (2,6)
+
 With weight: 8
 
 On point:    location:  1.125 -0.625
-   is located on boundary: 0
    idx:     (12,5)
+
 pt[0]:    location:  1.125 -0.625
-   is located on boundary: 0
    idx:     (12,5)
+
 With weight: -21.3333
 pt[1]:    location:  1.125 -0.875
-   is located on boundary: 0
    idx:     (12,4)
+
 With weight: 10.6667
 pt[2]:    location:  1.375 -0.625
-   is located on boundary: 0
    idx:     (13,5)
+
 With weight: -1.22853e-15
 pt[3]:    location:  1.375 -0.875
-   is located on boundary: 0
    idx:     (13,4)
+
 With weight: 2.66667
 pt[4]:    location:  1.375 -0.375
-   is located on boundary: 0
    idx:     (13,6)
+
 With weight: 8
 
 On point:    location:  1.375 -0.625
-   is located on boundary: 0
    idx:     (13,5)
+
 pt[0]:    location:  1.375 -0.625
-   is located on boundary: 0
    idx:     (13,5)
+
 With weight: -64
 pt[1]:    location:  1.375 -0.875
-   is located on boundary: 0
    idx:     (13,4)
+
 With weight: 16
 pt[2]:    location:  1.125 -0.625
-   is located on boundary: 0
    idx:     (12,5)
+
 With weight: 16
 pt[3]:    location:  1.625 -0.625
-   is located on boundary: 0
    idx:     (14,5)
+
 With weight: 16
 pt[4]:    location:  1.375 -0.375
-   is located on boundary: 0
    idx:     (13,6)
+
 With weight: 16
 
 On point:    location:  1.625 -0.625
-   is located on boundary: 0
    idx:     (14,5)
+
 pt[0]:    location:  1.625 -0.625
-   is located on boundary: 0
    idx:     (14,5)
+
 With weight: -64
 pt[1]:    location:  1.625 -0.875
-   is located on boundary: 0
    idx:     (14,4)
+
 With weight: 16
 pt[2]:    location:  1.375 -0.625
-   is located on boundary: 0
    idx:     (13,5)
+
 With weight: 16
 pt[3]:    location:  1.875 -0.625
-   is located on boundary: 0
    idx:     (15,5)
+
 With weight: 16
 pt[4]:    location:  1.625 -0.375
-   is located on boundary: 0
    idx:     (14,6)
+
 With weight: 16
 
 On point:    location:  1.875 -0.625
-   is located on boundary: 0
    idx:     (15,5)
+
 pt[0]:    location:  1.875 -0.625
-   is located on boundary: 0
    idx:     (15,5)
+
 With weight: -64
 pt[1]:    location:  1.875 -0.875
-   is located on boundary: 0
    idx:     (15,4)
+
 With weight: 16
 pt[2]:    location:  1.625 -0.625
-   is located on boundary: 0
    idx:     (14,5)
+
 With weight: 16
 pt[3]:    location:  2.125 -0.625
-   is located on boundary: 0
    idx:     (16,5)
+
 With weight: 16
 pt[4]:    location:  1.875 -0.375
-   is located on boundary: 0
    idx:     (15,6)
+
 With weight: 16
 
 On point:    location: -1.875 -0.375
-   is located on boundary: 0
    idx:     (0,6)
+
 pt[0]:    location: -1.875 -0.375
-   is located on boundary: 0
    idx:     (0,6)
+
 With weight: -64
 pt[1]:    location: -1.875 -0.625
-   is located on boundary: 0
    idx:     (0,5)
+
 With weight: 16
 pt[2]:    location: -2.125 -0.375
-   is located on boundary: 0
    idx:     (-1,6)
+
 With weight: 16
 pt[3]:    location: -1.625 -0.375
-   is located on boundary: 0
    idx:     (1,6)
+
 With weight: 16
 pt[4]:    location: -1.875 -0.125
-   is located on boundary: 0
    idx:     (0,7)
+
 With weight: 16
 
 On point:    location: -1.625 -0.375
-   is located on boundary: 0
    idx:     (1,6)
+
 pt[0]:    location: -1.625 -0.375
-   is located on boundary: 0
    idx:     (1,6)
+
 With weight: -64
 pt[1]:    location: -1.625 -0.625
-   is located on boundary: 0
    idx:     (1,5)
+
 With weight: 16
 pt[2]:    location: -1.875 -0.375
-   is located on boundary: 0
    idx:     (0,6)
+
 With weight: 16
 pt[3]:    location: -1.375 -0.375
-   is located on boundary: 0
    idx:     (2,6)
+
 With weight: 16
 pt[4]:    location: -1.625 -0.125
-   is located on boundary: 0
    idx:     (1,7)
+
 With weight: 16
 
 On point:    location: -1.375 -0.375
-   is located on boundary: 0
    idx:     (2,6)
+
 pt[0]:    location: -1.375 -0.375
-   is located on boundary: 0
    idx:     (2,6)
+
 With weight: -42.6667
 pt[1]:    location: -1.375 -0.625
-   is located on boundary: 0
    idx:     (2,5)
+
 With weight: 16
 pt[2]:    location: -1.625 -0.375
-   is located on boundary: 0
    idx:     (1,6)
+
 With weight: 10.6667
 pt[3]:    location: -1.375 -0.125
-   is located on boundary: 0
    idx:     (2,7)
+
 With weight: 16
 pt[4]:    location: -1.625 -0.625
-   is located on boundary: 0
    idx:     (1,5)
+
 With weight: -3.3629e-16
 
 On point:    location:  1.375 -0.375
-   is located on boundary: 0
    idx:     (13,6)
+
 pt[0]:    location:  1.375 -0.375
-   is located on boundary: 0
    idx:     (13,6)
+
 With weight: -45.1765
 pt[1]:    location:  1.375 -0.625
-   is located on boundary: 0
    idx:     (13,5)
+
 With weight: 8.47059
 pt[2]:    location:  1.625 -0.375
-   is located on boundary: 0
    idx:     (14,6)
+
 With weight: 13.1765
 pt[3]:    location:  1.375 -0.125
-   is located on boundary: 0
    idx:     (13,7)
+
 With weight: 16
 pt[4]:    location:  1.125 -0.625
-   is located on boundary: 0
    idx:     (12,5)
+
 With weight: 7.52941
 
 On point:    location:  1.625 -0.375
-   is located on boundary: 0
    idx:     (14,6)
+
 pt[0]:    location:  1.625 -0.375
-   is located on boundary: 0
    idx:     (14,6)
+
 With weight: -64
 pt[1]:    location:  1.625 -0.625
-   is located on boundary: 0
    idx:     (14,5)
+
 With weight: 16
 pt[2]:    location:  1.375 -0.375
-   is located on boundary: 0
    idx:     (13,6)
+
 With weight: 16
 pt[3]:    location:  1.875 -0.375
-   is located on boundary: 0
    idx:     (15,6)
+
 With weight: 16
 pt[4]:    location:  1.625 -0.125
-   is located on boundary: 0
    idx:     (14,7)
+
 With weight: 16
 
 On point:    location:  1.875 -0.375
-   is located on boundary: 0
    idx:     (15,6)
+
 pt[0]:    location:  1.875 -0.375
-   is located on boundary: 0
    idx:     (15,6)
+
 With weight: -64
 pt[1]:    location:  1.875 -0.625
-   is located on boundary: 0
    idx:     (15,5)
+
 With weight: 16
 pt[2]:    location:  1.625 -0.375
-   is located on boundary: 0
    idx:     (14,6)
+
 With weight: 16
 pt[3]:    location:  2.125 -0.375
-   is located on boundary: 0
    idx:     (16,6)
+
 With weight: 16
 pt[4]:    location:  1.875 -0.125
-   is located on boundary: 0
    idx:     (15,7)
+
 With weight: 16
 
 On point:    location: -1.875 -0.125
-   is located on boundary: 0
    idx:     (0,7)
+
 pt[0]:    location: -1.875 -0.125
-   is located on boundary: 0
    idx:     (0,7)
+
 With weight: -64
 pt[1]:    location: -1.875 -0.375
-   is located on boundary: 0
    idx:     (0,6)
+
 With weight: 16
 pt[2]:    location: -2.125 -0.125
-   is located on boundary: 0
    idx:     (-1,7)
+
 With weight: 16
 pt[3]:    location: -1.625 -0.125
-   is located on boundary: 0
    idx:     (1,7)
+
 With weight: 16
 pt[4]:    location: -1.875  0.125
-   is located on boundary: 0
    idx:     (0,8)
+
 With weight: 16
 
 On point:    location: -1.625 -0.125
-   is located on boundary: 0
    idx:     (1,7)
+
 pt[0]:    location: -1.625 -0.125
-   is located on boundary: 0
    idx:     (1,7)
+
 With weight: -64
 pt[1]:    location: -1.625 -0.375
-   is located on boundary: 0
    idx:     (1,6)
+
 With weight: 16
 pt[2]:    location: -1.875 -0.125
-   is located on boundary: 0
    idx:     (0,7)
+
 With weight: 16
 pt[3]:    location: -1.375 -0.125
-   is located on boundary: 0
    idx:     (2,7)
+
 With weight: 16
 pt[4]:    location: -1.625  0.125
-   is located on boundary: 0
    idx:     (1,8)
+
 With weight: 16
 
 On point:    location: -1.375 -0.125
-   is located on boundary: 0
    idx:     (2,7)
+
 pt[0]:    location: -1.375 -0.125
-   is located on boundary: 0
    idx:     (2,7)
+
 With weight: -42.6667
 pt[1]:    location: -1.375 -0.375
-   is located on boundary: 0
    idx:     (2,6)
+
 With weight: 16
 pt[2]:    location: -1.625 -0.125
-   is located on boundary: 0
    idx:     (1,7)
+
 With weight: 10.6667
 pt[3]:    location: -1.375  0.125
-   is located on boundary: 0
    idx:     (2,8)
+
 With weight: 16
 pt[4]:    location: -1.625 -0.375
-   is located on boundary: 0
    idx:     (1,6)
+
 With weight: -3.3629e-16
 
 On point:    location:  1.375 -0.125
-   is located on boundary: 0
    idx:     (13,7)
+
 pt[0]:    location:  1.375 -0.125
-   is located on boundary: 0
    idx:     (13,7)
+
 With weight: -42.6667
 pt[1]:    location:  1.375 -0.375
-   is located on boundary: 0
    idx:     (13,6)
+
 With weight: 16
 pt[2]:    location:  1.625 -0.125
-   is located on boundary: 0
    idx:     (14,7)
+
 With weight: 10.6667
 pt[3]:    location: 1.375 0.125
-   is located on boundary: 0
    idx:     (13,8)
+
 With weight: 16
 pt[4]:    location:  1.625 -0.375
-   is located on boundary: 0
    idx:     (14,6)
+
 With weight: -3.3629e-16
 
 On point:    location:  1.625 -0.125
-   is located on boundary: 0
    idx:     (14,7)
+
 pt[0]:    location:  1.625 -0.125
-   is located on boundary: 0
    idx:     (14,7)
+
 With weight: -64
 pt[1]:    location:  1.625 -0.375
-   is located on boundary: 0
    idx:     (14,6)
+
 With weight: 16
 pt[2]:    location:  1.375 -0.125
-   is located on boundary: 0
    idx:     (13,7)
+
 With weight: 16
 pt[3]:    location:  1.875 -0.125
-   is located on boundary: 0
    idx:     (15,7)
+
 With weight: 16
 pt[4]:    location: 1.625 0.125
-   is located on boundary: 0
    idx:     (14,8)
+
 With weight: 16
 
 On point:    location:  1.875 -0.125
-   is located on boundary: 0
    idx:     (15,7)
+
 pt[0]:    location:  1.875 -0.125
-   is located on boundary: 0
    idx:     (15,7)
+
 With weight: -64
 pt[1]:    location:  1.875 -0.375
-   is located on boundary: 0
    idx:     (15,6)
+
 With weight: 16
 pt[2]:    location:  1.625 -0.125
-   is located on boundary: 0
    idx:     (14,7)
+
 With weight: 16
 pt[3]:    location:  2.125 -0.125
-   is located on boundary: 0
    idx:     (16,7)
+
 With weight: 16
 pt[4]:    location: 1.875 0.125
-   is located on boundary: 0
    idx:     (15,8)
+
 With weight: 16
 
 On point:    location: -1.875  0.125
-   is located on boundary: 0
    idx:     (0,8)
+
 pt[0]:    location: -1.875  0.125
-   is located on boundary: 0
    idx:     (0,8)
+
 With weight: -64
 pt[1]:    location: -1.875 -0.125
-   is located on boundary: 0
    idx:     (0,7)
+
 With weight: 16
 pt[2]:    location: -2.125  0.125
-   is located on boundary: 0
    idx:     (-1,8)
+
 With weight: 16
 pt[3]:    location: -1.625  0.125
-   is located on boundary: 0
    idx:     (1,8)
+
 With weight: 16
 pt[4]:    location: -1.875  0.375
-   is located on boundary: 0
    idx:     (0,9)
+
 With weight: 16
 
 On point:    location: -1.625  0.125
-   is located on boundary: 0
    idx:     (1,8)
+
 pt[0]:    location: -1.625  0.125
-   is located on boundary: 0
    idx:     (1,8)
+
 With weight: -64
 pt[1]:    location: -1.625 -0.125
-   is located on boundary: 0
    idx:     (1,7)
+
 With weight: 16
 pt[2]:    location: -1.875  0.125
-   is located on boundary: 0
    idx:     (0,8)
+
 With weight: 16
 pt[3]:    location: -1.375  0.125
-   is located on boundary: 0
    idx:     (2,8)
+
 With weight: 16
 pt[4]:    location: -1.625  0.375
-   is located on boundary: 0
    idx:     (1,9)
+
 With weight: 16
 
 On point:    location: -1.375  0.125
-   is located on boundary: 0
    idx:     (2,8)
+
 pt[0]:    location: -1.375  0.125
-   is located on boundary: 0
    idx:     (2,8)
+
 With weight: -42.6667
 pt[1]:    location: -1.375 -0.125
-   is located on boundary: 0
    idx:     (2,7)
+
 With weight: 16
 pt[2]:    location: -1.625  0.125
-   is located on boundary: 0
    idx:     (1,8)
+
 With weight: 10.6667
 pt[3]:    location: -1.375  0.375
-   is located on boundary: 0
    idx:     (2,9)
+
 With weight: 16
 pt[4]:    location: -1.625 -0.125
-   is located on boundary: 0
    idx:     (1,7)
+
 With weight: -3.3629e-16
 
 On point:    location: 1.375 0.125
-   is located on boundary: 0
    idx:     (13,8)
+
 pt[0]:    location: 1.375 0.125
-   is located on boundary: 0
    idx:     (13,8)
+
 With weight: -42.6667
 pt[1]:    location:  1.375 -0.125
-   is located on boundary: 0
    idx:     (13,7)
+
 With weight: 16
 pt[2]:    location: 1.625 0.125
-   is located on boundary: 0
    idx:     (14,8)
+
 With weight: 10.6667
 pt[3]:    location: 1.375 0.375
-   is located on boundary: 0
    idx:     (13,9)
+
 With weight: 16
 pt[4]:    location: 1.625 0.375
-   is located on boundary: 0
    idx:     (14,9)
+
 With weight: -1.44512e-15
 
 On point:    location: 1.625 0.125
-   is located on boundary: 0
    idx:     (14,8)
+
 pt[0]:    location: 1.625 0.125
-   is located on boundary: 0
    idx:     (14,8)
+
 With weight: -64
 pt[1]:    location:  1.625 -0.125
-   is located on boundary: 0
    idx:     (14,7)
+
 With weight: 16
 pt[2]:    location: 1.375 0.125
-   is located on boundary: 0
    idx:     (13,8)
+
 With weight: 16
 pt[3]:    location: 1.875 0.125
-   is located on boundary: 0
    idx:     (15,8)
+
 With weight: 16
 pt[4]:    location: 1.625 0.375
-   is located on boundary: 0
    idx:     (14,9)
+
 With weight: 16
 
 On point:    location: 1.875 0.125
-   is located on boundary: 0
    idx:     (15,8)
+
 pt[0]:    location: 1.875 0.125
-   is located on boundary: 0
    idx:     (15,8)
+
 With weight: -64
 pt[1]:    location:  1.875 -0.125
-   is located on boundary: 0
    idx:     (15,7)
+
 With weight: 16
 pt[2]:    location: 1.625 0.125
-   is located on boundary: 0
    idx:     (14,8)
+
 With weight: 16
 pt[3]:    location: 2.125 0.125
-   is located on boundary: 0
    idx:     (16,8)
+
 With weight: 16
 pt[4]:    location: 1.875 0.375
-   is located on boundary: 0
    idx:     (15,9)
+
 With weight: 16
 
 On point:    location: -1.875  0.375
-   is located on boundary: 0
    idx:     (0,9)
+
 pt[0]:    location: -1.875  0.375
-   is located on boundary: 0
    idx:     (0,9)
+
 With weight: -64
 pt[1]:    location: -1.875  0.125
-   is located on boundary: 0
    idx:     (0,8)
+
 With weight: 16
 pt[2]:    location: -2.125  0.375
-   is located on boundary: 0
    idx:     (-1,9)
+
 With weight: 16
 pt[3]:    location: -1.625  0.375
-   is located on boundary: 0
    idx:     (1,9)
+
 With weight: 16
 pt[4]:    location: -1.875  0.625
-   is located on boundary: 0
    idx:     (0,10)
+
 With weight: 16
 
 On point:    location: -1.625  0.375
-   is located on boundary: 0
    idx:     (1,9)
+
 pt[0]:    location: -1.625  0.375
-   is located on boundary: 0
    idx:     (1,9)
+
 With weight: -64
 pt[1]:    location: -1.625  0.125
-   is located on boundary: 0
    idx:     (1,8)
+
 With weight: 16
 pt[2]:    location: -1.875  0.375
-   is located on boundary: 0
    idx:     (0,9)
+
 With weight: 16
 pt[3]:    location: -1.375  0.375
-   is located on boundary: 0
    idx:     (2,9)
+
 With weight: 16
 pt[4]:    location: -1.625  0.625
-   is located on boundary: 0
    idx:     (1,10)
+
 With weight: 16
 
 On point:    location: -1.375  0.375
-   is located on boundary: 0
    idx:     (2,9)
+
 pt[0]:    location: -1.375  0.375
-   is located on boundary: 0
    idx:     (2,9)
+
 With weight: -42.6667
 pt[1]:    location: -1.375  0.125
-   is located on boundary: 0
    idx:     (2,8)
+
 With weight: 16
 pt[2]:    location: -1.625  0.375
-   is located on boundary: 0
    idx:     (1,9)
+
 With weight: 10.6667
 pt[3]:    location: -1.375  0.625
-   is located on boundary: 0
    idx:     (2,10)
+
 With weight: 16
 pt[4]:    location: -1.625  0.625
-   is located on boundary: 0
    idx:     (1,10)
+
 With weight: -1.44512e-15
 
 On point:    location: 1.375 0.375
-   is located on boundary: 0
    idx:     (13,9)
+
 pt[0]:    location: 1.375 0.375
-   is located on boundary: 0
    idx:     (13,9)
+
 With weight: -42.6667
 pt[1]:    location: 1.375 0.125
-   is located on boundary: 0
    idx:     (13,8)
+
 With weight: 16
 pt[2]:    location: 1.625 0.375
-   is located on boundary: 0
    idx:     (14,9)
+
 With weight: 10.6667
 pt[3]:    location: 1.375 0.625
-   is located on boundary: 0
    idx:     (13,10)
+
 With weight: 16
 pt[4]:    location: 1.625 0.125
-   is located on boundary: 0
    idx:     (14,8)
+
 With weight: -3.3629e-16
 
 On point:    location: 1.625 0.375
-   is located on boundary: 0
    idx:     (14,9)
+
 pt[0]:    location: 1.625 0.375
-   is located on boundary: 0
    idx:     (14,9)
+
 With weight: -64
 pt[1]:    location: 1.625 0.125
-   is located on boundary: 0
    idx:     (14,8)
+
 With weight: 16
 pt[2]:    location: 1.375 0.375
-   is located on boundary: 0
    idx:     (13,9)
+
 With weight: 16
 pt[3]:    location: 1.875 0.375
-   is located on boundary: 0
    idx:     (15,9)
+
 With weight: 16
 pt[4]:    location: 1.625 0.625
-   is located on boundary: 0
    idx:     (14,10)
+
 With weight: 16
 
 On point:    location: 1.875 0.375
-   is located on boundary: 0
    idx:     (15,9)
+
 pt[0]:    location: 1.875 0.375
-   is located on boundary: 0
    idx:     (15,9)
+
 With weight: -64
 pt[1]:    location: 1.875 0.125
-   is located on boundary: 0
    idx:     (15,8)
+
 With weight: 16
 pt[2]:    location: 1.625 0.375
-   is located on boundary: 0
    idx:     (14,9)
+
 With weight: 16
 pt[3]:    location: 2.125 0.375
-   is located on boundary: 0
    idx:     (16,9)
+
 With weight: 16
 pt[4]:    location: 1.875 0.625
-   is located on boundary: 0
    idx:     (15,10)
+
 With weight: 16
 
 On point:    location: -1.875  0.625
-   is located on boundary: 0
    idx:     (0,10)
+
 pt[0]:    location: -1.875  0.625
-   is located on boundary: 0
    idx:     (0,10)
+
 With weight: -64
 pt[1]:    location: -1.875  0.375
-   is located on boundary: 0
    idx:     (0,9)
+
 With weight: 16
 pt[2]:    location: -2.125  0.625
-   is located on boundary: 0
    idx:     (-1,10)
+
 With weight: 16
 pt[3]:    location: -1.625  0.625
-   is located on boundary: 0
    idx:     (1,10)
+
 With weight: 16
 pt[4]:    location: -1.875  0.875
-   is located on boundary: 0
    idx:     (0,11)
+
 With weight: 16
 
 On point:    location: -1.625  0.625
-   is located on boundary: 0
    idx:     (1,10)
+
 pt[0]:    location: -1.625  0.625
-   is located on boundary: 0
    idx:     (1,10)
+
 With weight: -64
 pt[1]:    location: -1.625  0.375
-   is located on boundary: 0
    idx:     (1,9)
+
 With weight: 16
 pt[2]:    location: -1.875  0.625
-   is located on boundary: 0
    idx:     (0,10)
+
 With weight: 16
 pt[3]:    location: -1.375  0.625
-   is located on boundary: 0
    idx:     (2,10)
+
 With weight: 16
 pt[4]:    location: -1.625  0.875
-   is located on boundary: 0
    idx:     (1,11)
+
 With weight: 16
 
 On point:    location: -1.375  0.625
-   is located on boundary: 0
    idx:     (2,10)
+
 pt[0]:    location: -1.375  0.625
-   is located on boundary: 0
    idx:     (2,10)
+
 With weight: -64
 pt[1]:    location: -1.375  0.375
-   is located on boundary: 0
    idx:     (2,9)
+
 With weight: 16
 pt[2]:    location: -1.625  0.625
-   is located on boundary: 0
    idx:     (1,10)
+
 With weight: 16
 pt[3]:    location: -1.125  0.625
-   is located on boundary: 0
    idx:     (3,10)
+
 With weight: 16
 pt[4]:    location: -1.375  0.875
-   is located on boundary: 0
    idx:     (2,11)
+
 With weight: 16
 
 On point:    location: -1.125  0.625
-   is located on boundary: 0
    idx:     (3,10)
+
 pt[0]:    location: -1.125  0.625
-   is located on boundary: 0
    idx:     (3,10)
+
 With weight: -21.3333
 pt[1]:    location: -1.375  0.625
-   is located on boundary: 0
    idx:     (2,10)
+
 With weight: -2.90863e-16
 pt[2]:    location: -1.125  0.875
-   is located on boundary: 0
    idx:     (3,11)
+
 With weight: 10.6667
 pt[3]:    location: -1.375  0.375
-   is located on boundary: 0
    idx:     (2,9)
+
 With weight: 8
 pt[4]:    location: -1.375  0.875
-   is located on boundary: 0
    idx:     (2,11)
+
 With weight: 2.66667
 
 On point:    location: 1.125 0.625
-   is located on boundary: 0
    idx:     (12,10)
+
 pt[0]:    location: 1.125 0.625
-   is located on boundary: 0
    idx:     (12,10)
+
 With weight: -21.3333
 pt[1]:    location: 1.375 0.625
-   is located on boundary: 0
    idx:     (13,10)
+
 With weight: -2.90863e-16
 pt[2]:    location: 1.125 0.875
-   is located on boundary: 0
    idx:     (12,11)
+
 With weight: 10.6667
 pt[3]:    location: 1.375 0.375
-   is located on boundary: 0
    idx:     (13,9)
+
 With weight: 8
 pt[4]:    location: 1.375 0.875
-   is located on boundary: 0
    idx:     (13,11)
+
 With weight: 2.66667
 
 On point:    location: 1.375 0.625
-   is located on boundary: 0
    idx:     (13,10)
+
 pt[0]:    location: 1.375 0.625
-   is located on boundary: 0
    idx:     (13,10)
+
 With weight: -64
 pt[1]:    location: 1.375 0.375
-   is located on boundary: 0
    idx:     (13,9)
+
 With weight: 16
 pt[2]:    location: 1.125 0.625
-   is located on boundary: 0
    idx:     (12,10)
+
 With weight: 16
 pt[3]:    location: 1.625 0.625
-   is located on boundary: 0
    idx:     (14,10)
+
 With weight: 16
 pt[4]:    location: 1.375 0.875
-   is located on boundary: 0
    idx:     (13,11)
+
 With weight: 16
 
 On point:    location: 1.625 0.625
-   is located on boundary: 0
    idx:     (14,10)
+
 pt[0]:    location: 1.625 0.625
-   is located on boundary: 0
    idx:     (14,10)
+
 With weight: -64
 pt[1]:    location: 1.625 0.375
-   is located on boundary: 0
    idx:     (14,9)
+
 With weight: 16
 pt[2]:    location: 1.375 0.625
-   is located on boundary: 0
    idx:     (13,10)
+
 With weight: 16
 pt[3]:    location: 1.875 0.625
-   is located on boundary: 0
    idx:     (15,10)
+
 With weight: 16
 pt[4]:    location: 1.625 0.875
-   is located on boundary: 0
    idx:     (14,11)
+
 With weight: 16
 
 On point:    location: 1.875 0.625
-   is located on boundary: 0
    idx:     (15,10)
+
 pt[0]:    location: 1.875 0.625
-   is located on boundary: 0
    idx:     (15,10)
+
 With weight: -64
 pt[1]:    location: 1.875 0.375
-   is located on boundary: 0
    idx:     (15,9)
+
 With weight: 16
 pt[2]:    location: 1.625 0.625
-   is located on boundary: 0
    idx:     (14,10)
+
 With weight: 16
 pt[3]:    location: 2.125 0.625
-   is located on boundary: 0
    idx:     (16,10)
+
 With weight: 16
 pt[4]:    location: 1.875 0.875
-   is located on boundary: 0
    idx:     (15,11)
+
 With weight: 16
 
 On point:    location: -1.875  0.875
-   is located on boundary: 0
    idx:     (0,11)
+
 pt[0]:    location: -1.875  0.875
-   is located on boundary: 0
    idx:     (0,11)
+
 With weight: -64
 pt[1]:    location: -1.875  0.625
-   is located on boundary: 0
    idx:     (0,10)
+
 With weight: 16
 pt[2]:    location: -2.125  0.875
-   is located on boundary: 0
    idx:     (-1,11)
+
 With weight: 16
 pt[3]:    location: -1.625  0.875
-   is located on boundary: 0
    idx:     (1,11)
+
 With weight: 16
 pt[4]:    location: -1.875  1.125
-   is located on boundary: 0
    idx:     (0,12)
+
 With weight: 16
 
 On point:    location: -1.625  0.875
-   is located on boundary: 0
    idx:     (1,11)
+
 pt[0]:    location: -1.625  0.875
-   is located on boundary: 0
    idx:     (1,11)
+
 With weight: -64
 pt[1]:    location: -1.625  0.625
-   is located on boundary: 0
    idx:     (1,10)
+
 With weight: 16
 pt[2]:    location: -1.875  0.875
-   is located on boundary: 0
    idx:     (0,11)
+
 With weight: 16
 pt[3]:    location: -1.375  0.875
-   is located on boundary: 0
    idx:     (2,11)
+
 With weight: 16
 pt[4]:    location: -1.625  1.125
-   is located on boundary: 0
    idx:     (1,12)
+
 With weight: 16
 
 On point:    location: -1.375  0.875
-   is located on boundary: 0
    idx:     (2,11)
+
 pt[0]:    location: -1.375  0.875
-   is located on boundary: 0
    idx:     (2,11)
+
 With weight: -64
 pt[1]:    location: -1.375  0.625
-   is located on boundary: 0
    idx:     (2,10)
+
 With weight: 16
 pt[2]:    location: -1.625  0.875
-   is located on boundary: 0
    idx:     (1,11)
+
 With weight: 16
 pt[3]:    location: -1.125  0.875
-   is located on boundary: 0
    idx:     (3,11)
+
 With weight: 16
 pt[4]:    location: -1.375  1.125
-   is located on boundary: 0
    idx:     (2,12)
+
 With weight: 16
 
 On point:    location: -1.125  0.875
-   is located on boundary: 0
    idx:     (3,11)
+
 pt[0]:    location: -1.125  0.875
-   is located on boundary: 0
    idx:     (3,11)
+
 With weight: -42.6667
 pt[1]:    location: -1.125  0.625
-   is located on boundary: 0
    idx:     (3,10)
+
 With weight: 16
 pt[2]:    location: -1.375  0.875
-   is located on boundary: 0
    idx:     (2,11)
+
 With weight: 10.6667
 pt[3]:    location: -1.125  1.125
-   is located on boundary: 0
    idx:     (3,12)
+
 With weight: 16
 pt[4]:    location: -1.375  0.625
-   is located on boundary: 0
    idx:     (2,10)
+
 With weight: -3.3629e-16
 
 On point:    location: 1.125 0.875
-   is located on boundary: 0
    idx:     (12,11)
+
 pt[0]:    location: 1.125 0.875
-   is located on boundary: 0
    idx:     (12,11)
+
 With weight: -42.6667
 pt[1]:    location: 1.125 0.625
-   is located on boundary: 0
    idx:     (12,10)
+
 With weight: 16
 pt[2]:    location: 1.375 0.875
-   is located on boundary: 0
    idx:     (13,11)
+
 With weight: 10.6667
 pt[3]:    location: 1.125 1.125
-   is located on boundary: 0
    idx:     (12,12)
+
 With weight: 16
 pt[4]:    location: 1.375 0.625
-   is located on boundary: 0
    idx:     (13,10)
+
 With weight: -3.3629e-16
 
 On point:    location: 1.375 0.875
-   is located on boundary: 0
    idx:     (13,11)
+
 pt[0]:    location: 1.375 0.875
-   is located on boundary: 0
    idx:     (13,11)
+
 With weight: -64
 pt[1]:    location: 1.375 0.625
-   is located on boundary: 0
    idx:     (13,10)
+
 With weight: 16
 pt[2]:    location: 1.125 0.875
-   is located on boundary: 0
    idx:     (12,11)
+
 With weight: 16
 pt[3]:    location: 1.625 0.875
-   is located on boundary: 0
    idx:     (14,11)
+
 With weight: 16
 pt[4]:    location: 1.375 1.125
-   is located on boundary: 0
    idx:     (13,12)
+
 With weight: 16
 
 On point:    location: 1.625 0.875
-   is located on boundary: 0
    idx:     (14,11)
+
 pt[0]:    location: 1.625 0.875
-   is located on boundary: 0
    idx:     (14,11)
+
 With weight: -64
 pt[1]:    location: 1.625 0.625
-   is located on boundary: 0
    idx:     (14,10)
+
 With weight: 16
 pt[2]:    location: 1.375 0.875
-   is located on boundary: 0
    idx:     (13,11)
+
 With weight: 16
 pt[3]:    location: 1.875 0.875
-   is located on boundary: 0
    idx:     (15,11)
+
 With weight: 16
 pt[4]:    location: 1.625 1.125
-   is located on boundary: 0
    idx:     (14,12)
+
 With weight: 16
 
 On point:    location: 1.875 0.875
-   is located on boundary: 0
    idx:     (15,11)
+
 pt[0]:    location: 1.875 0.875
-   is located on boundary: 0
    idx:     (15,11)
+
 With weight: -64
 pt[1]:    location: 1.875 0.625
-   is located on boundary: 0
    idx:     (15,10)
+
 With weight: 16
 pt[2]:    location: 1.625 0.875
-   is located on boundary: 0
    idx:     (14,11)
+
 With weight: 16
 pt[3]:    location: 2.125 0.875
-   is located on boundary: 0
    idx:     (16,11)
+
 With weight: 16
 pt[4]:    location: 1.875 1.125
-   is located on boundary: 0
    idx:     (15,12)
+
 With weight: 16
 
 On point:    location: -1.875  1.125
-   is located on boundary: 0
    idx:     (0,12)
+
 pt[0]:    location: -1.875  1.125
-   is located on boundary: 0
    idx:     (0,12)
+
 With weight: -64
 pt[1]:    location: -1.875  0.875
-   is located on boundary: 0
    idx:     (0,11)
+
 With weight: 16
 pt[2]:    location: -2.125  1.125
-   is located on boundary: 0
    idx:     (-1,12)
+
 With weight: 16
 pt[3]:    location: -1.625  1.125
-   is located on boundary: 0
    idx:     (1,12)
+
 With weight: 16
 pt[4]:    location: -1.875  1.375
-   is located on boundary: 0
    idx:     (0,13)
+
 With weight: 16
 
 On point:    location: -1.625  1.125
-   is located on boundary: 0
    idx:     (1,12)
+
 pt[0]:    location: -1.625  1.125
-   is located on boundary: 0
    idx:     (1,12)
+
 With weight: -64
 pt[1]:    location: -1.625  0.875
-   is located on boundary: 0
    idx:     (1,11)
+
 With weight: 16
 pt[2]:    location: -1.875  1.125
-   is located on boundary: 0
    idx:     (0,12)
+
 With weight: 16
 pt[3]:    location: -1.375  1.125
-   is located on boundary: 0
    idx:     (2,12)
+
 With weight: 16
 pt[4]:    location: -1.625  1.375
-   is located on boundary: 0
    idx:     (1,13)
+
 With weight: 16
 
 On point:    location: -1.375  1.125
-   is located on boundary: 0
    idx:     (2,12)
+
 pt[0]:    location: -1.375  1.125
-   is located on boundary: 0
    idx:     (2,12)
+
 With weight: -64
 pt[1]:    location: -1.375  0.875
-   is located on boundary: 0
    idx:     (2,11)
+
 With weight: 16
 pt[2]:    location: -1.625  1.125
-   is located on boundary: 0
    idx:     (1,12)
+
 With weight: 16
 pt[3]:    location: -1.125  1.125
-   is located on boundary: 0
    idx:     (3,12)
+
 With weight: 16
 pt[4]:    location: -1.375  1.375
-   is located on boundary: 0
    idx:     (2,13)
+
 With weight: 16
 
 On point:    location: -1.125  1.125
-   is located on boundary: 0
    idx:     (3,12)
+
 pt[0]:    location: -1.125  1.125
-   is located on boundary: 0
    idx:     (3,12)
+
 With weight: -64
 pt[1]:    location: -1.125  0.875
-   is located on boundary: 0
    idx:     (3,11)
+
 With weight: 16
 pt[2]:    location: -1.375  1.125
-   is located on boundary: 0
    idx:     (2,12)
+
 With weight: 16
 pt[3]:    location: -0.875  1.125
-   is located on boundary: 0
    idx:     (4,12)
+
 With weight: 16
 pt[4]:    location: -1.125  1.375
-   is located on boundary: 0
    idx:     (3,13)
+
 With weight: 16
 
 On point:    location: -0.875  1.125
-   is located on boundary: 0
    idx:     (4,12)
+
 pt[0]:    location: -0.875  1.125
-   is located on boundary: 0
    idx:     (4,12)
+
 With weight: -45.1765
 pt[1]:    location: -1.125  1.125
-   is located on boundary: 0
    idx:     (3,12)
+
 With weight: 8.47059
 pt[2]:    location: -0.625  1.125
-   is located on boundary: 0
    idx:     (5,12)
+
 With weight: 16
 pt[3]:    location: -0.875  1.375
-   is located on boundary: 0
    idx:     (4,13)
+
 With weight: 13.1765
 pt[4]:    location: -1.125  0.875
-   is located on boundary: 0
    idx:     (3,11)
+
 With weight: 7.52941
 
 On point:    location: -0.625  1.125
-   is located on boundary: 0
    idx:     (5,12)
+
 pt[0]:    location: -0.625  1.125
-   is located on boundary: 0
    idx:     (5,12)
+
 With weight: -21.3333
 pt[1]:    location: -0.875  1.125
-   is located on boundary: 0
    idx:     (4,12)
+
 With weight: 10.6667
 pt[2]:    location: -0.625  1.375
-   is located on boundary: 0
    idx:     (5,13)
+
 With weight: 5.00358e-15
 pt[3]:    location: -0.875  1.375
-   is located on boundary: 0
    idx:     (4,13)
+
 With weight: 2.66667
 pt[4]:    location: -0.375  1.375
-   is located on boundary: 0
    idx:     (6,13)
+
 With weight: 8
 
 On point:    location: 0.625 1.125
-   is located on boundary: 0
    idx:     (10,12)
+
 pt[0]:    location: 0.625 1.125
-   is located on boundary: 0
    idx:     (10,12)
+
 With weight: -21.3333
 pt[1]:    location: 0.875 1.125
-   is located on boundary: 0
    idx:     (11,12)
+
 With weight: 10.6667
 pt[2]:    location: 0.625 1.375
-   is located on boundary: 0
    idx:     (10,13)
+
 With weight: 1.19902e-15
 pt[3]:    location: 0.375 1.375
-   is located on boundary: 0
    idx:     (9,13)
+
 With weight: 8
 pt[4]:    location: 0.875 1.375
-   is located on boundary: 0
    idx:     (11,13)
+
 With weight: 2.66667
 
 On point:    location: 0.875 1.125
-   is located on boundary: 0
    idx:     (11,12)
+
 pt[0]:    location: 0.875 1.125
-   is located on boundary: 0
    idx:     (11,12)
+
 With weight: -45.1765
 pt[1]:    location: 0.625 1.125
-   is located on boundary: 0
    idx:     (10,12)
+
 With weight: 16
 pt[2]:    location: 1.125 1.125
-   is located on boundary: 0
    idx:     (12,12)
+
 With weight: 8.47059
 pt[3]:    location: 0.875 1.375
-   is located on boundary: 0
    idx:     (11,13)
+
 With weight: 13.1765
 pt[4]:    location: 1.125 0.875
-   is located on boundary: 0
    idx:     (12,11)
+
 With weight: 7.52941
 
 On point:    location: 1.125 1.125
-   is located on boundary: 0
    idx:     (12,12)
+
 pt[0]:    location: 1.125 1.125
-   is located on boundary: 0
    idx:     (12,12)
+
 With weight: -64
 pt[1]:    location: 1.125 0.875
-   is located on boundary: 0
    idx:     (12,11)
+
 With weight: 16
 pt[2]:    location: 0.875 1.125
-   is located on boundary: 0
    idx:     (11,12)
+
 With weight: 16
 pt[3]:    location: 1.375 1.125
-   is located on boundary: 0
    idx:     (13,12)
+
 With weight: 16
 pt[4]:    location: 1.125 1.375
-   is located on boundary: 0
    idx:     (12,13)
+
 With weight: 16
 
 On point:    location: 1.375 1.125
-   is located on boundary: 0
    idx:     (13,12)
+
 pt[0]:    location: 1.375 1.125
-   is located on boundary: 0
    idx:     (13,12)
+
 With weight: -64
 pt[1]:    location: 1.375 0.875
-   is located on boundary: 0
    idx:     (13,11)
+
 With weight: 16
 pt[2]:    location: 1.125 1.125
-   is located on boundary: 0
    idx:     (12,12)
+
 With weight: 16
 pt[3]:    location: 1.625 1.125
-   is located on boundary: 0
    idx:     (14,12)
+
 With weight: 16
 pt[4]:    location: 1.375 1.375
-   is located on boundary: 0
    idx:     (13,13)
+
 With weight: 16
 
 On point:    location: 1.625 1.125
-   is located on boundary: 0
    idx:     (14,12)
+
 pt[0]:    location: 1.625 1.125
-   is located on boundary: 0
    idx:     (14,12)
+
 With weight: -64
 pt[1]:    location: 1.625 0.875
-   is located on boundary: 0
    idx:     (14,11)
+
 With weight: 16
 pt[2]:    location: 1.375 1.125
-   is located on boundary: 0
    idx:     (13,12)
+
 With weight: 16
 pt[3]:    location: 1.875 1.125
-   is located on boundary: 0
    idx:     (15,12)
+
 With weight: 16
 pt[4]:    location: 1.625 1.375
-   is located on boundary: 0
    idx:     (14,13)
+
 With weight: 16
 
 On point:    location: 1.875 1.125
-   is located on boundary: 0
    idx:     (15,12)
+
 pt[0]:    location: 1.875 1.125
-   is located on boundary: 0
    idx:     (15,12)
+
 With weight: -64
 pt[1]:    location: 1.875 0.875
-   is located on boundary: 0
    idx:     (15,11)
+
 With weight: 16
 pt[2]:    location: 1.625 1.125
-   is located on boundary: 0
    idx:     (14,12)
+
 With weight: 16
 pt[3]:    location: 2.125 1.125
-   is located on boundary: 0
    idx:     (16,12)
+
 With weight: 16
 pt[4]:    location: 1.875 1.375
-   is located on boundary: 0
    idx:     (15,13)
+
 With weight: 16
 
 On point:    location: -1.875  1.375
-   is located on boundary: 0
    idx:     (0,13)
+
 pt[0]:    location: -1.875  1.375
-   is located on boundary: 0
    idx:     (0,13)
+
 With weight: -64
 pt[1]:    location: -1.875  1.125
-   is located on boundary: 0
    idx:     (0,12)
+
 With weight: 16
 pt[2]:    location: -2.125  1.375
-   is located on boundary: 0
    idx:     (-1,13)
+
 With weight: 16
 pt[3]:    location: -1.625  1.375
-   is located on boundary: 0
    idx:     (1,13)
+
 With weight: 16
 pt[4]:    location: -1.875  1.625
-   is located on boundary: 0
    idx:     (0,14)
+
 With weight: 16
 
 On point:    location: -1.625  1.375
-   is located on boundary: 0
    idx:     (1,13)
+
 pt[0]:    location: -1.625  1.375
-   is located on boundary: 0
    idx:     (1,13)
+
 With weight: -64
 pt[1]:    location: -1.625  1.125
-   is located on boundary: 0
    idx:     (1,12)
+
 With weight: 16
 pt[2]:    location: -1.875  1.375
-   is located on boundary: 0
    idx:     (0,13)
+
 With weight: 16
 pt[3]:    location: -1.375  1.375
-   is located on boundary: 0
    idx:     (2,13)
+
 With weight: 16
 pt[4]:    location: -1.625  1.625
-   is located on boundary: 0
    idx:     (1,14)
+
 With weight: 16
 
 On point:    location: -1.375  1.375
-   is located on boundary: 0
    idx:     (2,13)
+
 pt[0]:    location: -1.375  1.375
-   is located on boundary: 0
    idx:     (2,13)
+
 With weight: -64
 pt[1]:    location: -1.375  1.125
-   is located on boundary: 0
    idx:     (2,12)
+
 With weight: 16
 pt[2]:    location: -1.625  1.375
-   is located on boundary: 0
    idx:     (1,13)
+
 With weight: 16
 pt[3]:    location: -1.125  1.375
-   is located on boundary: 0
    idx:     (3,13)
+
 With weight: 16
 pt[4]:    location: -1.375  1.625
-   is located on boundary: 0
    idx:     (2,14)
+
 With weight: 16
 
 On point:    location: -1.125  1.375
-   is located on boundary: 0
    idx:     (3,13)
+
 pt[0]:    location: -1.125  1.375
-   is located on boundary: 0
    idx:     (3,13)
+
 With weight: -64
 pt[1]:    location: -1.125  1.125
-   is located on boundary: 0
    idx:     (3,12)
+
 With weight: 16
 pt[2]:    location: -1.375  1.375
-   is located on boundary: 0
    idx:     (2,13)
+
 With weight: 16
 pt[3]:    location: -0.875  1.375
-   is located on boundary: 0
    idx:     (4,13)
+
 With weight: 16
 pt[4]:    location: -1.125  1.625
-   is located on boundary: 0
    idx:     (3,14)
+
 With weight: 16
 
 On point:    location: -0.875  1.375
-   is located on boundary: 0
    idx:     (4,13)
+
 pt[0]:    location: -0.875  1.375
-   is located on boundary: 0
    idx:     (4,13)
+
 With weight: -64
 pt[1]:    location: -0.875  1.125
-   is located on boundary: 0
    idx:     (4,12)
+
 With weight: 16
 pt[2]:    location: -1.125  1.375
-   is located on boundary: 0
    idx:     (3,13)
+
 With weight: 16
 pt[3]:    location: -0.625  1.375
-   is located on boundary: 0
    idx:     (5,13)
+
 With weight: 16
 pt[4]:    location: -0.875  1.625
-   is located on boundary: 0
    idx:     (4,14)
+
 With weight: 16
 
 On point:    location: -0.625  1.375
-   is located on boundary: 0
    idx:     (5,13)
+
 pt[0]:    location: -0.625  1.375
-   is located on boundary: 0
    idx:     (5,13)
+
 With weight: -64
 pt[1]:    location: -0.625  1.125
-   is located on boundary: 0
    idx:     (5,12)
+
 With weight: 16
 pt[2]:    location: -0.875  1.375
-   is located on boundary: 0
    idx:     (4,13)
+
 With weight: 16
 pt[3]:    location: -0.375  1.375
-   is located on boundary: 0
    idx:     (6,13)
+
 With weight: 16
 pt[4]:    location: -0.625  1.625
-   is located on boundary: 0
    idx:     (5,14)
+
 With weight: 16
 
 On point:    location: -0.375  1.375
-   is located on boundary: 0
    idx:     (6,13)
+
 pt[0]:    location: -0.375  1.375
-   is located on boundary: 0
    idx:     (6,13)
+
 With weight: -45.1765
 pt[1]:    location: -0.625  1.375
-   is located on boundary: 0
    idx:     (5,13)
+
 With weight: 8.47059
 pt[2]:    location: -0.125  1.375
-   is located on boundary: 0
    idx:     (7,13)
+
 With weight: 16
 pt[3]:    location: -0.375  1.625
-   is located on boundary: 0
    idx:     (6,14)
+
 With weight: 13.1765
 pt[4]:    location: -0.625  1.125
-   is located on boundary: 0
    idx:     (5,12)
+
 With weight: 7.52941
 
 On point:    location: -0.125  1.375
-   is located on boundary: 0
    idx:     (7,13)
+
 pt[0]:    location: -0.125  1.375
-   is located on boundary: 0
    idx:     (7,13)
+
 With weight: -42.6667
 pt[1]:    location: -0.375  1.375
-   is located on boundary: 0
    idx:     (6,13)
+
 With weight: 16
 pt[2]:    location: 0.125 1.375
-   is located on boundary: 0
    idx:     (8,13)
+
 With weight: 16
 pt[3]:    location: -0.125  1.625
-   is located on boundary: 0
    idx:     (7,14)
+
 With weight: 10.6667
 pt[4]:    location: -0.375  1.625
-   is located on boundary: 0
    idx:     (6,14)
+
 With weight: -2.03635e-15
 
 On point:    location: 0.125 1.375
-   is located on boundary: 0
    idx:     (8,13)
+
 pt[0]:    location: 0.125 1.375
-   is located on boundary: 0
    idx:     (8,13)
+
 With weight: -42.6667
 pt[1]:    location: -0.125  1.375
-   is located on boundary: 0
    idx:     (7,13)
+
 With weight: 16
 pt[2]:    location: 0.375 1.375
-   is located on boundary: 0
    idx:     (9,13)
+
 With weight: 16
 pt[3]:    location: 0.125 1.625
-   is located on boundary: 0
    idx:     (8,14)
+
 With weight: 10.6667
 pt[4]:    location: 0.375 1.625
-   is located on boundary: 0
    idx:     (9,14)
+
 With weight: 2.32318e-16
 
 On point:    location: 0.375 1.375
-   is located on boundary: 0
    idx:     (9,13)
+
 pt[0]:    location: 0.375 1.375
-   is located on boundary: 0
    idx:     (9,13)
+
 With weight: -45.1765
 pt[1]:    location: 0.125 1.375
-   is located on boundary: 0
    idx:     (8,13)
+
 With weight: 16
 pt[2]:    location: 0.625 1.375
-   is located on boundary: 0
    idx:     (10,13)
+
 With weight: 8.47059
 pt[3]:    location: 0.375 1.625
-   is located on boundary: 0
    idx:     (9,14)
+
 With weight: 13.1765
 pt[4]:    location: 0.625 1.125
-   is located on boundary: 0
    idx:     (10,12)
+
 With weight: 7.52941
 
 On point:    location: 0.625 1.375
-   is located on boundary: 0
    idx:     (10,13)
+
 pt[0]:    location: 0.625 1.375
-   is located on boundary: 0
    idx:     (10,13)
+
 With weight: -64
 pt[1]:    location: 0.625 1.125
-   is located on boundary: 0
    idx:     (10,12)
+
 With weight: 16
 pt[2]:    location: 0.375 1.375
-   is located on boundary: 0
    idx:     (9,13)
+
 With weight: 16
 pt[3]:    location: 0.875 1.375
-   is located on boundary: 0
    idx:     (11,13)
+
 With weight: 16
 pt[4]:    location: 0.625 1.625
-   is located on boundary: 0
    idx:     (10,14)
+
 With weight: 16
 
 On point:    location: 0.875 1.375
-   is located on boundary: 0
    idx:     (11,13)
+
 pt[0]:    location: 0.875 1.375
-   is located on boundary: 0
    idx:     (11,13)
+
 With weight: -64
 pt[1]:    location: 0.875 1.125
-   is located on boundary: 0
    idx:     (11,12)
+
 With weight: 16
 pt[2]:    location: 0.625 1.375
-   is located on boundary: 0
    idx:     (10,13)
+
 With weight: 16
 pt[3]:    location: 1.125 1.375
-   is located on boundary: 0
    idx:     (12,13)
+
 With weight: 16
 pt[4]:    location: 0.875 1.625
-   is located on boundary: 0
    idx:     (11,14)
+
 With weight: 16
 
 On point:    location: 1.125 1.375
-   is located on boundary: 0
    idx:     (12,13)
+
 pt[0]:    location: 1.125 1.375
-   is located on boundary: 0
    idx:     (12,13)
+
 With weight: -64
 pt[1]:    location: 1.125 1.125
-   is located on boundary: 0
    idx:     (12,12)
+
 With weight: 16
 pt[2]:    location: 0.875 1.375
-   is located on boundary: 0
    idx:     (11,13)
+
 With weight: 16
 pt[3]:    location: 1.375 1.375
-   is located on boundary: 0
    idx:     (13,13)
+
 With weight: 16
 pt[4]:    location: 1.125 1.625
-   is located on boundary: 0
    idx:     (12,14)
+
 With weight: 16
 
 On point:    location: 1.375 1.375
-   is located on boundary: 0
    idx:     (13,13)
+
 pt[0]:    location: 1.375 1.375
-   is located on boundary: 0
    idx:     (13,13)
+
 With weight: -64
 pt[1]:    location: 1.375 1.125
-   is located on boundary: 0
    idx:     (13,12)
+
 With weight: 16
 pt[2]:    location: 1.125 1.375
-   is located on boundary: 0
    idx:     (12,13)
+
 With weight: 16
 pt[3]:    location: 1.625 1.375
-   is located on boundary: 0
    idx:     (14,13)
+
 With weight: 16
 pt[4]:    location: 1.375 1.625
-   is located on boundary: 0
    idx:     (13,14)
+
 With weight: 16
 
 On point:    location: 1.625 1.375
-   is located on boundary: 0
    idx:     (14,13)
+
 pt[0]:    location: 1.625 1.375
-   is located on boundary: 0
    idx:     (14,13)
+
 With weight: -64
 pt[1]:    location: 1.625 1.125
-   is located on boundary: 0
    idx:     (14,12)
+
 With weight: 16
 pt[2]:    location: 1.375 1.375
-   is located on boundary: 0
    idx:     (13,13)
+
 With weight: 16
 pt[3]:    location: 1.875 1.375
-   is located on boundary: 0
    idx:     (15,13)
+
 With weight: 16
 pt[4]:    location: 1.625 1.625
-   is located on boundary: 0
    idx:     (14,14)
+
 With weight: 16
 
 On point:    location: 1.875 1.375
-   is located on boundary: 0
    idx:     (15,13)
+
 pt[0]:    location: 1.875 1.375
-   is located on boundary: 0
    idx:     (15,13)
+
 With weight: -64
 pt[1]:    location: 1.875 1.125
-   is located on boundary: 0
    idx:     (15,12)
+
 With weight: 16
 pt[2]:    location: 1.625 1.375
-   is located on boundary: 0
    idx:     (14,13)
+
 With weight: 16
 pt[3]:    location: 2.125 1.375
-   is located on boundary: 0
    idx:     (16,13)
+
 With weight: 16
 pt[4]:    location: 1.875 1.625
-   is located on boundary: 0
    idx:     (15,14)
+
 With weight: 16
 
 On point:    location: -1.875  1.625
-   is located on boundary: 0
    idx:     (0,14)
+
 pt[0]:    location: -1.875  1.625
-   is located on boundary: 0
    idx:     (0,14)
+
 With weight: -64
 pt[1]:    location: -1.875  1.375
-   is located on boundary: 0
    idx:     (0,13)
+
 With weight: 16
 pt[2]:    location: -2.125  1.625
-   is located on boundary: 0
    idx:     (-1,14)
+
 With weight: 16
 pt[3]:    location: -1.625  1.625
-   is located on boundary: 0
    idx:     (1,14)
+
 With weight: 16
 pt[4]:    location: -1.875  1.875
-   is located on boundary: 0
    idx:     (0,15)
+
 With weight: 16
 
 On point:    location: -1.625  1.625
-   is located on boundary: 0
    idx:     (1,14)
+
 pt[0]:    location: -1.625  1.625
-   is located on boundary: 0
    idx:     (1,14)
+
 With weight: -64
 pt[1]:    location: -1.625  1.375
-   is located on boundary: 0
    idx:     (1,13)
+
 With weight: 16
 pt[2]:    location: -1.875  1.625
-   is located on boundary: 0
    idx:     (0,14)
+
 With weight: 16
 pt[3]:    location: -1.375  1.625
-   is located on boundary: 0
    idx:     (2,14)
+
 With weight: 16
 pt[4]:    location: -1.625  1.875
-   is located on boundary: 0
    idx:     (1,15)
+
 With weight: 16
 
 On point:    location: -1.375  1.625
-   is located on boundary: 0
    idx:     (2,14)
+
 pt[0]:    location: -1.375  1.625
-   is located on boundary: 0
    idx:     (2,14)
+
 With weight: -64
 pt[1]:    location: -1.375  1.375
-   is located on boundary: 0
    idx:     (2,13)
+
 With weight: 16
 pt[2]:    location: -1.625  1.625
-   is located on boundary: 0
    idx:     (1,14)
+
 With weight: 16
 pt[3]:    location: -1.125  1.625
-   is located on boundary: 0
    idx:     (3,14)
+
 With weight: 16
 pt[4]:    location: -1.375  1.875
-   is located on boundary: 0
    idx:     (2,15)
+
 With weight: 16
 
 On point:    location: -1.125  1.625
-   is located on boundary: 0
    idx:     (3,14)
+
 pt[0]:    location: -1.125  1.625
-   is located on boundary: 0
    idx:     (3,14)
+
 With weight: -64
 pt[1]:    location: -1.125  1.375
-   is located on boundary: 0
    idx:     (3,13)
+
 With weight: 16
 pt[2]:    location: -1.375  1.625
-   is located on boundary: 0
    idx:     (2,14)
+
 With weight: 16
 pt[3]:    location: -0.875  1.625
-   is located on boundary: 0
    idx:     (4,14)
+
 With weight: 16
 pt[4]:    location: -1.125  1.875
-   is located on boundary: 0
    idx:     (3,15)
+
 With weight: 16
 
 On point:    location: -0.875  1.625
-   is located on boundary: 0
    idx:     (4,14)
+
 pt[0]:    location: -0.875  1.625
-   is located on boundary: 0
    idx:     (4,14)
+
 With weight: -64
 pt[1]:    location: -0.875  1.375
-   is located on boundary: 0
    idx:     (4,13)
+
 With weight: 16
 pt[2]:    location: -1.125  1.625
-   is located on boundary: 0
    idx:     (3,14)
+
 With weight: 16
 pt[3]:    location: -0.625  1.625
-   is located on boundary: 0
    idx:     (5,14)
+
 With weight: 16
 pt[4]:    location: -0.875  1.875
-   is located on boundary: 0
    idx:     (4,15)
+
 With weight: 16
 
 On point:    location: -0.625  1.625
-   is located on boundary: 0
    idx:     (5,14)
+
 pt[0]:    location: -0.625  1.625
-   is located on boundary: 0
    idx:     (5,14)
+
 With weight: -64
 pt[1]:    location: -0.625  1.375
-   is located on boundary: 0
    idx:     (5,13)
+
 With weight: 16
 pt[2]:    location: -0.875  1.625
-   is located on boundary: 0
    idx:     (4,14)
+
 With weight: 16
 pt[3]:    location: -0.375  1.625
-   is located on boundary: 0
    idx:     (6,14)
+
 With weight: 16
 pt[4]:    location: -0.625  1.875
-   is located on boundary: 0
    idx:     (5,15)
+
 With weight: 16
 
 On point:    location: -0.375  1.625
-   is located on boundary: 0
    idx:     (6,14)
+
 pt[0]:    location: -0.375  1.625
-   is located on boundary: 0
    idx:     (6,14)
+
 With weight: -64
 pt[1]:    location: -0.375  1.375
-   is located on boundary: 0
    idx:     (6,13)
+
 With weight: 16
 pt[2]:    location: -0.625  1.625
-   is located on boundary: 0
    idx:     (5,14)
+
 With weight: 16
 pt[3]:    location: -0.125  1.625
-   is located on boundary: 0
    idx:     (7,14)
+
 With weight: 16
 pt[4]:    location: -0.375  1.875
-   is located on boundary: 0
    idx:     (6,15)
+
 With weight: 16
 
 On point:    location: -0.125  1.625
-   is located on boundary: 0
    idx:     (7,14)
+
 pt[0]:    location: -0.125  1.625
-   is located on boundary: 0
    idx:     (7,14)
+
 With weight: -64
 pt[1]:    location: -0.125  1.375
-   is located on boundary: 0
    idx:     (7,13)
+
 With weight: 16
 pt[2]:    location: -0.375  1.625
-   is located on boundary: 0
    idx:     (6,14)
+
 With weight: 16
 pt[3]:    location: 0.125 1.625
-   is located on boundary: 0
    idx:     (8,14)
+
 With weight: 16
 pt[4]:    location: -0.125  1.875
-   is located on boundary: 0
    idx:     (7,15)
+
 With weight: 16
 
 On point:    location: 0.125 1.625
-   is located on boundary: 0
    idx:     (8,14)
+
 pt[0]:    location: 0.125 1.625
-   is located on boundary: 0
    idx:     (8,14)
+
 With weight: -64
 pt[1]:    location: 0.125 1.375
-   is located on boundary: 0
    idx:     (8,13)
+
 With weight: 16
 pt[2]:    location: -0.125  1.625
-   is located on boundary: 0
    idx:     (7,14)
+
 With weight: 16
 pt[3]:    location: 0.375 1.625
-   is located on boundary: 0
    idx:     (9,14)
+
 With weight: 16
 pt[4]:    location: 0.125 1.875
-   is located on boundary: 0
    idx:     (8,15)
+
 With weight: 16
 
 On point:    location: 0.375 1.625
-   is located on boundary: 0
    idx:     (9,14)
+
 pt[0]:    location: 0.375 1.625
-   is located on boundary: 0
    idx:     (9,14)
+
 With weight: -64
 pt[1]:    location: 0.375 1.375
-   is located on boundary: 0
    idx:     (9,13)
+
 With weight: 16
 pt[2]:    location: 0.125 1.625
-   is located on boundary: 0
    idx:     (8,14)
+
 With weight: 16
 pt[3]:    location: 0.625 1.625
-   is located on boundary: 0
    idx:     (10,14)
+
 With weight: 16
 pt[4]:    location: 0.375 1.875
-   is located on boundary: 0
    idx:     (9,15)
+
 With weight: 16
 
 On point:    location: 0.625 1.625
-   is located on boundary: 0
    idx:     (10,14)
+
 pt[0]:    location: 0.625 1.625
-   is located on boundary: 0
    idx:     (10,14)
+
 With weight: -64
 pt[1]:    location: 0.625 1.375
-   is located on boundary: 0
    idx:     (10,13)
+
 With weight: 16
 pt[2]:    location: 0.375 1.625
-   is located on boundary: 0
    idx:     (9,14)
+
 With weight: 16
 pt[3]:    location: 0.875 1.625
-   is located on boundary: 0
    idx:     (11,14)
+
 With weight: 16
 pt[4]:    location: 0.625 1.875
-   is located on boundary: 0
    idx:     (10,15)
+
 With weight: 16
 
 On point:    location: 0.875 1.625
-   is located on boundary: 0
    idx:     (11,14)
+
 pt[0]:    location: 0.875 1.625
-   is located on boundary: 0
    idx:     (11,14)
+
 With weight: -64
 pt[1]:    location: 0.875 1.375
-   is located on boundary: 0
    idx:     (11,13)
+
 With weight: 16
 pt[2]:    location: 0.625 1.625
-   is located on boundary: 0
    idx:     (10,14)
+
 With weight: 16
 pt[3]:    location: 1.125 1.625
-   is located on boundary: 0
    idx:     (12,14)
+
 With weight: 16
 pt[4]:    location: 0.875 1.875
-   is located on boundary: 0
    idx:     (11,15)
+
 With weight: 16
 
 On point:    location: 1.125 1.625
-   is located on boundary: 0
    idx:     (12,14)
+
 pt[0]:    location: 1.125 1.625
-   is located on boundary: 0
    idx:     (12,14)
+
 With weight: -64
 pt[1]:    location: 1.125 1.375
-   is located on boundary: 0
    idx:     (12,13)
+
 With weight: 16
 pt[2]:    location: 0.875 1.625
-   is located on boundary: 0
    idx:     (11,14)
+
 With weight: 16
 pt[3]:    location: 1.375 1.625
-   is located on boundary: 0
    idx:     (13,14)
+
 With weight: 16
 pt[4]:    location: 1.125 1.875
-   is located on boundary: 0
    idx:     (12,15)
+
 With weight: 16
 
 On point:    location: 1.375 1.625
-   is located on boundary: 0
    idx:     (13,14)
+
 pt[0]:    location: 1.375 1.625
-   is located on boundary: 0
    idx:     (13,14)
+
 With weight: -64
 pt[1]:    location: 1.375 1.375
-   is located on boundary: 0
    idx:     (13,13)
+
 With weight: 16
 pt[2]:    location: 1.125 1.625
-   is located on boundary: 0
    idx:     (12,14)
+
 With weight: 16
 pt[3]:    location: 1.625 1.625
-   is located on boundary: 0
    idx:     (14,14)
+
 With weight: 16
 pt[4]:    location: 1.375 1.875
-   is located on boundary: 0
    idx:     (13,15)
+
 With weight: 16
 
 On point:    location: 1.625 1.625
-   is located on boundary: 0
    idx:     (14,14)
+
 pt[0]:    location: 1.625 1.625
-   is located on boundary: 0
    idx:     (14,14)
+
 With weight: -64
 pt[1]:    location: 1.625 1.375
-   is located on boundary: 0
    idx:     (14,13)
+
 With weight: 16
 pt[2]:    location: 1.375 1.625
-   is located on boundary: 0
    idx:     (13,14)
+
 With weight: 16
 pt[3]:    location: 1.875 1.625
-   is located on boundary: 0
    idx:     (15,14)
+
 With weight: 16
 pt[4]:    location: 1.625 1.875
-   is located on boundary: 0
    idx:     (14,15)
+
 With weight: 16
 
 On point:    location: 1.875 1.625
-   is located on boundary: 0
    idx:     (15,14)
+
 pt[0]:    location: 1.875 1.625
-   is located on boundary: 0
    idx:     (15,14)
+
 With weight: -64
 pt[1]:    location: 1.875 1.375
-   is located on boundary: 0
    idx:     (15,13)
+
 With weight: 16
 pt[2]:    location: 1.625 1.625
-   is located on boundary: 0
    idx:     (14,14)
+
 With weight: 16
 pt[3]:    location: 2.125 1.625
-   is located on boundary: 0
    idx:     (16,14)
+
 With weight: 16
 pt[4]:    location: 1.875 1.875
-   is located on boundary: 0
    idx:     (15,15)
+
 With weight: 16
 
 On point:    location: -1.875  1.875
-   is located on boundary: 0
    idx:     (0,15)
+
 pt[0]:    location: -1.875  1.875
-   is located on boundary: 0
    idx:     (0,15)
+
 With weight: -64
 pt[1]:    location: -1.875  1.625
-   is located on boundary: 0
    idx:     (0,14)
+
 With weight: 16
 pt[2]:    location: -2.125  1.875
-   is located on boundary: 0
    idx:     (-1,15)
+
 With weight: 16
 pt[3]:    location: -1.625  1.875
-   is located on boundary: 0
    idx:     (1,15)
+
 With weight: 16
 pt[4]:    location: -1.875  2.125
-   is located on boundary: 0
    idx:     (0,16)
+
 With weight: 16
 
 On point:    location: -1.625  1.875
-   is located on boundary: 0
    idx:     (1,15)
+
 pt[0]:    location: -1.625  1.875
-   is located on boundary: 0
    idx:     (1,15)
+
 With weight: -64
 pt[1]:    location: -1.625  1.625
-   is located on boundary: 0
    idx:     (1,14)
+
 With weight: 16
 pt[2]:    location: -1.875  1.875
-   is located on boundary: 0
    idx:     (0,15)
+
 With weight: 16
 pt[3]:    location: -1.375  1.875
-   is located on boundary: 0
    idx:     (2,15)
+
 With weight: 16
 pt[4]:    location: -1.625  2.125
-   is located on boundary: 0
    idx:     (1,16)
+
 With weight: 16
 
 On point:    location: -1.375  1.875
-   is located on boundary: 0
    idx:     (2,15)
+
 pt[0]:    location: -1.375  1.875
-   is located on boundary: 0
    idx:     (2,15)
+
 With weight: -64
 pt[1]:    location: -1.375  1.625
-   is located on boundary: 0
    idx:     (2,14)
+
 With weight: 16
 pt[2]:    location: -1.625  1.875
-   is located on boundary: 0
    idx:     (1,15)
+
 With weight: 16
 pt[3]:    location: -1.125  1.875
-   is located on boundary: 0
    idx:     (3,15)
+
 With weight: 16
 pt[4]:    location: -1.375  2.125
-   is located on boundary: 0
    idx:     (2,16)
+
 With weight: 16
 
 On point:    location: -1.125  1.875
-   is located on boundary: 0
    idx:     (3,15)
+
 pt[0]:    location: -1.125  1.875
-   is located on boundary: 0
    idx:     (3,15)
+
 With weight: -64
 pt[1]:    location: -1.125  1.625
-   is located on boundary: 0
    idx:     (3,14)
+
 With weight: 16
 pt[2]:    location: -1.375  1.875
-   is located on boundary: 0
    idx:     (2,15)
+
 With weight: 16
 pt[3]:    location: -0.875  1.875
-   is located on boundary: 0
    idx:     (4,15)
+
 With weight: 16
 pt[4]:    location: -1.125  2.125
-   is located on boundary: 0
    idx:     (3,16)
+
 With weight: 16
 
 On point:    location: -0.875  1.875
-   is located on boundary: 0
    idx:     (4,15)
+
 pt[0]:    location: -0.875  1.875
-   is located on boundary: 0
    idx:     (4,15)
+
 With weight: -64
 pt[1]:    location: -0.875  1.625
-   is located on boundary: 0
    idx:     (4,14)
+
 With weight: 16
 pt[2]:    location: -1.125  1.875
-   is located on boundary: 0
    idx:     (3,15)
+
 With weight: 16
 pt[3]:    location: -0.625  1.875
-   is located on boundary: 0
    idx:     (5,15)
+
 With weight: 16
 pt[4]:    location: -0.875  2.125
-   is located on boundary: 0
    idx:     (4,16)
+
 With weight: 16
 
 On point:    location: -0.625  1.875
-   is located on boundary: 0
    idx:     (5,15)
+
 pt[0]:    location: -0.625  1.875
-   is located on boundary: 0
    idx:     (5,15)
+
 With weight: -64
 pt[1]:    location: -0.625  1.625
-   is located on boundary: 0
    idx:     (5,14)
+
 With weight: 16
 pt[2]:    location: -0.875  1.875
-   is located on boundary: 0
    idx:     (4,15)
+
 With weight: 16
 pt[3]:    location: -0.375  1.875
-   is located on boundary: 0
    idx:     (6,15)
+
 With weight: 16
 pt[4]:    location: -0.625  2.125
-   is located on boundary: 0
    idx:     (5,16)
+
 With weight: 16
 
 On point:    location: -0.375  1.875
-   is located on boundary: 0
    idx:     (6,15)
+
 pt[0]:    location: -0.375  1.875
-   is located on boundary: 0
    idx:     (6,15)
+
 With weight: -64
 pt[1]:    location: -0.375  1.625
-   is located on boundary: 0
    idx:     (6,14)
+
 With weight: 16
 pt[2]:    location: -0.625  1.875
-   is located on boundary: 0
    idx:     (5,15)
+
 With weight: 16
 pt[3]:    location: -0.125  1.875
-   is located on boundary: 0
    idx:     (7,15)
+
 With weight: 16
 pt[4]:    location: -0.375  2.125
-   is located on boundary: 0
    idx:     (6,16)
+
 With weight: 16
 
 On point:    location: -0.125  1.875
-   is located on boundary: 0
    idx:     (7,15)
+
 pt[0]:    location: -0.125  1.875
-   is located on boundary: 0
    idx:     (7,15)
+
 With weight: -64
 pt[1]:    location: -0.125  1.625
-   is located on boundary: 0
    idx:     (7,14)
+
 With weight: 16
 pt[2]:    location: -0.375  1.875
-   is located on boundary: 0
    idx:     (6,15)
+
 With weight: 16
 pt[3]:    location: 0.125 1.875
-   is located on boundary: 0
    idx:     (8,15)
+
 With weight: 16
 pt[4]:    location: -0.125  2.125
-   is located on boundary: 0
    idx:     (7,16)
+
 With weight: 16
 
 On point:    location: 0.125 1.875
-   is located on boundary: 0
    idx:     (8,15)
+
 pt[0]:    location: 0.125 1.875
-   is located on boundary: 0
    idx:     (8,15)
+
 With weight: -64
 pt[1]:    location: 0.125 1.625
-   is located on boundary: 0
    idx:     (8,14)
+
 With weight: 16
 pt[2]:    location: -0.125  1.875
-   is located on boundary: 0
    idx:     (7,15)
+
 With weight: 16
 pt[3]:    location: 0.375 1.875
-   is located on boundary: 0
    idx:     (9,15)
+
 With weight: 16
 pt[4]:    location: 0.125 2.125
-   is located on boundary: 0
    idx:     (8,16)
+
 With weight: 16
 
 On point:    location: 0.375 1.875
-   is located on boundary: 0
    idx:     (9,15)
+
 pt[0]:    location: 0.375 1.875
-   is located on boundary: 0
    idx:     (9,15)
+
 With weight: -64
 pt[1]:    location: 0.375 1.625
-   is located on boundary: 0
    idx:     (9,14)
+
 With weight: 16
 pt[2]:    location: 0.125 1.875
-   is located on boundary: 0
    idx:     (8,15)
+
 With weight: 16
 pt[3]:    location: 0.625 1.875
-   is located on boundary: 0
    idx:     (10,15)
+
 With weight: 16
 pt[4]:    location: 0.375 2.125
-   is located on boundary: 0
    idx:     (9,16)
+
 With weight: 16
 
 On point:    location: 0.625 1.875
-   is located on boundary: 0
    idx:     (10,15)
+
 pt[0]:    location: 0.625 1.875
-   is located on boundary: 0
    idx:     (10,15)
+
 With weight: -64
 pt[1]:    location: 0.625 1.625
-   is located on boundary: 0
    idx:     (10,14)
+
 With weight: 16
 pt[2]:    location: 0.375 1.875
-   is located on boundary: 0
    idx:     (9,15)
+
 With weight: 16
 pt[3]:    location: 0.875 1.875
-   is located on boundary: 0
    idx:     (11,15)
+
 With weight: 16
 pt[4]:    location: 0.625 2.125
-   is located on boundary: 0
    idx:     (10,16)
+
 With weight: 16
 
 On point:    location: 0.875 1.875
-   is located on boundary: 0
    idx:     (11,15)
+
 pt[0]:    location: 0.875 1.875
-   is located on boundary: 0
    idx:     (11,15)
+
 With weight: -64
 pt[1]:    location: 0.875 1.625
-   is located on boundary: 0
    idx:     (11,14)
+
 With weight: 16
 pt[2]:    location: 0.625 1.875
-   is located on boundary: 0
    idx:     (10,15)
+
 With weight: 16
 pt[3]:    location: 1.125 1.875
-   is located on boundary: 0
    idx:     (12,15)
+
 With weight: 16
 pt[4]:    location: 0.875 2.125
-   is located on boundary: 0
    idx:     (11,16)
+
 With weight: 16
 
 On point:    location: 1.125 1.875
-   is located on boundary: 0
    idx:     (12,15)
+
 pt[0]:    location: 1.125 1.875
-   is located on boundary: 0
    idx:     (12,15)
+
 With weight: -64
 pt[1]:    location: 1.125 1.625
-   is located on boundary: 0
    idx:     (12,14)
+
 With weight: 16
 pt[2]:    location: 0.875 1.875
-   is located on boundary: 0
    idx:     (11,15)
+
 With weight: 16
 pt[3]:    location: 1.375 1.875
-   is located on boundary: 0
    idx:     (13,15)
+
 With weight: 16
 pt[4]:    location: 1.125 2.125
-   is located on boundary: 0
    idx:     (12,16)
+
 With weight: 16
 
 On point:    location: 1.375 1.875
-   is located on boundary: 0
    idx:     (13,15)
+
 pt[0]:    location: 1.375 1.875
-   is located on boundary: 0
    idx:     (13,15)
+
 With weight: -64
 pt[1]:    location: 1.375 1.625
-   is located on boundary: 0
    idx:     (13,14)
+
 With weight: 16
 pt[2]:    location: 1.125 1.875
-   is located on boundary: 0
    idx:     (12,15)
+
 With weight: 16
 pt[3]:    location: 1.625 1.875
-   is located on boundary: 0
    idx:     (14,15)
+
 With weight: 16
 pt[4]:    location: 1.375 2.125
-   is located on boundary: 0
    idx:     (13,16)
+
 With weight: 16
 
 On point:    location: 1.625 1.875
-   is located on boundary: 0
    idx:     (14,15)
+
 pt[0]:    location: 1.625 1.875
-   is located on boundary: 0
    idx:     (14,15)
+
 With weight: -64
 pt[1]:    location: 1.625 1.625
-   is located on boundary: 0
    idx:     (14,14)
+
 With weight: 16
 pt[2]:    location: 1.375 1.875
-   is located on boundary: 0
    idx:     (13,15)
+
 With weight: 16
 pt[3]:    location: 1.875 1.875
-   is located on boundary: 0
    idx:     (15,15)
+
 With weight: 16
 pt[4]:    location: 1.625 2.125
-   is located on boundary: 0
    idx:     (14,16)
+
 With weight: 16
 
 On point:    location: 1.875 1.875
-   is located on boundary: 0
    idx:     (15,15)
+
 pt[0]:    location: 1.875 1.875
-   is located on boundary: 0
    idx:     (15,15)
+
 With weight: -64
 pt[1]:    location: 1.875 1.625
-   is located on boundary: 0
    idx:     (15,14)
+
 With weight: 16
 pt[2]:    location: 1.625 1.875
-   is located on boundary: 0
    idx:     (14,15)
+
 With weight: 16
 pt[3]:    location: 2.125 1.875
-   is located on boundary: 0
    idx:     (16,15)
+
 With weight: 16
 pt[4]:    location: 1.875 2.125
-   is located on boundary: 0
    idx:     (15,16)
+
 With weight: 16
 

--- a/tests/operators/rbf_fd_weights_2d.output
+++ b/tests/operators/rbf_fd_weights_2d.output
@@ -1,4224 +1,3168 @@
 On point:    location: -1.875 -1.875
    idx:     (0,0)
-
 pt[0]:    location: -1.875 -1.875
    idx:     (0,0)
-
 With weight: -64
 pt[1]:    location: -1.875 -2.125
    idx:     (0,-1)
-
 With weight: 16
 pt[2]:    location: -2.125 -1.875
    idx:     (-1,0)
-
 With weight: 16
 pt[3]:    location: -1.625 -1.875
    idx:     (1,0)
-
 With weight: 16
 pt[4]:    location: -1.875 -1.625
    idx:     (0,1)
-
 With weight: 16
 
 On point:    location: -1.625 -1.875
    idx:     (1,0)
-
 pt[0]:    location: -1.625 -1.875
    idx:     (1,0)
-
 With weight: -64
 pt[1]:    location: -1.625 -2.125
    idx:     (1,-1)
-
 With weight: 16
 pt[2]:    location: -1.875 -1.875
    idx:     (0,0)
-
 With weight: 16
 pt[3]:    location: -1.375 -1.875
    idx:     (2,0)
-
 With weight: 16
 pt[4]:    location: -1.625 -1.625
    idx:     (1,1)
-
 With weight: 16
 
 On point:    location: -1.375 -1.875
    idx:     (2,0)
-
 pt[0]:    location: -1.375 -1.875
    idx:     (2,0)
-
 With weight: -64
 pt[1]:    location: -1.375 -2.125
    idx:     (2,-1)
-
 With weight: 16
 pt[2]:    location: -1.625 -1.875
    idx:     (1,0)
-
 With weight: 16
 pt[3]:    location: -1.125 -1.875
    idx:     (3,0)
-
 With weight: 16
 pt[4]:    location: -1.375 -1.625
    idx:     (2,1)
-
 With weight: 16
 
 On point:    location: -1.125 -1.875
    idx:     (3,0)
-
 pt[0]:    location: -1.125 -1.875
    idx:     (3,0)
-
 With weight: -64
 pt[1]:    location: -1.125 -2.125
    idx:     (3,-1)
-
 With weight: 16
 pt[2]:    location: -1.375 -1.875
    idx:     (2,0)
-
 With weight: 16
 pt[3]:    location: -0.875 -1.875
    idx:     (4,0)
-
 With weight: 16
 pt[4]:    location: -1.125 -1.625
    idx:     (3,1)
-
 With weight: 16
 
 On point:    location: -0.875 -1.875
    idx:     (4,0)
-
 pt[0]:    location: -0.875 -1.875
    idx:     (4,0)
-
 With weight: -64
 pt[1]:    location: -0.875 -2.125
    idx:     (4,-1)
-
 With weight: 16
 pt[2]:    location: -1.125 -1.875
    idx:     (3,0)
-
 With weight: 16
 pt[3]:    location: -0.625 -1.875
    idx:     (5,0)
-
 With weight: 16
 pt[4]:    location: -0.875 -1.625
    idx:     (4,1)
-
 With weight: 16
 
 On point:    location: -0.625 -1.875
    idx:     (5,0)
-
 pt[0]:    location: -0.625 -1.875
    idx:     (5,0)
-
 With weight: -64
 pt[1]:    location: -0.625 -2.125
    idx:     (5,-1)
-
 With weight: 16
 pt[2]:    location: -0.875 -1.875
    idx:     (4,0)
-
 With weight: 16
 pt[3]:    location: -0.375 -1.875
    idx:     (6,0)
-
 With weight: 16
 pt[4]:    location: -0.625 -1.625
    idx:     (5,1)
-
 With weight: 16
 
 On point:    location: -0.375 -1.875
    idx:     (6,0)
-
 pt[0]:    location: -0.375 -1.875
    idx:     (6,0)
-
 With weight: -64
 pt[1]:    location: -0.375 -2.125
    idx:     (6,-1)
-
 With weight: 16
 pt[2]:    location: -0.625 -1.875
    idx:     (5,0)
-
 With weight: 16
 pt[3]:    location: -0.125 -1.875
    idx:     (7,0)
-
 With weight: 16
 pt[4]:    location: -0.375 -1.625
    idx:     (6,1)
-
 With weight: 16
 
 On point:    location: -0.125 -1.875
    idx:     (7,0)
-
 pt[0]:    location: -0.125 -1.875
    idx:     (7,0)
-
 With weight: -64
 pt[1]:    location: -0.125 -2.125
    idx:     (7,-1)
-
 With weight: 16
 pt[2]:    location: -0.375 -1.875
    idx:     (6,0)
-
 With weight: 16
 pt[3]:    location:  0.125 -1.875
    idx:     (8,0)
-
 With weight: 16
 pt[4]:    location: -0.125 -1.625
    idx:     (7,1)
-
 With weight: 16
 
 On point:    location:  0.125 -1.875
    idx:     (8,0)
-
 pt[0]:    location:  0.125 -1.875
    idx:     (8,0)
-
 With weight: -64
 pt[1]:    location:  0.125 -2.125
    idx:     (8,-1)
-
 With weight: 16
 pt[2]:    location: -0.125 -1.875
    idx:     (7,0)
-
 With weight: 16
 pt[3]:    location:  0.375 -1.875
    idx:     (9,0)
-
 With weight: 16
 pt[4]:    location:  0.125 -1.625
    idx:     (8,1)
-
 With weight: 16
 
 On point:    location:  0.375 -1.875
    idx:     (9,0)
-
 pt[0]:    location:  0.375 -1.875
    idx:     (9,0)
-
 With weight: -64
 pt[1]:    location:  0.375 -2.125
    idx:     (9,-1)
-
 With weight: 16
 pt[2]:    location:  0.125 -1.875
    idx:     (8,0)
-
 With weight: 16
 pt[3]:    location:  0.625 -1.875
    idx:     (10,0)
-
 With weight: 16
 pt[4]:    location:  0.375 -1.625
    idx:     (9,1)
-
 With weight: 16
 
 On point:    location:  0.625 -1.875
    idx:     (10,0)
-
 pt[0]:    location:  0.625 -1.875
    idx:     (10,0)
-
 With weight: -64
 pt[1]:    location:  0.625 -2.125
    idx:     (10,-1)
-
 With weight: 16
 pt[2]:    location:  0.375 -1.875
    idx:     (9,0)
-
 With weight: 16
 pt[3]:    location:  0.875 -1.875
    idx:     (11,0)
-
 With weight: 16
 pt[4]:    location:  0.625 -1.625
    idx:     (10,1)
-
 With weight: 16
 
 On point:    location:  0.875 -1.875
    idx:     (11,0)
-
 pt[0]:    location:  0.875 -1.875
    idx:     (11,0)
-
 With weight: -64
 pt[1]:    location:  0.875 -2.125
    idx:     (11,-1)
-
 With weight: 16
 pt[2]:    location:  0.625 -1.875
    idx:     (10,0)
-
 With weight: 16
 pt[3]:    location:  1.125 -1.875
    idx:     (12,0)
-
 With weight: 16
 pt[4]:    location:  0.875 -1.625
    idx:     (11,1)
-
 With weight: 16
 
 On point:    location:  1.125 -1.875
    idx:     (12,0)
-
 pt[0]:    location:  1.125 -1.875
    idx:     (12,0)
-
 With weight: -64
 pt[1]:    location:  1.125 -2.125
    idx:     (12,-1)
-
 With weight: 16
 pt[2]:    location:  0.875 -1.875
    idx:     (11,0)
-
 With weight: 16
 pt[3]:    location:  1.375 -1.875
    idx:     (13,0)
-
 With weight: 16
 pt[4]:    location:  1.125 -1.625
    idx:     (12,1)
-
 With weight: 16
 
 On point:    location:  1.375 -1.875
    idx:     (13,0)
-
 pt[0]:    location:  1.375 -1.875
    idx:     (13,0)
-
 With weight: -64
 pt[1]:    location:  1.375 -2.125
    idx:     (13,-1)
-
 With weight: 16
 pt[2]:    location:  1.125 -1.875
    idx:     (12,0)
-
 With weight: 16
 pt[3]:    location:  1.625 -1.875
    idx:     (14,0)
-
 With weight: 16
 pt[4]:    location:  1.375 -1.625
    idx:     (13,1)
-
 With weight: 16
 
 On point:    location:  1.625 -1.875
    idx:     (14,0)
-
 pt[0]:    location:  1.625 -1.875
    idx:     (14,0)
-
 With weight: -64
 pt[1]:    location:  1.625 -2.125
    idx:     (14,-1)
-
 With weight: 16
 pt[2]:    location:  1.375 -1.875
    idx:     (13,0)
-
 With weight: 16
 pt[3]:    location:  1.875 -1.875
    idx:     (15,0)
-
 With weight: 16
 pt[4]:    location:  1.625 -1.625
    idx:     (14,1)
-
 With weight: 16
 
 On point:    location:  1.875 -1.875
    idx:     (15,0)
-
 pt[0]:    location:  1.875 -1.875
    idx:     (15,0)
-
 With weight: -64
 pt[1]:    location:  1.875 -2.125
    idx:     (15,-1)
-
 With weight: 16
 pt[2]:    location:  1.625 -1.875
    idx:     (14,0)
-
 With weight: 16
 pt[3]:    location:  2.125 -1.875
    idx:     (16,0)
-
 With weight: 16
 pt[4]:    location:  1.875 -1.625
    idx:     (15,1)
-
 With weight: 16
 
 On point:    location: -1.875 -1.625
    idx:     (0,1)
-
 pt[0]:    location: -1.875 -1.625
    idx:     (0,1)
-
 With weight: -64
 pt[1]:    location: -1.875 -1.875
    idx:     (0,0)
-
 With weight: 16
 pt[2]:    location: -2.125 -1.625
    idx:     (-1,1)
-
 With weight: 16
 pt[3]:    location: -1.625 -1.625
    idx:     (1,1)
-
 With weight: 16
 pt[4]:    location: -1.875 -1.375
    idx:     (0,2)
-
 With weight: 16
 
 On point:    location: -1.625 -1.625
    idx:     (1,1)
-
 pt[0]:    location: -1.625 -1.625
    idx:     (1,1)
-
 With weight: -64
 pt[1]:    location: -1.625 -1.875
    idx:     (1,0)
-
 With weight: 16
 pt[2]:    location: -1.875 -1.625
    idx:     (0,1)
-
 With weight: 16
 pt[3]:    location: -1.375 -1.625
    idx:     (2,1)
-
 With weight: 16
 pt[4]:    location: -1.625 -1.375
    idx:     (1,2)
-
 With weight: 16
 
 On point:    location: -1.375 -1.625
    idx:     (2,1)
-
 pt[0]:    location: -1.375 -1.625
    idx:     (2,1)
-
 With weight: -64
 pt[1]:    location: -1.375 -1.875
    idx:     (2,0)
-
 With weight: 16
 pt[2]:    location: -1.625 -1.625
    idx:     (1,1)
-
 With weight: 16
 pt[3]:    location: -1.125 -1.625
    idx:     (3,1)
-
 With weight: 16
 pt[4]:    location: -1.375 -1.375
    idx:     (2,2)
-
 With weight: 16
 
 On point:    location: -1.125 -1.625
    idx:     (3,1)
-
 pt[0]:    location: -1.125 -1.625
    idx:     (3,1)
-
 With weight: -64
 pt[1]:    location: -1.125 -1.875
    idx:     (3,0)
-
 With weight: 16
 pt[2]:    location: -1.375 -1.625
    idx:     (2,1)
-
 With weight: 16
 pt[3]:    location: -0.875 -1.625
    idx:     (4,1)
-
 With weight: 16
 pt[4]:    location: -1.125 -1.375
    idx:     (3,2)
-
 With weight: 16
 
 On point:    location: -0.875 -1.625
    idx:     (4,1)
-
 pt[0]:    location: -0.875 -1.625
    idx:     (4,1)
-
 With weight: -64
 pt[1]:    location: -0.875 -1.875
    idx:     (4,0)
-
 With weight: 16
 pt[2]:    location: -1.125 -1.625
    idx:     (3,1)
-
 With weight: 16
 pt[3]:    location: -0.625 -1.625
    idx:     (5,1)
-
 With weight: 16
 pt[4]:    location: -0.875 -1.375
    idx:     (4,2)
-
 With weight: 16
 
 On point:    location: -0.625 -1.625
    idx:     (5,1)
-
 pt[0]:    location: -0.625 -1.625
    idx:     (5,1)
-
 With weight: -64
 pt[1]:    location: -0.625 -1.875
    idx:     (5,0)
-
 With weight: 16
 pt[2]:    location: -0.875 -1.625
    idx:     (4,1)
-
 With weight: 16
 pt[3]:    location: -0.375 -1.625
    idx:     (6,1)
-
 With weight: 16
 pt[4]:    location: -0.625 -1.375
    idx:     (5,2)
-
 With weight: 16
 
 On point:    location: -0.375 -1.625
    idx:     (6,1)
-
 pt[0]:    location: -0.375 -1.625
    idx:     (6,1)
-
 With weight: -64
 pt[1]:    location: -0.375 -1.875
    idx:     (6,0)
-
 With weight: 16
 pt[2]:    location: -0.625 -1.625
    idx:     (5,1)
-
 With weight: 16
 pt[3]:    location: -0.125 -1.625
    idx:     (7,1)
-
 With weight: 16
 pt[4]:    location: -0.375 -1.375
    idx:     (6,2)
-
 With weight: 16
 
 On point:    location: -0.125 -1.625
    idx:     (7,1)
-
 pt[0]:    location: -0.125 -1.625
    idx:     (7,1)
-
 With weight: -64
 pt[1]:    location: -0.125 -1.875
    idx:     (7,0)
-
 With weight: 16
 pt[2]:    location: -0.375 -1.625
    idx:     (6,1)
-
 With weight: 16
 pt[3]:    location:  0.125 -1.625
    idx:     (8,1)
-
 With weight: 16
 pt[4]:    location: -0.125 -1.375
    idx:     (7,2)
-
 With weight: 16
 
 On point:    location:  0.125 -1.625
    idx:     (8,1)
-
 pt[0]:    location:  0.125 -1.625
    idx:     (8,1)
-
 With weight: -64
 pt[1]:    location:  0.125 -1.875
    idx:     (8,0)
-
 With weight: 16
 pt[2]:    location: -0.125 -1.625
    idx:     (7,1)
-
 With weight: 16
 pt[3]:    location:  0.375 -1.625
    idx:     (9,1)
-
 With weight: 16
 pt[4]:    location:  0.125 -1.375
    idx:     (8,2)
-
 With weight: 16
 
 On point:    location:  0.375 -1.625
    idx:     (9,1)
-
 pt[0]:    location:  0.375 -1.625
    idx:     (9,1)
-
 With weight: -64
 pt[1]:    location:  0.375 -1.875
    idx:     (9,0)
-
 With weight: 16
 pt[2]:    location:  0.125 -1.625
    idx:     (8,1)
-
 With weight: 16
 pt[3]:    location:  0.625 -1.625
    idx:     (10,1)
-
 With weight: 16
 pt[4]:    location:  0.375 -1.375
    idx:     (9,2)
-
 With weight: 16
 
 On point:    location:  0.625 -1.625
    idx:     (10,1)
-
 pt[0]:    location:  0.625 -1.625
    idx:     (10,1)
-
 With weight: -64
 pt[1]:    location:  0.625 -1.875
    idx:     (10,0)
-
 With weight: 16
 pt[2]:    location:  0.375 -1.625
    idx:     (9,1)
-
 With weight: 16
 pt[3]:    location:  0.875 -1.625
    idx:     (11,1)
-
 With weight: 16
 pt[4]:    location:  0.625 -1.375
    idx:     (10,2)
-
 With weight: 16
 
 On point:    location:  0.875 -1.625
    idx:     (11,1)
-
 pt[0]:    location:  0.875 -1.625
    idx:     (11,1)
-
 With weight: -64
 pt[1]:    location:  0.875 -1.875
    idx:     (11,0)
-
 With weight: 16
 pt[2]:    location:  0.625 -1.625
    idx:     (10,1)
-
 With weight: 16
 pt[3]:    location:  1.125 -1.625
    idx:     (12,1)
-
 With weight: 16
 pt[4]:    location:  0.875 -1.375
    idx:     (11,2)
-
 With weight: 16
 
 On point:    location:  1.125 -1.625
    idx:     (12,1)
-
 pt[0]:    location:  1.125 -1.625
    idx:     (12,1)
-
 With weight: -64
 pt[1]:    location:  1.125 -1.875
    idx:     (12,0)
-
 With weight: 16
 pt[2]:    location:  0.875 -1.625
    idx:     (11,1)
-
 With weight: 16
 pt[3]:    location:  1.375 -1.625
    idx:     (13,1)
-
 With weight: 16
 pt[4]:    location:  1.125 -1.375
    idx:     (12,2)
-
 With weight: 16
 
 On point:    location:  1.375 -1.625
    idx:     (13,1)
-
 pt[0]:    location:  1.375 -1.625
    idx:     (13,1)
-
 With weight: -64
 pt[1]:    location:  1.375 -1.875
    idx:     (13,0)
-
 With weight: 16
 pt[2]:    location:  1.125 -1.625
    idx:     (12,1)
-
 With weight: 16
 pt[3]:    location:  1.625 -1.625
    idx:     (14,1)
-
 With weight: 16
 pt[4]:    location:  1.375 -1.375
    idx:     (13,2)
-
 With weight: 16
 
 On point:    location:  1.625 -1.625
    idx:     (14,1)
-
 pt[0]:    location:  1.625 -1.625
    idx:     (14,1)
-
 With weight: -64
 pt[1]:    location:  1.625 -1.875
    idx:     (14,0)
-
 With weight: 16
 pt[2]:    location:  1.375 -1.625
    idx:     (13,1)
-
 With weight: 16
 pt[3]:    location:  1.875 -1.625
    idx:     (15,1)
-
 With weight: 16
 pt[4]:    location:  1.625 -1.375
    idx:     (14,2)
-
 With weight: 16
 
 On point:    location:  1.875 -1.625
    idx:     (15,1)
-
 pt[0]:    location:  1.875 -1.625
    idx:     (15,1)
-
 With weight: -64
 pt[1]:    location:  1.875 -1.875
    idx:     (15,0)
-
 With weight: 16
 pt[2]:    location:  1.625 -1.625
    idx:     (14,1)
-
 With weight: 16
 pt[3]:    location:  2.125 -1.625
    idx:     (16,1)
-
 With weight: 16
 pt[4]:    location:  1.875 -1.375
    idx:     (15,2)
-
 With weight: 16
 
 On point:    location: -1.875 -1.375
    idx:     (0,2)
-
 pt[0]:    location: -1.875 -1.375
    idx:     (0,2)
-
 With weight: -64
 pt[1]:    location: -1.875 -1.625
    idx:     (0,1)
-
 With weight: 16
 pt[2]:    location: -2.125 -1.375
    idx:     (-1,2)
-
 With weight: 16
 pt[3]:    location: -1.625 -1.375
    idx:     (1,2)
-
 With weight: 16
 pt[4]:    location: -1.875 -1.125
    idx:     (0,3)
-
 With weight: 16
 
 On point:    location: -1.625 -1.375
    idx:     (1,2)
-
 pt[0]:    location: -1.625 -1.375
    idx:     (1,2)
-
 With weight: -64
 pt[1]:    location: -1.625 -1.625
    idx:     (1,1)
-
 With weight: 16
 pt[2]:    location: -1.875 -1.375
    idx:     (0,2)
-
 With weight: 16
 pt[3]:    location: -1.375 -1.375
    idx:     (2,2)
-
 With weight: 16
 pt[4]:    location: -1.625 -1.125
    idx:     (1,3)
-
 With weight: 16
 
 On point:    location: -1.375 -1.375
    idx:     (2,2)
-
 pt[0]:    location: -1.375 -1.375
    idx:     (2,2)
-
 With weight: -64
 pt[1]:    location: -1.375 -1.625
    idx:     (2,1)
-
 With weight: 16
 pt[2]:    location: -1.625 -1.375
    idx:     (1,2)
-
 With weight: 16
 pt[3]:    location: -1.125 -1.375
    idx:     (3,2)
-
 With weight: 16
 pt[4]:    location: -1.375 -1.125
    idx:     (2,3)
-
 With weight: 16
 
 On point:    location: -1.125 -1.375
    idx:     (3,2)
-
 pt[0]:    location: -1.125 -1.375
    idx:     (3,2)
-
 With weight: -64
 pt[1]:    location: -1.125 -1.625
    idx:     (3,1)
-
 With weight: 16
 pt[2]:    location: -1.375 -1.375
    idx:     (2,2)
-
 With weight: 16
 pt[3]:    location: -0.875 -1.375
    idx:     (4,2)
-
 With weight: 16
 pt[4]:    location: -1.125 -1.125
    idx:     (3,3)
-
 With weight: 16
 
 On point:    location: -0.875 -1.375
    idx:     (4,2)
-
 pt[0]:    location: -0.875 -1.375
    idx:     (4,2)
-
 With weight: -64
 pt[1]:    location: -0.875 -1.625
    idx:     (4,1)
-
 With weight: 16
 pt[2]:    location: -1.125 -1.375
    idx:     (3,2)
-
 With weight: 16
 pt[3]:    location: -0.625 -1.375
    idx:     (5,2)
-
 With weight: 16
 pt[4]:    location: -0.875 -1.125
    idx:     (4,3)
-
 With weight: 16
 
 On point:    location: -0.625 -1.375
    idx:     (5,2)
-
 pt[0]:    location: -0.625 -1.375
    idx:     (5,2)
-
 With weight: -64
 pt[1]:    location: -0.625 -1.625
    idx:     (5,1)
-
 With weight: 16
 pt[2]:    location: -0.875 -1.375
    idx:     (4,2)
-
 With weight: 16
 pt[3]:    location: -0.375 -1.375
    idx:     (6,2)
-
 With weight: 16
 pt[4]:    location: -0.625 -1.125
    idx:     (5,3)
-
 With weight: 16
 
 On point:    location: -0.375 -1.375
    idx:     (6,2)
-
 pt[0]:    location: -0.375 -1.375
    idx:     (6,2)
-
 With weight: -42.6667
 pt[1]:    location: -0.375 -1.625
    idx:     (6,1)
-
 With weight: 10.6667
 pt[2]:    location: -0.625 -1.375
    idx:     (5,2)
-
 With weight: 16
 pt[3]:    location: -0.125 -1.375
    idx:     (7,2)
-
 With weight: 16
 pt[4]:    location: -0.625 -1.625
    idx:     (5,1)
-
 With weight: -2.03742e-15
 
 On point:    location: -0.125 -1.375
    idx:     (7,2)
-
 pt[0]:    location: -0.125 -1.375
    idx:     (7,2)
-
 With weight: -42.6667
 pt[1]:    location: -0.125 -1.625
    idx:     (7,1)
-
 With weight: 10.6667
 pt[2]:    location: -0.375 -1.375
    idx:     (6,2)
-
 With weight: 16
 pt[3]:    location:  0.125 -1.375
    idx:     (8,2)
-
 With weight: 16
 pt[4]:    location: -0.375 -1.625
    idx:     (6,1)
-
 With weight: -2.03742e-15
 
 On point:    location:  0.125 -1.375
    idx:     (8,2)
-
 pt[0]:    location:  0.125 -1.375
    idx:     (8,2)
-
 With weight: -42.6667
 pt[1]:    location:  0.125 -1.625
    idx:     (8,1)
-
 With weight: 10.6667
 pt[2]:    location: -0.125 -1.375
    idx:     (7,2)
-
 With weight: 16
 pt[3]:    location:  0.375 -1.375
    idx:     (9,2)
-
 With weight: 16
 pt[4]:    location: -0.125 -1.625
    idx:     (7,1)
-
 With weight: -2.03742e-15
 
 On point:    location:  0.375 -1.375
    idx:     (9,2)
-
 pt[0]:    location:  0.375 -1.375
    idx:     (9,2)
-
 With weight: -42.6667
 pt[1]:    location:  0.375 -1.625
    idx:     (9,1)
-
 With weight: 10.6667
 pt[2]:    location:  0.125 -1.375
    idx:     (8,2)
-
 With weight: 16
 pt[3]:    location:  0.625 -1.375
    idx:     (10,2)
-
 With weight: 16
 pt[4]:    location:  0.125 -1.625
    idx:     (8,1)
-
 With weight: -2.03742e-15
 
 On point:    location:  0.625 -1.375
    idx:     (10,2)
-
 pt[0]:    location:  0.625 -1.375
    idx:     (10,2)
-
 With weight: -64
 pt[1]:    location:  0.625 -1.625
    idx:     (10,1)
-
 With weight: 16
 pt[2]:    location:  0.375 -1.375
    idx:     (9,2)
-
 With weight: 16
 pt[3]:    location:  0.875 -1.375
    idx:     (11,2)
-
 With weight: 16
 pt[4]:    location:  0.625 -1.125
    idx:     (10,3)
-
 With weight: 16
 
 On point:    location:  0.875 -1.375
    idx:     (11,2)
-
 pt[0]:    location:  0.875 -1.375
    idx:     (11,2)
-
 With weight: -64
 pt[1]:    location:  0.875 -1.625
    idx:     (11,1)
-
 With weight: 16
 pt[2]:    location:  0.625 -1.375
    idx:     (10,2)
-
 With weight: 16
 pt[3]:    location:  1.125 -1.375
    idx:     (12,2)
-
 With weight: 16
 pt[4]:    location:  0.875 -1.125
    idx:     (11,3)
-
 With weight: 16
 
 On point:    location:  1.125 -1.375
    idx:     (12,2)
-
 pt[0]:    location:  1.125 -1.375
    idx:     (12,2)
-
 With weight: -64
 pt[1]:    location:  1.125 -1.625
    idx:     (12,1)
-
 With weight: 16
 pt[2]:    location:  0.875 -1.375
    idx:     (11,2)
-
 With weight: 16
 pt[3]:    location:  1.375 -1.375
    idx:     (13,2)
-
 With weight: 16
 pt[4]:    location:  1.125 -1.125
    idx:     (12,3)
-
 With weight: 16
 
 On point:    location:  1.375 -1.375
    idx:     (13,2)
-
 pt[0]:    location:  1.375 -1.375
    idx:     (13,2)
-
 With weight: -64
 pt[1]:    location:  1.375 -1.625
    idx:     (13,1)
-
 With weight: 16
 pt[2]:    location:  1.125 -1.375
    idx:     (12,2)
-
 With weight: 16
 pt[3]:    location:  1.625 -1.375
    idx:     (14,2)
-
 With weight: 16
 pt[4]:    location:  1.375 -1.125
    idx:     (13,3)
-
 With weight: 16
 
 On point:    location:  1.625 -1.375
    idx:     (14,2)
-
 pt[0]:    location:  1.625 -1.375
    idx:     (14,2)
-
 With weight: -64
 pt[1]:    location:  1.625 -1.625
    idx:     (14,1)
-
 With weight: 16
 pt[2]:    location:  1.375 -1.375
    idx:     (13,2)
-
 With weight: 16
 pt[3]:    location:  1.875 -1.375
    idx:     (15,2)
-
 With weight: 16
 pt[4]:    location:  1.625 -1.125
    idx:     (14,3)
-
 With weight: 16
 
 On point:    location:  1.875 -1.375
    idx:     (15,2)
-
 pt[0]:    location:  1.875 -1.375
    idx:     (15,2)
-
 With weight: -64
 pt[1]:    location:  1.875 -1.625
    idx:     (15,1)
-
 With weight: 16
 pt[2]:    location:  1.625 -1.375
    idx:     (14,2)
-
 With weight: 16
 pt[3]:    location:  2.125 -1.375
    idx:     (16,2)
-
 With weight: 16
 pt[4]:    location:  1.875 -1.125
    idx:     (15,3)
-
 With weight: 16
 
 On point:    location: -1.875 -1.125
    idx:     (0,3)
-
 pt[0]:    location: -1.875 -1.125
    idx:     (0,3)
-
 With weight: -64
 pt[1]:    location: -1.875 -1.375
    idx:     (0,2)
-
 With weight: 16
 pt[2]:    location: -2.125 -1.125
    idx:     (-1,3)
-
 With weight: 16
 pt[3]:    location: -1.625 -1.125
    idx:     (1,3)
-
 With weight: 16
 pt[4]:    location: -1.875 -0.875
    idx:     (0,4)
-
 With weight: 16
 
 On point:    location: -1.625 -1.125
    idx:     (1,3)
-
 pt[0]:    location: -1.625 -1.125
    idx:     (1,3)
-
 With weight: -64
 pt[1]:    location: -1.625 -1.375
    idx:     (1,2)
-
 With weight: 16
 pt[2]:    location: -1.875 -1.125
    idx:     (0,3)
-
 With weight: 16
 pt[3]:    location: -1.375 -1.125
    idx:     (2,3)
-
 With weight: 16
 pt[4]:    location: -1.625 -0.875
    idx:     (1,4)
-
 With weight: 16
 
 On point:    location: -1.375 -1.125
    idx:     (2,3)
-
 pt[0]:    location: -1.375 -1.125
    idx:     (2,3)
-
 With weight: -64
 pt[1]:    location: -1.375 -1.375
    idx:     (2,2)
-
 With weight: 16
 pt[2]:    location: -1.625 -1.125
    idx:     (1,3)
-
 With weight: 16
 pt[3]:    location: -1.125 -1.125
    idx:     (3,3)
-
 With weight: 16
 pt[4]:    location: -1.375 -0.875
    idx:     (2,4)
-
 With weight: 16
 
 On point:    location: -1.125 -1.125
    idx:     (3,3)
-
 pt[0]:    location: -1.125 -1.125
    idx:     (3,3)
-
 With weight: -64
 pt[1]:    location: -1.125 -1.375
    idx:     (3,2)
-
 With weight: 16
 pt[2]:    location: -1.375 -1.125
    idx:     (2,3)
-
 With weight: 16
 pt[3]:    location: -0.875 -1.125
    idx:     (4,3)
-
 With weight: 16
 pt[4]:    location: -1.125 -0.875
    idx:     (3,4)
-
 With weight: 16
 
 On point:    location: -0.875 -1.125
    idx:     (4,3)
-
 pt[0]:    location: -0.875 -1.125
    idx:     (4,3)
-
 With weight: -45.1765
 pt[1]:    location: -0.875 -1.375
    idx:     (4,2)
-
 With weight: 13.1765
 pt[2]:    location: -1.125 -1.125
    idx:     (3,3)
-
 With weight: 8.47059
 pt[3]:    location: -0.625 -1.125
    idx:     (5,3)
-
 With weight: 16
 pt[4]:    location: -1.125 -0.875
    idx:     (3,4)
-
 With weight: 7.52941
 
 On point:    location: -0.625 -1.125
    idx:     (5,3)
-
 pt[0]:    location: -0.625 -1.125
    idx:     (5,3)
-
 With weight: -21.3333
 pt[1]:    location: -0.625 -1.375
    idx:     (5,2)
-
 With weight: 1.2191e-15
 pt[2]:    location: -0.875 -1.125
    idx:     (4,3)
-
 With weight: 10.6667
 pt[3]:    location: -0.875 -1.375
    idx:     (4,2)
-
 With weight: 2.66667
 pt[4]:    location: -0.375 -1.375
    idx:     (6,2)
-
 With weight: 8
 
 On point:    location:  0.625 -1.125
    idx:     (10,3)
-
 pt[0]:    location:  0.625 -1.125
    idx:     (10,3)
-
 With weight: -21.3333
 pt[1]:    location:  0.625 -1.375
    idx:     (10,2)
-
 With weight: 2.81359e-15
 pt[2]:    location:  0.875 -1.125
    idx:     (11,3)
-
 With weight: 10.6667
 pt[3]:    location:  0.375 -1.375
    idx:     (9,2)
-
 With weight: 8
 pt[4]:    location:  0.875 -1.375
    idx:     (11,2)
-
 With weight: 2.66667
 
 On point:    location:  0.875 -1.125
    idx:     (11,3)
-
 pt[0]:    location:  0.875 -1.125
    idx:     (11,3)
-
 With weight: -42.6667
 pt[1]:    location:  0.875 -1.375
    idx:     (11,2)
-
 With weight: 10.6667
 pt[2]:    location:  0.625 -1.125
    idx:     (10,3)
-
 With weight: 16
 pt[3]:    location:  1.125 -1.125
    idx:     (12,3)
-
 With weight: 16
 pt[4]:    location:  0.625 -1.375
    idx:     (10,2)
-
 With weight: -2.03742e-15
 
 On point:    location:  1.125 -1.125
    idx:     (12,3)
-
 pt[0]:    location:  1.125 -1.125
    idx:     (12,3)
-
 With weight: -64
 pt[1]:    location:  1.125 -1.375
    idx:     (12,2)
-
 With weight: 16
 pt[2]:    location:  0.875 -1.125
    idx:     (11,3)
-
 With weight: 16
 pt[3]:    location:  1.375 -1.125
    idx:     (13,3)
-
 With weight: 16
 pt[4]:    location:  1.125 -0.875
    idx:     (12,4)
-
 With weight: 16
 
 On point:    location:  1.375 -1.125
    idx:     (13,3)
-
 pt[0]:    location:  1.375 -1.125
    idx:     (13,3)
-
 With weight: -64
 pt[1]:    location:  1.375 -1.375
    idx:     (13,2)
-
 With weight: 16
 pt[2]:    location:  1.125 -1.125
    idx:     (12,3)
-
 With weight: 16
 pt[3]:    location:  1.625 -1.125
    idx:     (14,3)
-
 With weight: 16
 pt[4]:    location:  1.375 -0.875
    idx:     (13,4)
-
 With weight: 16
 
 On point:    location:  1.625 -1.125
    idx:     (14,3)
-
 pt[0]:    location:  1.625 -1.125
    idx:     (14,3)
-
 With weight: -64
 pt[1]:    location:  1.625 -1.375
    idx:     (14,2)
-
 With weight: 16
 pt[2]:    location:  1.375 -1.125
    idx:     (13,3)
-
 With weight: 16
 pt[3]:    location:  1.875 -1.125
    idx:     (15,3)
-
 With weight: 16
 pt[4]:    location:  1.625 -0.875
    idx:     (14,4)
-
 With weight: 16
 
 On point:    location:  1.875 -1.125
    idx:     (15,3)
-
 pt[0]:    location:  1.875 -1.125
    idx:     (15,3)
-
 With weight: -64
 pt[1]:    location:  1.875 -1.375
    idx:     (15,2)
-
 With weight: 16
 pt[2]:    location:  1.625 -1.125
    idx:     (14,3)
-
 With weight: 16
 pt[3]:    location:  2.125 -1.125
    idx:     (16,3)
-
 With weight: 16
 pt[4]:    location:  1.875 -0.875
    idx:     (15,4)
-
 With weight: 16
 
 On point:    location: -1.875 -0.875
    idx:     (0,4)
-
 pt[0]:    location: -1.875 -0.875
    idx:     (0,4)
-
 With weight: -64
 pt[1]:    location: -1.875 -1.125
    idx:     (0,3)
-
 With weight: 16
 pt[2]:    location: -2.125 -0.875
    idx:     (-1,4)
-
 With weight: 16
 pt[3]:    location: -1.625 -0.875
    idx:     (1,4)
-
 With weight: 16
 pt[4]:    location: -1.875 -0.625
    idx:     (0,5)
-
 With weight: 16
 
 On point:    location: -1.625 -0.875
    idx:     (1,4)
-
 pt[0]:    location: -1.625 -0.875
    idx:     (1,4)
-
 With weight: -64
 pt[1]:    location: -1.625 -1.125
    idx:     (1,3)
-
 With weight: 16
 pt[2]:    location: -1.875 -0.875
    idx:     (0,4)
-
 With weight: 16
 pt[3]:    location: -1.375 -0.875
    idx:     (2,4)
-
 With weight: 16
 pt[4]:    location: -1.625 -0.625
    idx:     (1,5)
-
 With weight: 16
 
 On point:    location: -1.375 -0.875
    idx:     (2,4)
-
 pt[0]:    location: -1.375 -0.875
    idx:     (2,4)
-
 With weight: -64
 pt[1]:    location: -1.375 -1.125
    idx:     (2,3)
-
 With weight: 16
 pt[2]:    location: -1.625 -0.875
    idx:     (1,4)
-
 With weight: 16
 pt[3]:    location: -1.125 -0.875
    idx:     (3,4)
-
 With weight: 16
 pt[4]:    location: -1.375 -0.625
    idx:     (2,5)
-
 With weight: 16
 
 On point:    location: -1.125 -0.875
    idx:     (3,4)
-
 pt[0]:    location: -1.125 -0.875
    idx:     (3,4)
-
 With weight: -42.6667
 pt[1]:    location: -1.125 -1.125
    idx:     (3,3)
-
 With weight: 16
 pt[2]:    location: -1.375 -0.875
    idx:     (2,4)
-
 With weight: 10.6667
 pt[3]:    location: -1.125 -0.625
    idx:     (3,5)
-
 With weight: 16
 pt[4]:    location: -1.375 -1.125
    idx:     (2,3)
-
 With weight: -3.3629e-16
 
 On point:    location:  1.125 -0.875
    idx:     (12,4)
-
 pt[0]:    location:  1.125 -0.875
    idx:     (12,4)
-
 With weight: -45.1765
 pt[1]:    location:  1.125 -1.125
    idx:     (12,3)
-
 With weight: 8.47059
 pt[2]:    location:  1.375 -0.875
    idx:     (13,4)
-
 With weight: 13.1765
 pt[3]:    location:  1.125 -0.625
    idx:     (12,5)
-
 With weight: 16
 pt[4]:    location:  0.875 -1.125
    idx:     (11,3)
-
 With weight: 7.52941
 
 On point:    location:  1.375 -0.875
    idx:     (13,4)
-
 pt[0]:    location:  1.375 -0.875
    idx:     (13,4)
-
 With weight: -64
 pt[1]:    location:  1.375 -1.125
    idx:     (13,3)
-
 With weight: 16
 pt[2]:    location:  1.125 -0.875
    idx:     (12,4)
-
 With weight: 16
 pt[3]:    location:  1.625 -0.875
    idx:     (14,4)
-
 With weight: 16
 pt[4]:    location:  1.375 -0.625
    idx:     (13,5)
-
 With weight: 16
 
 On point:    location:  1.625 -0.875
    idx:     (14,4)
-
 pt[0]:    location:  1.625 -0.875
    idx:     (14,4)
-
 With weight: -64
 pt[1]:    location:  1.625 -1.125
    idx:     (14,3)
-
 With weight: 16
 pt[2]:    location:  1.375 -0.875
    idx:     (13,4)
-
 With weight: 16
 pt[3]:    location:  1.875 -0.875
    idx:     (15,4)
-
 With weight: 16
 pt[4]:    location:  1.625 -0.625
    idx:     (14,5)
-
 With weight: 16
 
 On point:    location:  1.875 -0.875
    idx:     (15,4)
-
 pt[0]:    location:  1.875 -0.875
    idx:     (15,4)
-
 With weight: -64
 pt[1]:    location:  1.875 -1.125
    idx:     (15,3)
-
 With weight: 16
 pt[2]:    location:  1.625 -0.875
    idx:     (14,4)
-
 With weight: 16
 pt[3]:    location:  2.125 -0.875
    idx:     (16,4)
-
 With weight: 16
 pt[4]:    location:  1.875 -0.625
    idx:     (15,5)
-
 With weight: 16
 
 On point:    location: -1.875 -0.625
    idx:     (0,5)
-
 pt[0]:    location: -1.875 -0.625
    idx:     (0,5)
-
 With weight: -64
 pt[1]:    location: -1.875 -0.875
    idx:     (0,4)
-
 With weight: 16
 pt[2]:    location: -2.125 -0.625
    idx:     (-1,5)
-
 With weight: 16
 pt[3]:    location: -1.625 -0.625
    idx:     (1,5)
-
 With weight: 16
 pt[4]:    location: -1.875 -0.375
    idx:     (0,6)
-
 With weight: 16
 
 On point:    location: -1.625 -0.625
    idx:     (1,5)
-
 pt[0]:    location: -1.625 -0.625
    idx:     (1,5)
-
 With weight: -64
 pt[1]:    location: -1.625 -0.875
    idx:     (1,4)
-
 With weight: 16
 pt[2]:    location: -1.875 -0.625
    idx:     (0,5)
-
 With weight: 16
 pt[3]:    location: -1.375 -0.625
    idx:     (2,5)
-
 With weight: 16
 pt[4]:    location: -1.625 -0.375
    idx:     (1,6)
-
 With weight: 16
 
 On point:    location: -1.375 -0.625
    idx:     (2,5)
-
 pt[0]:    location: -1.375 -0.625
    idx:     (2,5)
-
 With weight: -64
 pt[1]:    location: -1.375 -0.875
    idx:     (2,4)
-
 With weight: 16
 pt[2]:    location: -1.625 -0.625
    idx:     (1,5)
-
 With weight: 16
 pt[3]:    location: -1.125 -0.625
    idx:     (3,5)
-
 With weight: 16
 pt[4]:    location: -1.375 -0.375
    idx:     (2,6)
-
 With weight: 16
 
 On point:    location: -1.125 -0.625
    idx:     (3,5)
-
 pt[0]:    location: -1.125 -0.625
    idx:     (3,5)
-
 With weight: -21.3333
 pt[1]:    location: -1.125 -0.875
    idx:     (3,4)
-
 With weight: 10.6667
 pt[2]:    location: -1.375 -0.625
    idx:     (2,5)
-
 With weight: -1.22853e-15
 pt[3]:    location: -1.375 -0.875
    idx:     (2,4)
-
 With weight: 2.66667
 pt[4]:    location: -1.375 -0.375
    idx:     (2,6)
-
 With weight: 8
 
 On point:    location:  1.125 -0.625
    idx:     (12,5)
-
 pt[0]:    location:  1.125 -0.625
    idx:     (12,5)
-
 With weight: -21.3333
 pt[1]:    location:  1.125 -0.875
    idx:     (12,4)
-
 With weight: 10.6667
 pt[2]:    location:  1.375 -0.625
    idx:     (13,5)
-
 With weight: -1.22853e-15
 pt[3]:    location:  1.375 -0.875
    idx:     (13,4)
-
 With weight: 2.66667
 pt[4]:    location:  1.375 -0.375
    idx:     (13,6)
-
 With weight: 8
 
 On point:    location:  1.375 -0.625
    idx:     (13,5)
-
 pt[0]:    location:  1.375 -0.625
    idx:     (13,5)
-
 With weight: -64
 pt[1]:    location:  1.375 -0.875
    idx:     (13,4)
-
 With weight: 16
 pt[2]:    location:  1.125 -0.625
    idx:     (12,5)
-
 With weight: 16
 pt[3]:    location:  1.625 -0.625
    idx:     (14,5)
-
 With weight: 16
 pt[4]:    location:  1.375 -0.375
    idx:     (13,6)
-
 With weight: 16
 
 On point:    location:  1.625 -0.625
    idx:     (14,5)
-
 pt[0]:    location:  1.625 -0.625
    idx:     (14,5)
-
 With weight: -64
 pt[1]:    location:  1.625 -0.875
    idx:     (14,4)
-
 With weight: 16
 pt[2]:    location:  1.375 -0.625
    idx:     (13,5)
-
 With weight: 16
 pt[3]:    location:  1.875 -0.625
    idx:     (15,5)
-
 With weight: 16
 pt[4]:    location:  1.625 -0.375
    idx:     (14,6)
-
 With weight: 16
 
 On point:    location:  1.875 -0.625
    idx:     (15,5)
-
 pt[0]:    location:  1.875 -0.625
    idx:     (15,5)
-
 With weight: -64
 pt[1]:    location:  1.875 -0.875
    idx:     (15,4)
-
 With weight: 16
 pt[2]:    location:  1.625 -0.625
    idx:     (14,5)
-
 With weight: 16
 pt[3]:    location:  2.125 -0.625
    idx:     (16,5)
-
 With weight: 16
 pt[4]:    location:  1.875 -0.375
    idx:     (15,6)
-
 With weight: 16
 
 On point:    location: -1.875 -0.375
    idx:     (0,6)
-
 pt[0]:    location: -1.875 -0.375
    idx:     (0,6)
-
 With weight: -64
 pt[1]:    location: -1.875 -0.625
    idx:     (0,5)
-
 With weight: 16
 pt[2]:    location: -2.125 -0.375
    idx:     (-1,6)
-
 With weight: 16
 pt[3]:    location: -1.625 -0.375
    idx:     (1,6)
-
 With weight: 16
 pt[4]:    location: -1.875 -0.125
    idx:     (0,7)
-
 With weight: 16
 
 On point:    location: -1.625 -0.375
    idx:     (1,6)
-
 pt[0]:    location: -1.625 -0.375
    idx:     (1,6)
-
 With weight: -64
 pt[1]:    location: -1.625 -0.625
    idx:     (1,5)
-
 With weight: 16
 pt[2]:    location: -1.875 -0.375
    idx:     (0,6)
-
 With weight: 16
 pt[3]:    location: -1.375 -0.375
    idx:     (2,6)
-
 With weight: 16
 pt[4]:    location: -1.625 -0.125
    idx:     (1,7)
-
 With weight: 16
 
 On point:    location: -1.375 -0.375
    idx:     (2,6)
-
 pt[0]:    location: -1.375 -0.375
    idx:     (2,6)
-
 With weight: -42.6667
 pt[1]:    location: -1.375 -0.625
    idx:     (2,5)
-
 With weight: 16
 pt[2]:    location: -1.625 -0.375
    idx:     (1,6)
-
 With weight: 10.6667
 pt[3]:    location: -1.375 -0.125
    idx:     (2,7)
-
 With weight: 16
 pt[4]:    location: -1.625 -0.625
    idx:     (1,5)
-
 With weight: -3.3629e-16
 
 On point:    location:  1.375 -0.375
    idx:     (13,6)
-
 pt[0]:    location:  1.375 -0.375
    idx:     (13,6)
-
 With weight: -45.1765
 pt[1]:    location:  1.375 -0.625
    idx:     (13,5)
-
 With weight: 8.47059
 pt[2]:    location:  1.625 -0.375
    idx:     (14,6)
-
 With weight: 13.1765
 pt[3]:    location:  1.375 -0.125
    idx:     (13,7)
-
 With weight: 16
 pt[4]:    location:  1.125 -0.625
    idx:     (12,5)
-
 With weight: 7.52941
 
 On point:    location:  1.625 -0.375
    idx:     (14,6)
-
 pt[0]:    location:  1.625 -0.375
    idx:     (14,6)
-
 With weight: -64
 pt[1]:    location:  1.625 -0.625
    idx:     (14,5)
-
 With weight: 16
 pt[2]:    location:  1.375 -0.375
    idx:     (13,6)
-
 With weight: 16
 pt[3]:    location:  1.875 -0.375
    idx:     (15,6)
-
 With weight: 16
 pt[4]:    location:  1.625 -0.125
    idx:     (14,7)
-
 With weight: 16
 
 On point:    location:  1.875 -0.375
    idx:     (15,6)
-
 pt[0]:    location:  1.875 -0.375
    idx:     (15,6)
-
 With weight: -64
 pt[1]:    location:  1.875 -0.625
    idx:     (15,5)
-
 With weight: 16
 pt[2]:    location:  1.625 -0.375
    idx:     (14,6)
-
 With weight: 16
 pt[3]:    location:  2.125 -0.375
    idx:     (16,6)
-
 With weight: 16
 pt[4]:    location:  1.875 -0.125
    idx:     (15,7)
-
 With weight: 16
 
 On point:    location: -1.875 -0.125
    idx:     (0,7)
-
 pt[0]:    location: -1.875 -0.125
    idx:     (0,7)
-
 With weight: -64
 pt[1]:    location: -1.875 -0.375
    idx:     (0,6)
-
 With weight: 16
 pt[2]:    location: -2.125 -0.125
    idx:     (-1,7)
-
 With weight: 16
 pt[3]:    location: -1.625 -0.125
    idx:     (1,7)
-
 With weight: 16
 pt[4]:    location: -1.875  0.125
    idx:     (0,8)
-
 With weight: 16
 
 On point:    location: -1.625 -0.125
    idx:     (1,7)
-
 pt[0]:    location: -1.625 -0.125
    idx:     (1,7)
-
 With weight: -64
 pt[1]:    location: -1.625 -0.375
    idx:     (1,6)
-
 With weight: 16
 pt[2]:    location: -1.875 -0.125
    idx:     (0,7)
-
 With weight: 16
 pt[3]:    location: -1.375 -0.125
    idx:     (2,7)
-
 With weight: 16
 pt[4]:    location: -1.625  0.125
    idx:     (1,8)
-
 With weight: 16
 
 On point:    location: -1.375 -0.125
    idx:     (2,7)
-
 pt[0]:    location: -1.375 -0.125
    idx:     (2,7)
-
 With weight: -42.6667
 pt[1]:    location: -1.375 -0.375
    idx:     (2,6)
-
 With weight: 16
 pt[2]:    location: -1.625 -0.125
    idx:     (1,7)
-
 With weight: 10.6667
 pt[3]:    location: -1.375  0.125
    idx:     (2,8)
-
 With weight: 16
 pt[4]:    location: -1.625 -0.375
    idx:     (1,6)
-
 With weight: -3.3629e-16
 
 On point:    location:  1.375 -0.125
    idx:     (13,7)
-
 pt[0]:    location:  1.375 -0.125
    idx:     (13,7)
-
 With weight: -42.6667
 pt[1]:    location:  1.375 -0.375
    idx:     (13,6)
-
 With weight: 16
 pt[2]:    location:  1.625 -0.125
    idx:     (14,7)
-
 With weight: 10.6667
 pt[3]:    location: 1.375 0.125
    idx:     (13,8)
-
 With weight: 16
 pt[4]:    location:  1.625 -0.375
    idx:     (14,6)
-
 With weight: -3.3629e-16
 
 On point:    location:  1.625 -0.125
    idx:     (14,7)
-
 pt[0]:    location:  1.625 -0.125
    idx:     (14,7)
-
 With weight: -64
 pt[1]:    location:  1.625 -0.375
    idx:     (14,6)
-
 With weight: 16
 pt[2]:    location:  1.375 -0.125
    idx:     (13,7)
-
 With weight: 16
 pt[3]:    location:  1.875 -0.125
    idx:     (15,7)
-
 With weight: 16
 pt[4]:    location: 1.625 0.125
    idx:     (14,8)
-
 With weight: 16
 
 On point:    location:  1.875 -0.125
    idx:     (15,7)
-
 pt[0]:    location:  1.875 -0.125
    idx:     (15,7)
-
 With weight: -64
 pt[1]:    location:  1.875 -0.375
    idx:     (15,6)
-
 With weight: 16
 pt[2]:    location:  1.625 -0.125
    idx:     (14,7)
-
 With weight: 16
 pt[3]:    location:  2.125 -0.125
    idx:     (16,7)
-
 With weight: 16
 pt[4]:    location: 1.875 0.125
    idx:     (15,8)
-
 With weight: 16
 
 On point:    location: -1.875  0.125
    idx:     (0,8)
-
 pt[0]:    location: -1.875  0.125
    idx:     (0,8)
-
 With weight: -64
 pt[1]:    location: -1.875 -0.125
    idx:     (0,7)
-
 With weight: 16
 pt[2]:    location: -2.125  0.125
    idx:     (-1,8)
-
 With weight: 16
 pt[3]:    location: -1.625  0.125
    idx:     (1,8)
-
 With weight: 16
 pt[4]:    location: -1.875  0.375
    idx:     (0,9)
-
 With weight: 16
 
 On point:    location: -1.625  0.125
    idx:     (1,8)
-
 pt[0]:    location: -1.625  0.125
    idx:     (1,8)
-
 With weight: -64
 pt[1]:    location: -1.625 -0.125
    idx:     (1,7)
-
 With weight: 16
 pt[2]:    location: -1.875  0.125
    idx:     (0,8)
-
 With weight: 16
 pt[3]:    location: -1.375  0.125
    idx:     (2,8)
-
 With weight: 16
 pt[4]:    location: -1.625  0.375
    idx:     (1,9)
-
 With weight: 16
 
 On point:    location: -1.375  0.125
    idx:     (2,8)
-
 pt[0]:    location: -1.375  0.125
    idx:     (2,8)
-
 With weight: -42.6667
 pt[1]:    location: -1.375 -0.125
    idx:     (2,7)
-
 With weight: 16
 pt[2]:    location: -1.625  0.125
    idx:     (1,8)
-
 With weight: 10.6667
 pt[3]:    location: -1.375  0.375
    idx:     (2,9)
-
 With weight: 16
 pt[4]:    location: -1.625 -0.125
    idx:     (1,7)
-
 With weight: -3.3629e-16
 
 On point:    location: 1.375 0.125
    idx:     (13,8)
-
 pt[0]:    location: 1.375 0.125
    idx:     (13,8)
-
 With weight: -42.6667
 pt[1]:    location:  1.375 -0.125
    idx:     (13,7)
-
 With weight: 16
 pt[2]:    location: 1.625 0.125
    idx:     (14,8)
-
 With weight: 10.6667
 pt[3]:    location: 1.375 0.375
    idx:     (13,9)
-
 With weight: 16
 pt[4]:    location: 1.625 0.375
    idx:     (14,9)
-
 With weight: -1.44512e-15
 
 On point:    location: 1.625 0.125
    idx:     (14,8)
-
 pt[0]:    location: 1.625 0.125
    idx:     (14,8)
-
 With weight: -64
 pt[1]:    location:  1.625 -0.125
    idx:     (14,7)
-
 With weight: 16
 pt[2]:    location: 1.375 0.125
    idx:     (13,8)
-
 With weight: 16
 pt[3]:    location: 1.875 0.125
    idx:     (15,8)
-
 With weight: 16
 pt[4]:    location: 1.625 0.375
    idx:     (14,9)
-
 With weight: 16
 
 On point:    location: 1.875 0.125
    idx:     (15,8)
-
 pt[0]:    location: 1.875 0.125
    idx:     (15,8)
-
 With weight: -64
 pt[1]:    location:  1.875 -0.125
    idx:     (15,7)
-
 With weight: 16
 pt[2]:    location: 1.625 0.125
    idx:     (14,8)
-
 With weight: 16
 pt[3]:    location: 2.125 0.125
    idx:     (16,8)
-
 With weight: 16
 pt[4]:    location: 1.875 0.375
    idx:     (15,9)
-
 With weight: 16
 
 On point:    location: -1.875  0.375
    idx:     (0,9)
-
 pt[0]:    location: -1.875  0.375
    idx:     (0,9)
-
 With weight: -64
 pt[1]:    location: -1.875  0.125
    idx:     (0,8)
-
 With weight: 16
 pt[2]:    location: -2.125  0.375
    idx:     (-1,9)
-
 With weight: 16
 pt[3]:    location: -1.625  0.375
    idx:     (1,9)
-
 With weight: 16
 pt[4]:    location: -1.875  0.625
    idx:     (0,10)
-
 With weight: 16
 
 On point:    location: -1.625  0.375
    idx:     (1,9)
-
 pt[0]:    location: -1.625  0.375
    idx:     (1,9)
-
 With weight: -64
 pt[1]:    location: -1.625  0.125
    idx:     (1,8)
-
 With weight: 16
 pt[2]:    location: -1.875  0.375
    idx:     (0,9)
-
 With weight: 16
 pt[3]:    location: -1.375  0.375
    idx:     (2,9)
-
 With weight: 16
 pt[4]:    location: -1.625  0.625
    idx:     (1,10)
-
 With weight: 16
 
 On point:    location: -1.375  0.375
    idx:     (2,9)
-
 pt[0]:    location: -1.375  0.375
    idx:     (2,9)
-
 With weight: -42.6667
 pt[1]:    location: -1.375  0.125
    idx:     (2,8)
-
 With weight: 16
 pt[2]:    location: -1.625  0.375
    idx:     (1,9)
-
 With weight: 10.6667
 pt[3]:    location: -1.375  0.625
    idx:     (2,10)
-
 With weight: 16
 pt[4]:    location: -1.625  0.625
    idx:     (1,10)
-
 With weight: -1.44512e-15
 
 On point:    location: 1.375 0.375
    idx:     (13,9)
-
 pt[0]:    location: 1.375 0.375
    idx:     (13,9)
-
 With weight: -42.6667
 pt[1]:    location: 1.375 0.125
    idx:     (13,8)
-
 With weight: 16
 pt[2]:    location: 1.625 0.375
    idx:     (14,9)
-
 With weight: 10.6667
 pt[3]:    location: 1.375 0.625
    idx:     (13,10)
-
 With weight: 16
 pt[4]:    location: 1.625 0.125
    idx:     (14,8)
-
 With weight: -3.3629e-16
 
 On point:    location: 1.625 0.375
    idx:     (14,9)
-
 pt[0]:    location: 1.625 0.375
    idx:     (14,9)
-
 With weight: -64
 pt[1]:    location: 1.625 0.125
    idx:     (14,8)
-
 With weight: 16
 pt[2]:    location: 1.375 0.375
    idx:     (13,9)
-
 With weight: 16
 pt[3]:    location: 1.875 0.375
    idx:     (15,9)
-
 With weight: 16
 pt[4]:    location: 1.625 0.625
    idx:     (14,10)
-
 With weight: 16
 
 On point:    location: 1.875 0.375
    idx:     (15,9)
-
 pt[0]:    location: 1.875 0.375
    idx:     (15,9)
-
 With weight: -64
 pt[1]:    location: 1.875 0.125
    idx:     (15,8)
-
 With weight: 16
 pt[2]:    location: 1.625 0.375
    idx:     (14,9)
-
 With weight: 16
 pt[3]:    location: 2.125 0.375
    idx:     (16,9)
-
 With weight: 16
 pt[4]:    location: 1.875 0.625
    idx:     (15,10)
-
 With weight: 16
 
 On point:    location: -1.875  0.625
    idx:     (0,10)
-
 pt[0]:    location: -1.875  0.625
    idx:     (0,10)
-
 With weight: -64
 pt[1]:    location: -1.875  0.375
    idx:     (0,9)
-
 With weight: 16
 pt[2]:    location: -2.125  0.625
    idx:     (-1,10)
-
 With weight: 16
 pt[3]:    location: -1.625  0.625
    idx:     (1,10)
-
 With weight: 16
 pt[4]:    location: -1.875  0.875
    idx:     (0,11)
-
 With weight: 16
 
 On point:    location: -1.625  0.625
    idx:     (1,10)
-
 pt[0]:    location: -1.625  0.625
    idx:     (1,10)
-
 With weight: -64
 pt[1]:    location: -1.625  0.375
    idx:     (1,9)
-
 With weight: 16
 pt[2]:    location: -1.875  0.625
    idx:     (0,10)
-
 With weight: 16
 pt[3]:    location: -1.375  0.625
    idx:     (2,10)
-
 With weight: 16
 pt[4]:    location: -1.625  0.875
    idx:     (1,11)
-
 With weight: 16
 
 On point:    location: -1.375  0.625
    idx:     (2,10)
-
 pt[0]:    location: -1.375  0.625
    idx:     (2,10)
-
 With weight: -64
 pt[1]:    location: -1.375  0.375
    idx:     (2,9)
-
 With weight: 16
 pt[2]:    location: -1.625  0.625
    idx:     (1,10)
-
 With weight: 16
 pt[3]:    location: -1.125  0.625
    idx:     (3,10)
-
 With weight: 16
 pt[4]:    location: -1.375  0.875
    idx:     (2,11)
-
 With weight: 16
 
 On point:    location: -1.125  0.625
    idx:     (3,10)
-
 pt[0]:    location: -1.125  0.625
    idx:     (3,10)
-
 With weight: -21.3333
 pt[1]:    location: -1.375  0.625
    idx:     (2,10)
-
 With weight: -2.90863e-16
 pt[2]:    location: -1.125  0.875
    idx:     (3,11)
-
 With weight: 10.6667
 pt[3]:    location: -1.375  0.375
    idx:     (2,9)
-
 With weight: 8
 pt[4]:    location: -1.375  0.875
    idx:     (2,11)
-
 With weight: 2.66667
 
 On point:    location: 1.125 0.625
    idx:     (12,10)
-
 pt[0]:    location: 1.125 0.625
    idx:     (12,10)
-
 With weight: -21.3333
 pt[1]:    location: 1.375 0.625
    idx:     (13,10)
-
 With weight: -2.90863e-16
 pt[2]:    location: 1.125 0.875
    idx:     (12,11)
-
 With weight: 10.6667
 pt[3]:    location: 1.375 0.375
    idx:     (13,9)
-
 With weight: 8
 pt[4]:    location: 1.375 0.875
    idx:     (13,11)
-
 With weight: 2.66667
 
 On point:    location: 1.375 0.625
    idx:     (13,10)
-
 pt[0]:    location: 1.375 0.625
    idx:     (13,10)
-
 With weight: -64
 pt[1]:    location: 1.375 0.375
    idx:     (13,9)
-
 With weight: 16
 pt[2]:    location: 1.125 0.625
    idx:     (12,10)
-
 With weight: 16
 pt[3]:    location: 1.625 0.625
    idx:     (14,10)
-
 With weight: 16
 pt[4]:    location: 1.375 0.875
    idx:     (13,11)
-
 With weight: 16
 
 On point:    location: 1.625 0.625
    idx:     (14,10)
-
 pt[0]:    location: 1.625 0.625
    idx:     (14,10)
-
 With weight: -64
 pt[1]:    location: 1.625 0.375
    idx:     (14,9)
-
 With weight: 16
 pt[2]:    location: 1.375 0.625
    idx:     (13,10)
-
 With weight: 16
 pt[3]:    location: 1.875 0.625
    idx:     (15,10)
-
 With weight: 16
 pt[4]:    location: 1.625 0.875
    idx:     (14,11)
-
 With weight: 16
 
 On point:    location: 1.875 0.625
    idx:     (15,10)
-
 pt[0]:    location: 1.875 0.625
    idx:     (15,10)
-
 With weight: -64
 pt[1]:    location: 1.875 0.375
    idx:     (15,9)
-
 With weight: 16
 pt[2]:    location: 1.625 0.625
    idx:     (14,10)
-
 With weight: 16
 pt[3]:    location: 2.125 0.625
    idx:     (16,10)
-
 With weight: 16
 pt[4]:    location: 1.875 0.875
    idx:     (15,11)
-
 With weight: 16
 
 On point:    location: -1.875  0.875
    idx:     (0,11)
-
 pt[0]:    location: -1.875  0.875
    idx:     (0,11)
-
 With weight: -64
 pt[1]:    location: -1.875  0.625
    idx:     (0,10)
-
 With weight: 16
 pt[2]:    location: -2.125  0.875
    idx:     (-1,11)
-
 With weight: 16
 pt[3]:    location: -1.625  0.875
    idx:     (1,11)
-
 With weight: 16
 pt[4]:    location: -1.875  1.125
    idx:     (0,12)
-
 With weight: 16
 
 On point:    location: -1.625  0.875
    idx:     (1,11)
-
 pt[0]:    location: -1.625  0.875
    idx:     (1,11)
-
 With weight: -64
 pt[1]:    location: -1.625  0.625
    idx:     (1,10)
-
 With weight: 16
 pt[2]:    location: -1.875  0.875
    idx:     (0,11)
-
 With weight: 16
 pt[3]:    location: -1.375  0.875
    idx:     (2,11)
-
 With weight: 16
 pt[4]:    location: -1.625  1.125
    idx:     (1,12)
-
 With weight: 16
 
 On point:    location: -1.375  0.875
    idx:     (2,11)
-
 pt[0]:    location: -1.375  0.875
    idx:     (2,11)
-
 With weight: -64
 pt[1]:    location: -1.375  0.625
    idx:     (2,10)
-
 With weight: 16
 pt[2]:    location: -1.625  0.875
    idx:     (1,11)
-
 With weight: 16
 pt[3]:    location: -1.125  0.875
    idx:     (3,11)
-
 With weight: 16
 pt[4]:    location: -1.375  1.125
    idx:     (2,12)
-
 With weight: 16
 
 On point:    location: -1.125  0.875
    idx:     (3,11)
-
 pt[0]:    location: -1.125  0.875
    idx:     (3,11)
-
 With weight: -42.6667
 pt[1]:    location: -1.125  0.625
    idx:     (3,10)
-
 With weight: 16
 pt[2]:    location: -1.375  0.875
    idx:     (2,11)
-
 With weight: 10.6667
 pt[3]:    location: -1.125  1.125
    idx:     (3,12)
-
 With weight: 16
 pt[4]:    location: -1.375  0.625
    idx:     (2,10)
-
 With weight: -3.3629e-16
 
 On point:    location: 1.125 0.875
    idx:     (12,11)
-
 pt[0]:    location: 1.125 0.875
    idx:     (12,11)
-
 With weight: -42.6667
 pt[1]:    location: 1.125 0.625
    idx:     (12,10)
-
 With weight: 16
 pt[2]:    location: 1.375 0.875
    idx:     (13,11)
-
 With weight: 10.6667
 pt[3]:    location: 1.125 1.125
    idx:     (12,12)
-
 With weight: 16
 pt[4]:    location: 1.375 0.625
    idx:     (13,10)
-
 With weight: -3.3629e-16
 
 On point:    location: 1.375 0.875
    idx:     (13,11)
-
 pt[0]:    location: 1.375 0.875
    idx:     (13,11)
-
 With weight: -64
 pt[1]:    location: 1.375 0.625
    idx:     (13,10)
-
 With weight: 16
 pt[2]:    location: 1.125 0.875
    idx:     (12,11)
-
 With weight: 16
 pt[3]:    location: 1.625 0.875
    idx:     (14,11)
-
 With weight: 16
 pt[4]:    location: 1.375 1.125
    idx:     (13,12)
-
 With weight: 16
 
 On point:    location: 1.625 0.875
    idx:     (14,11)
-
 pt[0]:    location: 1.625 0.875
    idx:     (14,11)
-
 With weight: -64
 pt[1]:    location: 1.625 0.625
    idx:     (14,10)
-
 With weight: 16
 pt[2]:    location: 1.375 0.875
    idx:     (13,11)
-
 With weight: 16
 pt[3]:    location: 1.875 0.875
    idx:     (15,11)
-
 With weight: 16
 pt[4]:    location: 1.625 1.125
    idx:     (14,12)
-
 With weight: 16
 
 On point:    location: 1.875 0.875
    idx:     (15,11)
-
 pt[0]:    location: 1.875 0.875
    idx:     (15,11)
-
 With weight: -64
 pt[1]:    location: 1.875 0.625
    idx:     (15,10)
-
 With weight: 16
 pt[2]:    location: 1.625 0.875
    idx:     (14,11)
-
 With weight: 16
 pt[3]:    location: 2.125 0.875
    idx:     (16,11)
-
 With weight: 16
 pt[4]:    location: 1.875 1.125
    idx:     (15,12)
-
 With weight: 16
 
 On point:    location: -1.875  1.125
    idx:     (0,12)
-
 pt[0]:    location: -1.875  1.125
    idx:     (0,12)
-
 With weight: -64
 pt[1]:    location: -1.875  0.875
    idx:     (0,11)
-
 With weight: 16
 pt[2]:    location: -2.125  1.125
    idx:     (-1,12)
-
 With weight: 16
 pt[3]:    location: -1.625  1.125
    idx:     (1,12)
-
 With weight: 16
 pt[4]:    location: -1.875  1.375
    idx:     (0,13)
-
 With weight: 16
 
 On point:    location: -1.625  1.125
    idx:     (1,12)
-
 pt[0]:    location: -1.625  1.125
    idx:     (1,12)
-
 With weight: -64
 pt[1]:    location: -1.625  0.875
    idx:     (1,11)
-
 With weight: 16
 pt[2]:    location: -1.875  1.125
    idx:     (0,12)
-
 With weight: 16
 pt[3]:    location: -1.375  1.125
    idx:     (2,12)
-
 With weight: 16
 pt[4]:    location: -1.625  1.375
    idx:     (1,13)
-
 With weight: 16
 
 On point:    location: -1.375  1.125
    idx:     (2,12)
-
 pt[0]:    location: -1.375  1.125
    idx:     (2,12)
-
 With weight: -64
 pt[1]:    location: -1.375  0.875
    idx:     (2,11)
-
 With weight: 16
 pt[2]:    location: -1.625  1.125
    idx:     (1,12)
-
 With weight: 16
 pt[3]:    location: -1.125  1.125
    idx:     (3,12)
-
 With weight: 16
 pt[4]:    location: -1.375  1.375
    idx:     (2,13)
-
 With weight: 16
 
 On point:    location: -1.125  1.125
    idx:     (3,12)
-
 pt[0]:    location: -1.125  1.125
    idx:     (3,12)
-
 With weight: -64
 pt[1]:    location: -1.125  0.875
    idx:     (3,11)
-
 With weight: 16
 pt[2]:    location: -1.375  1.125
    idx:     (2,12)
-
 With weight: 16
 pt[3]:    location: -0.875  1.125
    idx:     (4,12)
-
 With weight: 16
 pt[4]:    location: -1.125  1.375
    idx:     (3,13)
-
 With weight: 16
 
 On point:    location: -0.875  1.125
    idx:     (4,12)
-
 pt[0]:    location: -0.875  1.125
    idx:     (4,12)
-
 With weight: -45.1765
 pt[1]:    location: -1.125  1.125
    idx:     (3,12)
-
 With weight: 8.47059
 pt[2]:    location: -0.625  1.125
    idx:     (5,12)
-
 With weight: 16
 pt[3]:    location: -0.875  1.375
    idx:     (4,13)
-
 With weight: 13.1765
 pt[4]:    location: -1.125  0.875
    idx:     (3,11)
-
 With weight: 7.52941
 
 On point:    location: -0.625  1.125
    idx:     (5,12)
-
 pt[0]:    location: -0.625  1.125
    idx:     (5,12)
-
 With weight: -21.3333
 pt[1]:    location: -0.875  1.125
    idx:     (4,12)
-
 With weight: 10.6667
 pt[2]:    location: -0.625  1.375
    idx:     (5,13)
-
 With weight: 5.00358e-15
 pt[3]:    location: -0.875  1.375
    idx:     (4,13)
-
 With weight: 2.66667
 pt[4]:    location: -0.375  1.375
    idx:     (6,13)
-
 With weight: 8
 
 On point:    location: 0.625 1.125
    idx:     (10,12)
-
 pt[0]:    location: 0.625 1.125
    idx:     (10,12)
-
 With weight: -21.3333
 pt[1]:    location: 0.875 1.125
    idx:     (11,12)
-
 With weight: 10.6667
 pt[2]:    location: 0.625 1.375
    idx:     (10,13)
-
 With weight: 1.19902e-15
 pt[3]:    location: 0.375 1.375
    idx:     (9,13)
-
 With weight: 8
 pt[4]:    location: 0.875 1.375
    idx:     (11,13)
-
 With weight: 2.66667
 
 On point:    location: 0.875 1.125
    idx:     (11,12)
-
 pt[0]:    location: 0.875 1.125
    idx:     (11,12)
-
 With weight: -45.1765
 pt[1]:    location: 0.625 1.125
    idx:     (10,12)
-
 With weight: 16
 pt[2]:    location: 1.125 1.125
    idx:     (12,12)
-
 With weight: 8.47059
 pt[3]:    location: 0.875 1.375
    idx:     (11,13)
-
 With weight: 13.1765
 pt[4]:    location: 1.125 0.875
    idx:     (12,11)
-
 With weight: 7.52941
 
 On point:    location: 1.125 1.125
    idx:     (12,12)
-
 pt[0]:    location: 1.125 1.125
    idx:     (12,12)
-
 With weight: -64
 pt[1]:    location: 1.125 0.875
    idx:     (12,11)
-
 With weight: 16
 pt[2]:    location: 0.875 1.125
    idx:     (11,12)
-
 With weight: 16
 pt[3]:    location: 1.375 1.125
    idx:     (13,12)
-
 With weight: 16
 pt[4]:    location: 1.125 1.375
    idx:     (12,13)
-
 With weight: 16
 
 On point:    location: 1.375 1.125
    idx:     (13,12)
-
 pt[0]:    location: 1.375 1.125
    idx:     (13,12)
-
 With weight: -64
 pt[1]:    location: 1.375 0.875
    idx:     (13,11)
-
 With weight: 16
 pt[2]:    location: 1.125 1.125
    idx:     (12,12)
-
 With weight: 16
 pt[3]:    location: 1.625 1.125
    idx:     (14,12)
-
 With weight: 16
 pt[4]:    location: 1.375 1.375
    idx:     (13,13)
-
 With weight: 16
 
 On point:    location: 1.625 1.125
    idx:     (14,12)
-
 pt[0]:    location: 1.625 1.125
    idx:     (14,12)
-
 With weight: -64
 pt[1]:    location: 1.625 0.875
    idx:     (14,11)
-
 With weight: 16
 pt[2]:    location: 1.375 1.125
    idx:     (13,12)
-
 With weight: 16
 pt[3]:    location: 1.875 1.125
    idx:     (15,12)
-
 With weight: 16
 pt[4]:    location: 1.625 1.375
    idx:     (14,13)
-
 With weight: 16
 
 On point:    location: 1.875 1.125
    idx:     (15,12)
-
 pt[0]:    location: 1.875 1.125
    idx:     (15,12)
-
 With weight: -64
 pt[1]:    location: 1.875 0.875
    idx:     (15,11)
-
 With weight: 16
 pt[2]:    location: 1.625 1.125
    idx:     (14,12)
-
 With weight: 16
 pt[3]:    location: 2.125 1.125
    idx:     (16,12)
-
 With weight: 16
 pt[4]:    location: 1.875 1.375
    idx:     (15,13)
-
 With weight: 16
 
 On point:    location: -1.875  1.375
    idx:     (0,13)
-
 pt[0]:    location: -1.875  1.375
    idx:     (0,13)
-
 With weight: -64
 pt[1]:    location: -1.875  1.125
    idx:     (0,12)
-
 With weight: 16
 pt[2]:    location: -2.125  1.375
    idx:     (-1,13)
-
 With weight: 16
 pt[3]:    location: -1.625  1.375
    idx:     (1,13)
-
 With weight: 16
 pt[4]:    location: -1.875  1.625
    idx:     (0,14)
-
 With weight: 16
 
 On point:    location: -1.625  1.375
    idx:     (1,13)
-
 pt[0]:    location: -1.625  1.375
    idx:     (1,13)
-
 With weight: -64
 pt[1]:    location: -1.625  1.125
    idx:     (1,12)
-
 With weight: 16
 pt[2]:    location: -1.875  1.375
    idx:     (0,13)
-
 With weight: 16
 pt[3]:    location: -1.375  1.375
    idx:     (2,13)
-
 With weight: 16
 pt[4]:    location: -1.625  1.625
    idx:     (1,14)
-
 With weight: 16
 
 On point:    location: -1.375  1.375
    idx:     (2,13)
-
 pt[0]:    location: -1.375  1.375
    idx:     (2,13)
-
 With weight: -64
 pt[1]:    location: -1.375  1.125
    idx:     (2,12)
-
 With weight: 16
 pt[2]:    location: -1.625  1.375
    idx:     (1,13)
-
 With weight: 16
 pt[3]:    location: -1.125  1.375
    idx:     (3,13)
-
 With weight: 16
 pt[4]:    location: -1.375  1.625
    idx:     (2,14)
-
 With weight: 16
 
 On point:    location: -1.125  1.375
    idx:     (3,13)
-
 pt[0]:    location: -1.125  1.375
    idx:     (3,13)
-
 With weight: -64
 pt[1]:    location: -1.125  1.125
    idx:     (3,12)
-
 With weight: 16
 pt[2]:    location: -1.375  1.375
    idx:     (2,13)
-
 With weight: 16
 pt[3]:    location: -0.875  1.375
    idx:     (4,13)
-
 With weight: 16
 pt[4]:    location: -1.125  1.625
    idx:     (3,14)
-
 With weight: 16
 
 On point:    location: -0.875  1.375
    idx:     (4,13)
-
 pt[0]:    location: -0.875  1.375
    idx:     (4,13)
-
 With weight: -64
 pt[1]:    location: -0.875  1.125
    idx:     (4,12)
-
 With weight: 16
 pt[2]:    location: -1.125  1.375
    idx:     (3,13)
-
 With weight: 16
 pt[3]:    location: -0.625  1.375
    idx:     (5,13)
-
 With weight: 16
 pt[4]:    location: -0.875  1.625
    idx:     (4,14)
-
 With weight: 16
 
 On point:    location: -0.625  1.375
    idx:     (5,13)
-
 pt[0]:    location: -0.625  1.375
    idx:     (5,13)
-
 With weight: -64
 pt[1]:    location: -0.625  1.125
    idx:     (5,12)
-
 With weight: 16
 pt[2]:    location: -0.875  1.375
    idx:     (4,13)
-
 With weight: 16
 pt[3]:    location: -0.375  1.375
    idx:     (6,13)
-
 With weight: 16
 pt[4]:    location: -0.625  1.625
    idx:     (5,14)
-
 With weight: 16
 
 On point:    location: -0.375  1.375
    idx:     (6,13)
-
 pt[0]:    location: -0.375  1.375
    idx:     (6,13)
-
 With weight: -45.1765
 pt[1]:    location: -0.625  1.375
    idx:     (5,13)
-
 With weight: 8.47059
 pt[2]:    location: -0.125  1.375
    idx:     (7,13)
-
 With weight: 16
 pt[3]:    location: -0.375  1.625
    idx:     (6,14)
-
 With weight: 13.1765
 pt[4]:    location: -0.625  1.125
    idx:     (5,12)
-
 With weight: 7.52941
 
 On point:    location: -0.125  1.375
    idx:     (7,13)
-
 pt[0]:    location: -0.125  1.375
    idx:     (7,13)
-
 With weight: -42.6667
 pt[1]:    location: -0.375  1.375
    idx:     (6,13)
-
 With weight: 16
 pt[2]:    location: 0.125 1.375
    idx:     (8,13)
-
 With weight: 16
 pt[3]:    location: -0.125  1.625
    idx:     (7,14)
-
 With weight: 10.6667
 pt[4]:    location: -0.375  1.625
    idx:     (6,14)
-
 With weight: -2.03635e-15
 
 On point:    location: 0.125 1.375
    idx:     (8,13)
-
 pt[0]:    location: 0.125 1.375
    idx:     (8,13)
-
 With weight: -42.6667
 pt[1]:    location: -0.125  1.375
    idx:     (7,13)
-
 With weight: 16
 pt[2]:    location: 0.375 1.375
    idx:     (9,13)
-
 With weight: 16
 pt[3]:    location: 0.125 1.625
    idx:     (8,14)
-
 With weight: 10.6667
 pt[4]:    location: 0.375 1.625
    idx:     (9,14)
-
 With weight: 2.32318e-16
 
 On point:    location: 0.375 1.375
    idx:     (9,13)
-
 pt[0]:    location: 0.375 1.375
    idx:     (9,13)
-
 With weight: -45.1765
 pt[1]:    location: 0.125 1.375
    idx:     (8,13)
-
 With weight: 16
 pt[2]:    location: 0.625 1.375
    idx:     (10,13)
-
 With weight: 8.47059
 pt[3]:    location: 0.375 1.625
    idx:     (9,14)
-
 With weight: 13.1765
 pt[4]:    location: 0.625 1.125
    idx:     (10,12)
-
 With weight: 7.52941
 
 On point:    location: 0.625 1.375
    idx:     (10,13)
-
 pt[0]:    location: 0.625 1.375
    idx:     (10,13)
-
 With weight: -64
 pt[1]:    location: 0.625 1.125
    idx:     (10,12)
-
 With weight: 16
 pt[2]:    location: 0.375 1.375
    idx:     (9,13)
-
 With weight: 16
 pt[3]:    location: 0.875 1.375
    idx:     (11,13)
-
 With weight: 16
 pt[4]:    location: 0.625 1.625
    idx:     (10,14)
-
 With weight: 16
 
 On point:    location: 0.875 1.375
    idx:     (11,13)
-
 pt[0]:    location: 0.875 1.375
    idx:     (11,13)
-
 With weight: -64
 pt[1]:    location: 0.875 1.125
    idx:     (11,12)
-
 With weight: 16
 pt[2]:    location: 0.625 1.375
    idx:     (10,13)
-
 With weight: 16
 pt[3]:    location: 1.125 1.375
    idx:     (12,13)
-
 With weight: 16
 pt[4]:    location: 0.875 1.625
    idx:     (11,14)
-
 With weight: 16
 
 On point:    location: 1.125 1.375
    idx:     (12,13)
-
 pt[0]:    location: 1.125 1.375
    idx:     (12,13)
-
 With weight: -64
 pt[1]:    location: 1.125 1.125
    idx:     (12,12)
-
 With weight: 16
 pt[2]:    location: 0.875 1.375
    idx:     (11,13)
-
 With weight: 16
 pt[3]:    location: 1.375 1.375
    idx:     (13,13)
-
 With weight: 16
 pt[4]:    location: 1.125 1.625
    idx:     (12,14)
-
 With weight: 16
 
 On point:    location: 1.375 1.375
    idx:     (13,13)
-
 pt[0]:    location: 1.375 1.375
    idx:     (13,13)
-
 With weight: -64
 pt[1]:    location: 1.375 1.125
    idx:     (13,12)
-
 With weight: 16
 pt[2]:    location: 1.125 1.375
    idx:     (12,13)
-
 With weight: 16
 pt[3]:    location: 1.625 1.375
    idx:     (14,13)
-
 With weight: 16
 pt[4]:    location: 1.375 1.625
    idx:     (13,14)
-
 With weight: 16
 
 On point:    location: 1.625 1.375
    idx:     (14,13)
-
 pt[0]:    location: 1.625 1.375
    idx:     (14,13)
-
 With weight: -64
 pt[1]:    location: 1.625 1.125
    idx:     (14,12)
-
 With weight: 16
 pt[2]:    location: 1.375 1.375
    idx:     (13,13)
-
 With weight: 16
 pt[3]:    location: 1.875 1.375
    idx:     (15,13)
-
 With weight: 16
 pt[4]:    location: 1.625 1.625
    idx:     (14,14)
-
 With weight: 16
 
 On point:    location: 1.875 1.375
    idx:     (15,13)
-
 pt[0]:    location: 1.875 1.375
    idx:     (15,13)
-
 With weight: -64
 pt[1]:    location: 1.875 1.125
    idx:     (15,12)
-
 With weight: 16
 pt[2]:    location: 1.625 1.375
    idx:     (14,13)
-
 With weight: 16
 pt[3]:    location: 2.125 1.375
    idx:     (16,13)
-
 With weight: 16
 pt[4]:    location: 1.875 1.625
    idx:     (15,14)
-
 With weight: 16
 
 On point:    location: -1.875  1.625
    idx:     (0,14)
-
 pt[0]:    location: -1.875  1.625
    idx:     (0,14)
-
 With weight: -64
 pt[1]:    location: -1.875  1.375
    idx:     (0,13)
-
 With weight: 16
 pt[2]:    location: -2.125  1.625
    idx:     (-1,14)
-
 With weight: 16
 pt[3]:    location: -1.625  1.625
    idx:     (1,14)
-
 With weight: 16
 pt[4]:    location: -1.875  1.875
    idx:     (0,15)
-
 With weight: 16
 
 On point:    location: -1.625  1.625
    idx:     (1,14)
-
 pt[0]:    location: -1.625  1.625
    idx:     (1,14)
-
 With weight: -64
 pt[1]:    location: -1.625  1.375
    idx:     (1,13)
-
 With weight: 16
 pt[2]:    location: -1.875  1.625
    idx:     (0,14)
-
 With weight: 16
 pt[3]:    location: -1.375  1.625
    idx:     (2,14)
-
 With weight: 16
 pt[4]:    location: -1.625  1.875
    idx:     (1,15)
-
 With weight: 16
 
 On point:    location: -1.375  1.625
    idx:     (2,14)
-
 pt[0]:    location: -1.375  1.625
    idx:     (2,14)
-
 With weight: -64
 pt[1]:    location: -1.375  1.375
    idx:     (2,13)
-
 With weight: 16
 pt[2]:    location: -1.625  1.625
    idx:     (1,14)
-
 With weight: 16
 pt[3]:    location: -1.125  1.625
    idx:     (3,14)
-
 With weight: 16
 pt[4]:    location: -1.375  1.875
    idx:     (2,15)
-
 With weight: 16
 
 On point:    location: -1.125  1.625
    idx:     (3,14)
-
 pt[0]:    location: -1.125  1.625
    idx:     (3,14)
-
 With weight: -64
 pt[1]:    location: -1.125  1.375
    idx:     (3,13)
-
 With weight: 16
 pt[2]:    location: -1.375  1.625
    idx:     (2,14)
-
 With weight: 16
 pt[3]:    location: -0.875  1.625
    idx:     (4,14)
-
 With weight: 16
 pt[4]:    location: -1.125  1.875
    idx:     (3,15)
-
 With weight: 16
 
 On point:    location: -0.875  1.625
    idx:     (4,14)
-
 pt[0]:    location: -0.875  1.625
    idx:     (4,14)
-
 With weight: -64
 pt[1]:    location: -0.875  1.375
    idx:     (4,13)
-
 With weight: 16
 pt[2]:    location: -1.125  1.625
    idx:     (3,14)
-
 With weight: 16
 pt[3]:    location: -0.625  1.625
    idx:     (5,14)
-
 With weight: 16
 pt[4]:    location: -0.875  1.875
    idx:     (4,15)
-
 With weight: 16
 
 On point:    location: -0.625  1.625
    idx:     (5,14)
-
 pt[0]:    location: -0.625  1.625
    idx:     (5,14)
-
 With weight: -64
 pt[1]:    location: -0.625  1.375
    idx:     (5,13)
-
 With weight: 16
 pt[2]:    location: -0.875  1.625
    idx:     (4,14)
-
 With weight: 16
 pt[3]:    location: -0.375  1.625
    idx:     (6,14)
-
 With weight: 16
 pt[4]:    location: -0.625  1.875
    idx:     (5,15)
-
 With weight: 16
 
 On point:    location: -0.375  1.625
    idx:     (6,14)
-
 pt[0]:    location: -0.375  1.625
    idx:     (6,14)
-
 With weight: -64
 pt[1]:    location: -0.375  1.375
    idx:     (6,13)
-
 With weight: 16
 pt[2]:    location: -0.625  1.625
    idx:     (5,14)
-
 With weight: 16
 pt[3]:    location: -0.125  1.625
    idx:     (7,14)
-
 With weight: 16
 pt[4]:    location: -0.375  1.875
    idx:     (6,15)
-
 With weight: 16
 
 On point:    location: -0.125  1.625
    idx:     (7,14)
-
 pt[0]:    location: -0.125  1.625
    idx:     (7,14)
-
 With weight: -64
 pt[1]:    location: -0.125  1.375
    idx:     (7,13)
-
 With weight: 16
 pt[2]:    location: -0.375  1.625
    idx:     (6,14)
-
 With weight: 16
 pt[3]:    location: 0.125 1.625
    idx:     (8,14)
-
 With weight: 16
 pt[4]:    location: -0.125  1.875
    idx:     (7,15)
-
 With weight: 16
 
 On point:    location: 0.125 1.625
    idx:     (8,14)
-
 pt[0]:    location: 0.125 1.625
    idx:     (8,14)
-
 With weight: -64
 pt[1]:    location: 0.125 1.375
    idx:     (8,13)
-
 With weight: 16
 pt[2]:    location: -0.125  1.625
    idx:     (7,14)
-
 With weight: 16
 pt[3]:    location: 0.375 1.625
    idx:     (9,14)
-
 With weight: 16
 pt[4]:    location: 0.125 1.875
    idx:     (8,15)
-
 With weight: 16
 
 On point:    location: 0.375 1.625
    idx:     (9,14)
-
 pt[0]:    location: 0.375 1.625
    idx:     (9,14)
-
 With weight: -64
 pt[1]:    location: 0.375 1.375
    idx:     (9,13)
-
 With weight: 16
 pt[2]:    location: 0.125 1.625
    idx:     (8,14)
-
 With weight: 16
 pt[3]:    location: 0.625 1.625
    idx:     (10,14)
-
 With weight: 16
 pt[4]:    location: 0.375 1.875
    idx:     (9,15)
-
 With weight: 16
 
 On point:    location: 0.625 1.625
    idx:     (10,14)
-
 pt[0]:    location: 0.625 1.625
    idx:     (10,14)
-
 With weight: -64
 pt[1]:    location: 0.625 1.375
    idx:     (10,13)
-
 With weight: 16
 pt[2]:    location: 0.375 1.625
    idx:     (9,14)
-
 With weight: 16
 pt[3]:    location: 0.875 1.625
    idx:     (11,14)
-
 With weight: 16
 pt[4]:    location: 0.625 1.875
    idx:     (10,15)
-
 With weight: 16
 
 On point:    location: 0.875 1.625
    idx:     (11,14)
-
 pt[0]:    location: 0.875 1.625
    idx:     (11,14)
-
 With weight: -64
 pt[1]:    location: 0.875 1.375
    idx:     (11,13)
-
 With weight: 16
 pt[2]:    location: 0.625 1.625
    idx:     (10,14)
-
 With weight: 16
 pt[3]:    location: 1.125 1.625
    idx:     (12,14)
-
 With weight: 16
 pt[4]:    location: 0.875 1.875
    idx:     (11,15)
-
 With weight: 16
 
 On point:    location: 1.125 1.625
    idx:     (12,14)
-
 pt[0]:    location: 1.125 1.625
    idx:     (12,14)
-
 With weight: -64
 pt[1]:    location: 1.125 1.375
    idx:     (12,13)
-
 With weight: 16
 pt[2]:    location: 0.875 1.625
    idx:     (11,14)
-
 With weight: 16
 pt[3]:    location: 1.375 1.625
    idx:     (13,14)
-
 With weight: 16
 pt[4]:    location: 1.125 1.875
    idx:     (12,15)
-
 With weight: 16
 
 On point:    location: 1.375 1.625
    idx:     (13,14)
-
 pt[0]:    location: 1.375 1.625
    idx:     (13,14)
-
 With weight: -64
 pt[1]:    location: 1.375 1.375
    idx:     (13,13)
-
 With weight: 16
 pt[2]:    location: 1.125 1.625
    idx:     (12,14)
-
 With weight: 16
 pt[3]:    location: 1.625 1.625
    idx:     (14,14)
-
 With weight: 16
 pt[4]:    location: 1.375 1.875
    idx:     (13,15)
-
 With weight: 16
 
 On point:    location: 1.625 1.625
    idx:     (14,14)
-
 pt[0]:    location: 1.625 1.625
    idx:     (14,14)
-
 With weight: -64
 pt[1]:    location: 1.625 1.375
    idx:     (14,13)
-
 With weight: 16
 pt[2]:    location: 1.375 1.625
    idx:     (13,14)
-
 With weight: 16
 pt[3]:    location: 1.875 1.625
    idx:     (15,14)
-
 With weight: 16
 pt[4]:    location: 1.625 1.875
    idx:     (14,15)
-
 With weight: 16
 
 On point:    location: 1.875 1.625
    idx:     (15,14)
-
 pt[0]:    location: 1.875 1.625
    idx:     (15,14)
-
 With weight: -64
 pt[1]:    location: 1.875 1.375
    idx:     (15,13)
-
 With weight: 16
 pt[2]:    location: 1.625 1.625
    idx:     (14,14)
-
 With weight: 16
 pt[3]:    location: 2.125 1.625
    idx:     (16,14)
-
 With weight: 16
 pt[4]:    location: 1.875 1.875
    idx:     (15,15)
-
 With weight: 16
 
 On point:    location: -1.875  1.875
    idx:     (0,15)
-
 pt[0]:    location: -1.875  1.875
    idx:     (0,15)
-
 With weight: -64
 pt[1]:    location: -1.875  1.625
    idx:     (0,14)
-
 With weight: 16
 pt[2]:    location: -2.125  1.875
    idx:     (-1,15)
-
 With weight: 16
 pt[3]:    location: -1.625  1.875
    idx:     (1,15)
-
 With weight: 16
 pt[4]:    location: -1.875  2.125
    idx:     (0,16)
-
 With weight: 16
 
 On point:    location: -1.625  1.875
    idx:     (1,15)
-
 pt[0]:    location: -1.625  1.875
    idx:     (1,15)
-
 With weight: -64
 pt[1]:    location: -1.625  1.625
    idx:     (1,14)
-
 With weight: 16
 pt[2]:    location: -1.875  1.875
    idx:     (0,15)
-
 With weight: 16
 pt[3]:    location: -1.375  1.875
    idx:     (2,15)
-
 With weight: 16
 pt[4]:    location: -1.625  2.125
    idx:     (1,16)
-
 With weight: 16
 
 On point:    location: -1.375  1.875
    idx:     (2,15)
-
 pt[0]:    location: -1.375  1.875
    idx:     (2,15)
-
 With weight: -64
 pt[1]:    location: -1.375  1.625
    idx:     (2,14)
-
 With weight: 16
 pt[2]:    location: -1.625  1.875
    idx:     (1,15)
-
 With weight: 16
 pt[3]:    location: -1.125  1.875
    idx:     (3,15)
-
 With weight: 16
 pt[4]:    location: -1.375  2.125
    idx:     (2,16)
-
 With weight: 16
 
 On point:    location: -1.125  1.875
    idx:     (3,15)
-
 pt[0]:    location: -1.125  1.875
    idx:     (3,15)
-
 With weight: -64
 pt[1]:    location: -1.125  1.625
    idx:     (3,14)
-
 With weight: 16
 pt[2]:    location: -1.375  1.875
    idx:     (2,15)
-
 With weight: 16
 pt[3]:    location: -0.875  1.875
    idx:     (4,15)
-
 With weight: 16
 pt[4]:    location: -1.125  2.125
    idx:     (3,16)
-
 With weight: 16
 
 On point:    location: -0.875  1.875
    idx:     (4,15)
-
 pt[0]:    location: -0.875  1.875
    idx:     (4,15)
-
 With weight: -64
 pt[1]:    location: -0.875  1.625
    idx:     (4,14)
-
 With weight: 16
 pt[2]:    location: -1.125  1.875
    idx:     (3,15)
-
 With weight: 16
 pt[3]:    location: -0.625  1.875
    idx:     (5,15)
-
 With weight: 16
 pt[4]:    location: -0.875  2.125
    idx:     (4,16)
-
 With weight: 16
 
 On point:    location: -0.625  1.875
    idx:     (5,15)
-
 pt[0]:    location: -0.625  1.875
    idx:     (5,15)
-
 With weight: -64
 pt[1]:    location: -0.625  1.625
    idx:     (5,14)
-
 With weight: 16
 pt[2]:    location: -0.875  1.875
    idx:     (4,15)
-
 With weight: 16
 pt[3]:    location: -0.375  1.875
    idx:     (6,15)
-
 With weight: 16
 pt[4]:    location: -0.625  2.125
    idx:     (5,16)
-
 With weight: 16
 
 On point:    location: -0.375  1.875
    idx:     (6,15)
-
 pt[0]:    location: -0.375  1.875
    idx:     (6,15)
-
 With weight: -64
 pt[1]:    location: -0.375  1.625
    idx:     (6,14)
-
 With weight: 16
 pt[2]:    location: -0.625  1.875
    idx:     (5,15)
-
 With weight: 16
 pt[3]:    location: -0.125  1.875
    idx:     (7,15)
-
 With weight: 16
 pt[4]:    location: -0.375  2.125
    idx:     (6,16)
-
 With weight: 16
 
 On point:    location: -0.125  1.875
    idx:     (7,15)
-
 pt[0]:    location: -0.125  1.875
    idx:     (7,15)
-
 With weight: -64
 pt[1]:    location: -0.125  1.625
    idx:     (7,14)
-
 With weight: 16
 pt[2]:    location: -0.375  1.875
    idx:     (6,15)
-
 With weight: 16
 pt[3]:    location: 0.125 1.875
    idx:     (8,15)
-
 With weight: 16
 pt[4]:    location: -0.125  2.125
    idx:     (7,16)
-
 With weight: 16
 
 On point:    location: 0.125 1.875
    idx:     (8,15)
-
 pt[0]:    location: 0.125 1.875
    idx:     (8,15)
-
 With weight: -64
 pt[1]:    location: 0.125 1.625
    idx:     (8,14)
-
 With weight: 16
 pt[2]:    location: -0.125  1.875
    idx:     (7,15)
-
 With weight: 16
 pt[3]:    location: 0.375 1.875
    idx:     (9,15)
-
 With weight: 16
 pt[4]:    location: 0.125 2.125
    idx:     (8,16)
-
 With weight: 16
 
 On point:    location: 0.375 1.875
    idx:     (9,15)
-
 pt[0]:    location: 0.375 1.875
    idx:     (9,15)
-
 With weight: -64
 pt[1]:    location: 0.375 1.625
    idx:     (9,14)
-
 With weight: 16
 pt[2]:    location: 0.125 1.875
    idx:     (8,15)
-
 With weight: 16
 pt[3]:    location: 0.625 1.875
    idx:     (10,15)
-
 With weight: 16
 pt[4]:    location: 0.375 2.125
    idx:     (9,16)
-
 With weight: 16
 
 On point:    location: 0.625 1.875
    idx:     (10,15)
-
 pt[0]:    location: 0.625 1.875
    idx:     (10,15)
-
 With weight: -64
 pt[1]:    location: 0.625 1.625
    idx:     (10,14)
-
 With weight: 16
 pt[2]:    location: 0.375 1.875
    idx:     (9,15)
-
 With weight: 16
 pt[3]:    location: 0.875 1.875
    idx:     (11,15)
-
 With weight: 16
 pt[4]:    location: 0.625 2.125
    idx:     (10,16)
-
 With weight: 16
 
 On point:    location: 0.875 1.875
    idx:     (11,15)
-
 pt[0]:    location: 0.875 1.875
    idx:     (11,15)
-
 With weight: -64
 pt[1]:    location: 0.875 1.625
    idx:     (11,14)
-
 With weight: 16
 pt[2]:    location: 0.625 1.875
    idx:     (10,15)
-
 With weight: 16
 pt[3]:    location: 1.125 1.875
    idx:     (12,15)
-
 With weight: 16
 pt[4]:    location: 0.875 2.125
    idx:     (11,16)
-
 With weight: 16
 
 On point:    location: 1.125 1.875
    idx:     (12,15)
-
 pt[0]:    location: 1.125 1.875
    idx:     (12,15)
-
 With weight: -64
 pt[1]:    location: 1.125 1.625
    idx:     (12,14)
-
 With weight: 16
 pt[2]:    location: 0.875 1.875
    idx:     (11,15)
-
 With weight: 16
 pt[3]:    location: 1.375 1.875
    idx:     (13,15)
-
 With weight: 16
 pt[4]:    location: 1.125 2.125
    idx:     (12,16)
-
 With weight: 16
 
 On point:    location: 1.375 1.875
    idx:     (13,15)
-
 pt[0]:    location: 1.375 1.875
    idx:     (13,15)
-
 With weight: -64
 pt[1]:    location: 1.375 1.625
    idx:     (13,14)
-
 With weight: 16
 pt[2]:    location: 1.125 1.875
    idx:     (12,15)
-
 With weight: 16
 pt[3]:    location: 1.625 1.875
    idx:     (14,15)
-
 With weight: 16
 pt[4]:    location: 1.375 2.125
    idx:     (13,16)
-
 With weight: 16
 
 On point:    location: 1.625 1.875
    idx:     (14,15)
-
 pt[0]:    location: 1.625 1.875
    idx:     (14,15)
-
 With weight: -64
 pt[1]:    location: 1.625 1.625
    idx:     (14,14)
-
 With weight: 16
 pt[2]:    location: 1.375 1.875
    idx:     (13,15)
-
 With weight: 16
 pt[3]:    location: 1.875 1.875
    idx:     (15,15)
-
 With weight: 16
 pt[4]:    location: 1.625 2.125
    idx:     (14,16)
-
 With weight: 16
 
 On point:    location: 1.875 1.875
    idx:     (15,15)
-
 pt[0]:    location: 1.875 1.875
    idx:     (15,15)
-
 With weight: -64
 pt[1]:    location: 1.875 1.625
    idx:     (15,14)
-
 With weight: 16
 pt[2]:    location: 1.625 1.875
    idx:     (14,15)
-
 With weight: 16
 pt[3]:    location: 2.125 1.875
    idx:     (16,15)
-
 With weight: 16
 pt[4]:    location: 1.875 2.125
    idx:     (15,16)
-
 With weight: 16
 

--- a/tests/operators/rbf_fd_weights_3d.output
+++ b/tests/operators/rbf_fd_weights_3d.output
@@ -1,11264 +1,8448 @@
 On point:    location: -1.75 -1.75 -1.75
    idx:     (0,0,0)
-
 pt[0]:    location: -1.75 -1.75 -1.75
    idx:     (0,0,0)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -2.25
    idx:     (0,0,-1)
-
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -1.75
    idx:     (0,-1,0)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -1.75
    idx:     (-1,0,0)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -1.75
    idx:     (1,0,0)
-
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -1.75
    idx:     (0,1,0)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.75 -1.25
    idx:     (0,0,1)
-
 With weight: 4
 
 On point:    location: -1.25 -1.75 -1.75
    idx:     (1,0,0)
-
 pt[0]:    location: -1.25 -1.75 -1.75
    idx:     (1,0,0)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -2.25
    idx:     (1,0,-1)
-
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -1.75
    idx:     (1,-1,0)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -1.75
    idx:     (0,0,0)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -1.75
    idx:     (2,0,0)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -1.75
    idx:     (1,1,0)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.75 -1.25
    idx:     (1,0,1)
-
 With weight: 4
 
 On point:    location: -0.75 -1.75 -1.75
    idx:     (2,0,0)
-
 pt[0]:    location: -0.75 -1.75 -1.75
    idx:     (2,0,0)
-
 With weight: -24
 pt[1]:    location: -0.75 -1.75 -2.25
    idx:     (2,0,-1)
-
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -1.75
    idx:     (2,-1,0)
-
 With weight: 4
 pt[3]:    location: -1.25 -1.75 -1.75
    idx:     (1,0,0)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -1.75
    idx:     (3,0,0)
-
 With weight: 4
 pt[5]:    location: -0.75 -1.25 -1.75
    idx:     (2,1,0)
-
 With weight: 4
 pt[6]:    location: -0.75 -1.75 -1.25
    idx:     (2,0,1)
-
 With weight: 4
 
 On point:    location: -0.25 -1.75 -1.75
    idx:     (3,0,0)
-
 pt[0]:    location: -0.25 -1.75 -1.75
    idx:     (3,0,0)
-
 With weight: -24
 pt[1]:    location: -0.25 -1.75 -2.25
    idx:     (3,0,-1)
-
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -1.75
    idx:     (3,-1,0)
-
 With weight: 4
 pt[3]:    location: -0.75 -1.75 -1.75
    idx:     (2,0,0)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -1.75
    idx:     (4,0,0)
-
 With weight: 4
 pt[5]:    location: -0.25 -1.25 -1.75
    idx:     (3,1,0)
-
 With weight: 4
 pt[6]:    location: -0.25 -1.75 -1.25
    idx:     (3,0,1)
-
 With weight: 4
 
 On point:    location:  0.25 -1.75 -1.75
    idx:     (4,0,0)
-
 pt[0]:    location:  0.25 -1.75 -1.75
    idx:     (4,0,0)
-
 With weight: -24
 pt[1]:    location:  0.25 -1.75 -2.25
    idx:     (4,0,-1)
-
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -1.75
    idx:     (4,-1,0)
-
 With weight: 4
 pt[3]:    location: -0.25 -1.75 -1.75
    idx:     (3,0,0)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -1.75
    idx:     (5,0,0)
-
 With weight: 4
 pt[5]:    location:  0.25 -1.25 -1.75
    idx:     (4,1,0)
-
 With weight: 4
 pt[6]:    location:  0.25 -1.75 -1.25
    idx:     (4,0,1)
-
 With weight: 4
 
 On point:    location:  0.75 -1.75 -1.75
    idx:     (5,0,0)
-
 pt[0]:    location:  0.75 -1.75 -1.75
    idx:     (5,0,0)
-
 With weight: -24
 pt[1]:    location:  0.75 -1.75 -2.25
    idx:     (5,0,-1)
-
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -1.75
    idx:     (5,-1,0)
-
 With weight: 4
 pt[3]:    location:  0.25 -1.75 -1.75
    idx:     (4,0,0)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -1.75
    idx:     (6,0,0)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.75
    idx:     (5,1,0)
-
 With weight: 4
 pt[6]:    location:  0.75 -1.75 -1.25
    idx:     (5,0,1)
-
 With weight: 4
 
 On point:    location:  1.25 -1.75 -1.75
    idx:     (6,0,0)
-
 pt[0]:    location:  1.25 -1.75 -1.75
    idx:     (6,0,0)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -2.25
    idx:     (6,0,-1)
-
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -1.75
    idx:     (6,-1,0)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -1.75
    idx:     (5,0,0)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -1.75
    idx:     (7,0,0)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -1.75
    idx:     (6,1,0)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.75 -1.25
    idx:     (6,0,1)
-
 With weight: 4
 
 On point:    location:  1.75 -1.75 -1.75
    idx:     (7,0,0)
-
 pt[0]:    location:  1.75 -1.75 -1.75
    idx:     (7,0,0)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -2.25
    idx:     (7,0,-1)
-
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -1.75
    idx:     (7,-1,0)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -1.75
    idx:     (6,0,0)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -1.75
    idx:     (8,0,0)
-
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -1.75
    idx:     (7,1,0)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.75 -1.25
    idx:     (7,0,1)
-
 With weight: 4
 
 On point:    location: -1.75 -1.25 -1.75
    idx:     (0,1,0)
-
 pt[0]:    location: -1.75 -1.25 -1.75
    idx:     (0,1,0)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -2.25
    idx:     (0,1,-1)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -1.75
    idx:     (0,0,0)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -1.75
    idx:     (-1,1,0)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -1.75
    idx:     (1,1,0)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -1.75
    idx:     (0,2,0)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -1.25
    idx:     (0,1,1)
-
 With weight: 4
 
 On point:    location: -1.25 -1.25 -1.75
    idx:     (1,1,0)
-
 pt[0]:    location: -1.25 -1.25 -1.75
    idx:     (1,1,0)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.25 -2.25
    idx:     (1,1,-1)
-
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -1.75
    idx:     (1,0,0)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.25 -1.75
    idx:     (0,1,0)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.25 -1.75
    idx:     (2,1,0)
-
 With weight: 4
 pt[5]:    location: -1.25 -0.75 -1.75
    idx:     (1,2,0)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.25 -1.25
    idx:     (1,1,1)
-
 With weight: 4
 
 On point:    location: -0.75 -1.25 -1.75
    idx:     (2,1,0)
-
 pt[0]:    location: -0.75 -1.25 -1.75
    idx:     (2,1,0)
-
 With weight: -24
 pt[1]:    location: -0.75 -1.25 -2.25
    idx:     (2,1,-1)
-
 With weight: 4
 pt[2]:    location: -0.75 -1.75 -1.75
    idx:     (2,0,0)
-
 With weight: 4
 pt[3]:    location: -1.25 -1.25 -1.75
    idx:     (1,1,0)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.25 -1.75
    idx:     (3,1,0)
-
 With weight: 4
 pt[5]:    location: -0.75 -0.75 -1.75
    idx:     (2,2,0)
-
 With weight: 4
 pt[6]:    location: -0.75 -1.25 -1.25
    idx:     (2,1,1)
-
 With weight: 4
 
 On point:    location: -0.25 -1.25 -1.75
    idx:     (3,1,0)
-
 pt[0]:    location: -0.25 -1.25 -1.75
    idx:     (3,1,0)
-
 With weight: -24
 pt[1]:    location: -0.25 -1.25 -2.25
    idx:     (3,1,-1)
-
 With weight: 4
 pt[2]:    location: -0.25 -1.75 -1.75
    idx:     (3,0,0)
-
 With weight: 4
 pt[3]:    location: -0.75 -1.25 -1.75
    idx:     (2,1,0)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.25 -1.75
    idx:     (4,1,0)
-
 With weight: 4
 pt[5]:    location: -0.25 -0.75 -1.75
    idx:     (3,2,0)
-
 With weight: 4
 pt[6]:    location: -0.25 -1.25 -1.25
    idx:     (3,1,1)
-
 With weight: 4
 
 On point:    location:  0.25 -1.25 -1.75
    idx:     (4,1,0)
-
 pt[0]:    location:  0.25 -1.25 -1.75
    idx:     (4,1,0)
-
 With weight: -24
 pt[1]:    location:  0.25 -1.25 -2.25
    idx:     (4,1,-1)
-
 With weight: 4
 pt[2]:    location:  0.25 -1.75 -1.75
    idx:     (4,0,0)
-
 With weight: 4
 pt[3]:    location: -0.25 -1.25 -1.75
    idx:     (3,1,0)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.25 -1.75
    idx:     (5,1,0)
-
 With weight: 4
 pt[5]:    location:  0.25 -0.75 -1.75
    idx:     (4,2,0)
-
 With weight: 4
 pt[6]:    location:  0.25 -1.25 -1.25
    idx:     (4,1,1)
-
 With weight: 4
 
 On point:    location:  0.75 -1.25 -1.75
    idx:     (5,1,0)
-
 pt[0]:    location:  0.75 -1.25 -1.75
    idx:     (5,1,0)
-
 With weight: -24
 pt[1]:    location:  0.75 -1.25 -2.25
    idx:     (5,1,-1)
-
 With weight: 4
 pt[2]:    location:  0.75 -1.75 -1.75
    idx:     (5,0,0)
-
 With weight: 4
 pt[3]:    location:  0.25 -1.25 -1.75
    idx:     (4,1,0)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.25 -1.75
    idx:     (6,1,0)
-
 With weight: 4
 pt[5]:    location:  0.75 -0.75 -1.75
    idx:     (5,2,0)
-
 With weight: 4
 pt[6]:    location:  0.75 -1.25 -1.25
    idx:     (5,1,1)
-
 With weight: 4
 
 On point:    location:  1.25 -1.25 -1.75
    idx:     (6,1,0)
-
 pt[0]:    location:  1.25 -1.25 -1.75
    idx:     (6,1,0)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.25 -2.25
    idx:     (6,1,-1)
-
 With weight: 4
 pt[2]:    location:  1.25 -1.75 -1.75
    idx:     (6,0,0)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.25 -1.75
    idx:     (5,1,0)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.25 -1.75
    idx:     (7,1,0)
-
 With weight: 4
 pt[5]:    location:  1.25 -0.75 -1.75
    idx:     (6,2,0)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.25 -1.25
    idx:     (6,1,1)
-
 With weight: 4
 
 On point:    location:  1.75 -1.25 -1.75
    idx:     (7,1,0)
-
 pt[0]:    location:  1.75 -1.25 -1.75
    idx:     (7,1,0)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -2.25
    idx:     (7,1,-1)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -1.75
    idx:     (7,0,0)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -1.75
    idx:     (6,1,0)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -1.75
    idx:     (8,1,0)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -1.75
    idx:     (7,2,0)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -1.25
    idx:     (7,1,1)
-
 With weight: 4
 
 On point:    location: -1.75 -0.75 -1.75
    idx:     (0,2,0)
-
 pt[0]:    location: -1.75 -0.75 -1.75
    idx:     (0,2,0)
-
 With weight: -24
 pt[1]:    location: -1.75 -0.75 -2.25
    idx:     (0,2,-1)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -1.75
    idx:     (0,1,0)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -1.75
    idx:     (-1,2,0)
-
 With weight: 4
 pt[4]:    location: -1.25 -0.75 -1.75
    idx:     (1,2,0)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.25 -1.75
    idx:     (0,3,0)
-
 With weight: 4
 pt[6]:    location: -1.75 -0.75 -1.25
    idx:     (0,2,1)
-
 With weight: 4
 
 On point:    location: -1.25 -0.75 -1.75
    idx:     (1,2,0)
-
 pt[0]:    location: -1.25 -0.75 -1.75
    idx:     (1,2,0)
-
 With weight: -24
 pt[1]:    location: -1.25 -0.75 -2.25
    idx:     (1,2,-1)
-
 With weight: 4
 pt[2]:    location: -1.25 -1.25 -1.75
    idx:     (1,1,0)
-
 With weight: 4
 pt[3]:    location: -1.75 -0.75 -1.75
    idx:     (0,2,0)
-
 With weight: 4
 pt[4]:    location: -0.75 -0.75 -1.75
    idx:     (2,2,0)
-
 With weight: 4
 pt[5]:    location: -1.25 -0.25 -1.75
    idx:     (1,3,0)
-
 With weight: 4
 pt[6]:    location: -1.25 -0.75 -1.25
    idx:     (1,2,1)
-
 With weight: 4
 
 On point:    location: -0.75 -0.75 -1.75
    idx:     (2,2,0)
-
 pt[0]:    location: -0.75 -0.75 -1.75
    idx:     (2,2,0)
-
 With weight: -18.6667
 pt[1]:    location: -0.75 -0.75 -2.25
    idx:     (2,2,-1)
-
 With weight: 2.66667
 pt[2]:    location: -0.75 -1.25 -1.75
    idx:     (2,1,0)
-
 With weight: 4
 pt[3]:    location: -1.25 -0.75 -1.75
    idx:     (1,2,0)
-
 With weight: 4
 pt[4]:    location: -0.25 -0.75 -1.75
    idx:     (3,2,0)
-
 With weight: 4
 pt[5]:    location: -0.75 -0.25 -1.75
    idx:     (2,3,0)
-
 With weight: 4
 pt[6]:    location: -0.75 -1.25 -2.25
    idx:     (2,1,-1)
-
 With weight: -5.7285e-16
 
 On point:    location: -0.25 -0.75 -1.75
    idx:     (3,2,0)
-
 pt[0]:    location: -0.25 -0.75 -1.75
    idx:     (3,2,0)
-
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.75 -2.25
    idx:     (3,2,-1)
-
 With weight: 2.66667
 pt[2]:    location: -0.25 -1.25 -1.75
    idx:     (3,1,0)
-
 With weight: 4
 pt[3]:    location: -0.75 -0.75 -1.75
    idx:     (2,2,0)
-
 With weight: 4
 pt[4]:    location:  0.25 -0.75 -1.75
    idx:     (4,2,0)
-
 With weight: 4
 pt[5]:    location: -0.25 -0.25 -1.75
    idx:     (3,3,0)
-
 With weight: 4
 pt[6]:    location: -0.25 -1.25 -2.25
    idx:     (3,1,-1)
-
 With weight: -5.7285e-16
 
 On point:    location:  0.25 -0.75 -1.75
    idx:     (4,2,0)
-
 pt[0]:    location:  0.25 -0.75 -1.75
    idx:     (4,2,0)
-
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.75 -2.25
    idx:     (4,2,-1)
-
 With weight: 2.66667
 pt[2]:    location:  0.25 -1.25 -1.75
    idx:     (4,1,0)
-
 With weight: 4
 pt[3]:    location: -0.25 -0.75 -1.75
    idx:     (3,2,0)
-
 With weight: 4
 pt[4]:    location:  0.75 -0.75 -1.75
    idx:     (5,2,0)
-
 With weight: 4
 pt[5]:    location:  0.25 -0.25 -1.75
    idx:     (4,3,0)
-
 With weight: 4
 pt[6]:    location:  0.25 -1.25 -2.25
    idx:     (4,1,-1)
-
 With weight: -5.7285e-16
 
 On point:    location:  0.75 -0.75 -1.75
    idx:     (5,2,0)
-
 pt[0]:    location:  0.75 -0.75 -1.75
    idx:     (5,2,0)
-
 With weight: -18.6667
 pt[1]:    location:  0.75 -0.75 -2.25
    idx:     (5,2,-1)
-
 With weight: 2.66667
 pt[2]:    location:  0.75 -1.25 -1.75
    idx:     (5,1,0)
-
 With weight: 4
 pt[3]:    location:  0.25 -0.75 -1.75
    idx:     (4,2,0)
-
 With weight: 4
 pt[4]:    location:  1.25 -0.75 -1.75
    idx:     (6,2,0)
-
 With weight: 4
 pt[5]:    location:  0.75 -0.25 -1.75
    idx:     (5,3,0)
-
 With weight: 4
 pt[6]:    location:  0.75 -1.25 -2.25
    idx:     (5,1,-1)
-
 With weight: -5.7285e-16
 
 On point:    location:  1.25 -0.75 -1.75
    idx:     (6,2,0)
-
 pt[0]:    location:  1.25 -0.75 -1.75
    idx:     (6,2,0)
-
 With weight: -24
 pt[1]:    location:  1.25 -0.75 -2.25
    idx:     (6,2,-1)
-
 With weight: 4
 pt[2]:    location:  1.25 -1.25 -1.75
    idx:     (6,1,0)
-
 With weight: 4
 pt[3]:    location:  0.75 -0.75 -1.75
    idx:     (5,2,0)
-
 With weight: 4
 pt[4]:    location:  1.75 -0.75 -1.75
    idx:     (7,2,0)
-
 With weight: 4
 pt[5]:    location:  1.25 -0.25 -1.75
    idx:     (6,3,0)
-
 With weight: 4
 pt[6]:    location:  1.25 -0.75 -1.25
    idx:     (6,2,1)
-
 With weight: 4
 
 On point:    location:  1.75 -0.75 -1.75
    idx:     (7,2,0)
-
 pt[0]:    location:  1.75 -0.75 -1.75
    idx:     (7,2,0)
-
 With weight: -24
 pt[1]:    location:  1.75 -0.75 -2.25
    idx:     (7,2,-1)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.25 -1.75
    idx:     (7,1,0)
-
 With weight: 4
 pt[3]:    location:  1.25 -0.75 -1.75
    idx:     (6,2,0)
-
 With weight: 4
 pt[4]:    location:  2.25 -0.75 -1.75
    idx:     (8,2,0)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.25 -1.75
    idx:     (7,3,0)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -1.25
    idx:     (7,2,1)
-
 With weight: 4
 
 On point:    location: -1.75 -0.25 -1.75
    idx:     (0,3,0)
-
 pt[0]:    location: -1.75 -0.25 -1.75
    idx:     (0,3,0)
-
 With weight: -24
 pt[1]:    location: -1.75 -0.25 -2.25
    idx:     (0,3,-1)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -1.75
    idx:     (0,2,0)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -1.75
    idx:     (-1,3,0)
-
 With weight: 4
 pt[4]:    location: -1.25 -0.25 -1.75
    idx:     (1,3,0)
-
 With weight: 4
 pt[5]:    location: -1.75  0.25 -1.75
    idx:     (0,4,0)
-
 With weight: 4
 pt[6]:    location: -1.75 -0.25 -1.25
    idx:     (0,3,1)
-
 With weight: 4
 
 On point:    location: -1.25 -0.25 -1.75
    idx:     (1,3,0)
-
 pt[0]:    location: -1.25 -0.25 -1.75
    idx:     (1,3,0)
-
 With weight: -24
 pt[1]:    location: -1.25 -0.25 -2.25
    idx:     (1,3,-1)
-
 With weight: 4
 pt[2]:    location: -1.25 -0.75 -1.75
    idx:     (1,2,0)
-
 With weight: 4
 pt[3]:    location: -1.75 -0.25 -1.75
    idx:     (0,3,0)
-
 With weight: 4
 pt[4]:    location: -0.75 -0.25 -1.75
    idx:     (2,3,0)
-
 With weight: 4
 pt[5]:    location: -1.25  0.25 -1.75
    idx:     (1,4,0)
-
 With weight: 4
 pt[6]:    location: -1.25 -0.25 -1.25
    idx:     (1,3,1)
-
 With weight: 4
 
 On point:    location: -0.75 -0.25 -1.75
    idx:     (2,3,0)
-
 pt[0]:    location: -0.75 -0.25 -1.75
    idx:     (2,3,0)
-
 With weight: -18.6667
 pt[1]:    location: -0.75 -0.25 -2.25
    idx:     (2,3,-1)
-
 With weight: 2.66667
 pt[2]:    location: -0.75 -0.75 -1.75
    idx:     (2,2,0)
-
 With weight: 4
 pt[3]:    location: -1.25 -0.25 -1.75
    idx:     (1,3,0)
-
 With weight: 4
 pt[4]:    location: -0.25 -0.25 -1.75
    idx:     (3,3,0)
-
 With weight: 4
 pt[5]:    location: -0.75  0.25 -1.75
    idx:     (2,4,0)
-
 With weight: 4
 pt[6]:    location: -0.75 -0.75 -2.25
    idx:     (2,2,-1)
-
 With weight: -5.7285e-16
 
 On point:    location: -0.25 -0.25 -1.75
    idx:     (3,3,0)
-
 pt[0]:    location: -0.25 -0.25 -1.75
    idx:     (3,3,0)
-
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.25 -2.25
    idx:     (3,3,-1)
-
 With weight: 2.66667
 pt[2]:    location: -0.25 -0.75 -1.75
    idx:     (3,2,0)
-
 With weight: 4
 pt[3]:    location: -0.75 -0.25 -1.75
    idx:     (2,3,0)
-
 With weight: 4
 pt[4]:    location:  0.25 -0.25 -1.75
    idx:     (4,3,0)
-
 With weight: 4
 pt[5]:    location: -0.25  0.25 -1.75
    idx:     (3,4,0)
-
 With weight: 4
 pt[6]:    location: -0.25 -0.75 -2.25
    idx:     (3,2,-1)
-
 With weight: -5.7285e-16
 
 On point:    location:  0.25 -0.25 -1.75
    idx:     (4,3,0)
-
 pt[0]:    location:  0.25 -0.25 -1.75
    idx:     (4,3,0)
-
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.25 -2.25
    idx:     (4,3,-1)
-
 With weight: 2.66667
 pt[2]:    location:  0.25 -0.75 -1.75
    idx:     (4,2,0)
-
 With weight: 4
 pt[3]:    location: -0.25 -0.25 -1.75
    idx:     (3,3,0)
-
 With weight: 4
 pt[4]:    location:  0.75 -0.25 -1.75
    idx:     (5,3,0)
-
 With weight: 4
 pt[5]:    location:  0.25  0.25 -1.75
    idx:     (4,4,0)
-
 With weight: 4
 pt[6]:    location:  0.25 -0.75 -2.25
    idx:     (4,2,-1)
-
 With weight: -5.7285e-16
 
 On point:    location:  0.75 -0.25 -1.75
    idx:     (5,3,0)
-
 pt[0]:    location:  0.75 -0.25 -1.75
    idx:     (5,3,0)
-
 With weight: -18.6667
 pt[1]:    location:  0.75 -0.25 -2.25
    idx:     (5,3,-1)
-
 With weight: 2.66667
 pt[2]:    location:  0.75 -0.75 -1.75
    idx:     (5,2,0)
-
 With weight: 4
 pt[3]:    location:  0.25 -0.25 -1.75
    idx:     (4,3,0)
-
 With weight: 4
 pt[4]:    location:  1.25 -0.25 -1.75
    idx:     (6,3,0)
-
 With weight: 4
 pt[5]:    location:  0.75  0.25 -1.75
    idx:     (5,4,0)
-
 With weight: 4
 pt[6]:    location:  0.75 -0.75 -2.25
    idx:     (5,2,-1)
-
 With weight: -5.7285e-16
 
 On point:    location:  1.25 -0.25 -1.75
    idx:     (6,3,0)
-
 pt[0]:    location:  1.25 -0.25 -1.75
    idx:     (6,3,0)
-
 With weight: -24
 pt[1]:    location:  1.25 -0.25 -2.25
    idx:     (6,3,-1)
-
 With weight: 4
 pt[2]:    location:  1.25 -0.75 -1.75
    idx:     (6,2,0)
-
 With weight: 4
 pt[3]:    location:  0.75 -0.25 -1.75
    idx:     (5,3,0)
-
 With weight: 4
 pt[4]:    location:  1.75 -0.25 -1.75
    idx:     (7,3,0)
-
 With weight: 4
 pt[5]:    location:  1.25  0.25 -1.75
    idx:     (6,4,0)
-
 With weight: 4
 pt[6]:    location:  1.25 -0.25 -1.25
    idx:     (6,3,1)
-
 With weight: 4
 
 On point:    location:  1.75 -0.25 -1.75
    idx:     (7,3,0)
-
 pt[0]:    location:  1.75 -0.25 -1.75
    idx:     (7,3,0)
-
 With weight: -24
 pt[1]:    location:  1.75 -0.25 -2.25
    idx:     (7,3,-1)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -1.75
    idx:     (7,2,0)
-
 With weight: 4
 pt[3]:    location:  1.25 -0.25 -1.75
    idx:     (6,3,0)
-
 With weight: 4
 pt[4]:    location:  2.25 -0.25 -1.75
    idx:     (8,3,0)
-
 With weight: 4
 pt[5]:    location:  1.75  0.25 -1.75
    idx:     (7,4,0)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.25 -1.25
    idx:     (7,3,1)
-
 With weight: 4
 
 On point:    location: -1.75  0.25 -1.75
    idx:     (0,4,0)
-
 pt[0]:    location: -1.75  0.25 -1.75
    idx:     (0,4,0)
-
 With weight: -24
 pt[1]:    location: -1.75  0.25 -2.25
    idx:     (0,4,-1)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -1.75
    idx:     (0,3,0)
-
 With weight: 4
 pt[3]:    location: -2.25  0.25 -1.75
    idx:     (-1,4,0)
-
 With weight: 4
 pt[4]:    location: -1.25  0.25 -1.75
    idx:     (1,4,0)
-
 With weight: 4
 pt[5]:    location: -1.75  0.75 -1.75
    idx:     (0,5,0)
-
 With weight: 4
 pt[6]:    location: -1.75  0.25 -1.25
    idx:     (0,4,1)
-
 With weight: 4
 
 On point:    location: -1.25  0.25 -1.75
    idx:     (1,4,0)
-
 pt[0]:    location: -1.25  0.25 -1.75
    idx:     (1,4,0)
-
 With weight: -24
 pt[1]:    location: -1.25  0.25 -2.25
    idx:     (1,4,-1)
-
 With weight: 4
 pt[2]:    location: -1.25 -0.25 -1.75
    idx:     (1,3,0)
-
 With weight: 4
 pt[3]:    location: -1.75  0.25 -1.75
    idx:     (0,4,0)
-
 With weight: 4
 pt[4]:    location: -0.75  0.25 -1.75
    idx:     (2,4,0)
-
 With weight: 4
 pt[5]:    location: -1.25  0.75 -1.75
    idx:     (1,5,0)
-
 With weight: 4
 pt[6]:    location: -1.25  0.25 -1.25
    idx:     (1,4,1)
-
 With weight: 4
 
 On point:    location: -0.75  0.25 -1.75
    idx:     (2,4,0)
-
 pt[0]:    location: -0.75  0.25 -1.75
    idx:     (2,4,0)
-
 With weight: -18.6667
 pt[1]:    location: -0.75  0.25 -2.25
    idx:     (2,4,-1)
-
 With weight: 2.66667
 pt[2]:    location: -0.75 -0.25 -1.75
    idx:     (2,3,0)
-
 With weight: 4
 pt[3]:    location: -1.25  0.25 -1.75
    idx:     (1,4,0)
-
 With weight: 4
 pt[4]:    location: -0.25  0.25 -1.75
    idx:     (3,4,0)
-
 With weight: 4
 pt[5]:    location: -0.75  0.75 -1.75
    idx:     (2,5,0)
-
 With weight: 4
 pt[6]:    location: -1.25  0.25 -2.25
    idx:     (1,4,-1)
-
 With weight: 1.82407e-15
 
 On point:    location: -0.25  0.25 -1.75
    idx:     (3,4,0)
-
 pt[0]:    location: -0.25  0.25 -1.75
    idx:     (3,4,0)
-
 With weight: -18.6667
 pt[1]:    location: -0.25  0.25 -2.25
    idx:     (3,4,-1)
-
 With weight: 2.66667
 pt[2]:    location: -0.25 -0.25 -1.75
    idx:     (3,3,0)
-
 With weight: 4
 pt[3]:    location: -0.75  0.25 -1.75
    idx:     (2,4,0)
-
 With weight: 4
 pt[4]:    location:  0.25  0.25 -1.75
    idx:     (4,4,0)
-
 With weight: 4
 pt[5]:    location: -0.25  0.75 -1.75
    idx:     (3,5,0)
-
 With weight: 4
 pt[6]:    location: -0.75  0.25 -2.25
    idx:     (2,4,-1)
-
 With weight: 1.82407e-15
 
 On point:    location:  0.25  0.25 -1.75
    idx:     (4,4,0)
-
 pt[0]:    location:  0.25  0.25 -1.75
    idx:     (4,4,0)
-
 With weight: -18.6667
 pt[1]:    location:  0.25  0.25 -2.25
    idx:     (4,4,-1)
-
 With weight: 2.66667
 pt[2]:    location:  0.25 -0.25 -1.75
    idx:     (4,3,0)
-
 With weight: 4
 pt[3]:    location: -0.25  0.25 -1.75
    idx:     (3,4,0)
-
 With weight: 4
 pt[4]:    location:  0.75  0.25 -1.75
    idx:     (5,4,0)
-
 With weight: 4
 pt[5]:    location:  0.25  0.75 -1.75
    idx:     (4,5,0)
-
 With weight: 4
 pt[6]:    location:  0.75  0.25 -2.25
    idx:     (5,4,-1)
-
 With weight: -2.7135e-16
 
 On point:    location:  0.75  0.25 -1.75
    idx:     (5,4,0)
-
 pt[0]:    location:  0.75  0.25 -1.75
    idx:     (5,4,0)
-
 With weight: -18.6667
 pt[1]:    location:  0.75  0.25 -2.25
    idx:     (5,4,-1)
-
 With weight: 2.66667
 pt[2]:    location:  0.75 -0.25 -1.75
    idx:     (5,3,0)
-
 With weight: 4
 pt[3]:    location:  0.25  0.25 -1.75
    idx:     (4,4,0)
-
 With weight: 4
 pt[4]:    location:  1.25  0.25 -1.75
    idx:     (6,4,0)
-
 With weight: 4
 pt[5]:    location:  0.75  0.75 -1.75
    idx:     (5,5,0)
-
 With weight: 4
 pt[6]:    location:  0.25  0.25 -2.25
    idx:     (4,4,-1)
-
 With weight: 1.82407e-15
 
 On point:    location:  1.25  0.25 -1.75
    idx:     (6,4,0)
-
 pt[0]:    location:  1.25  0.25 -1.75
    idx:     (6,4,0)
-
 With weight: -24
 pt[1]:    location:  1.25  0.25 -2.25
    idx:     (6,4,-1)
-
 With weight: 4
 pt[2]:    location:  1.25 -0.25 -1.75
    idx:     (6,3,0)
-
 With weight: 4
 pt[3]:    location:  0.75  0.25 -1.75
    idx:     (5,4,0)
-
 With weight: 4
 pt[4]:    location:  1.75  0.25 -1.75
    idx:     (7,4,0)
-
 With weight: 4
 pt[5]:    location:  1.25  0.75 -1.75
    idx:     (6,5,0)
-
 With weight: 4
 pt[6]:    location:  1.25  0.25 -1.25
    idx:     (6,4,1)
-
 With weight: 4
 
 On point:    location:  1.75  0.25 -1.75
    idx:     (7,4,0)
-
 pt[0]:    location:  1.75  0.25 -1.75
    idx:     (7,4,0)
-
 With weight: -24
 pt[1]:    location:  1.75  0.25 -2.25
    idx:     (7,4,-1)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.25 -1.75
    idx:     (7,3,0)
-
 With weight: 4
 pt[3]:    location:  1.25  0.25 -1.75
    idx:     (6,4,0)
-
 With weight: 4
 pt[4]:    location:  2.25  0.25 -1.75
    idx:     (8,4,0)
-
 With weight: 4
 pt[5]:    location:  1.75  0.75 -1.75
    idx:     (7,5,0)
-
 With weight: 4
 pt[6]:    location:  1.75  0.25 -1.25
    idx:     (7,4,1)
-
 With weight: 4
 
 On point:    location: -1.75  0.75 -1.75
    idx:     (0,5,0)
-
 pt[0]:    location: -1.75  0.75 -1.75
    idx:     (0,5,0)
-
 With weight: -24
 pt[1]:    location: -1.75  0.75 -2.25
    idx:     (0,5,-1)
-
 With weight: 4
 pt[2]:    location: -1.75  0.25 -1.75
    idx:     (0,4,0)
-
 With weight: 4
 pt[3]:    location: -2.25  0.75 -1.75
    idx:     (-1,5,0)
-
 With weight: 4
 pt[4]:    location: -1.25  0.75 -1.75
    idx:     (1,5,0)
-
 With weight: 4
 pt[5]:    location: -1.75  1.25 -1.75
    idx:     (0,6,0)
-
 With weight: 4
 pt[6]:    location: -1.75  0.75 -1.25
    idx:     (0,5,1)
-
 With weight: 4
 
 On point:    location: -1.25  0.75 -1.75
    idx:     (1,5,0)
-
 pt[0]:    location: -1.25  0.75 -1.75
    idx:     (1,5,0)
-
 With weight: -24
 pt[1]:    location: -1.25  0.75 -2.25
    idx:     (1,5,-1)
-
 With weight: 4
 pt[2]:    location: -1.25  0.25 -1.75
    idx:     (1,4,0)
-
 With weight: 4
 pt[3]:    location: -1.75  0.75 -1.75
    idx:     (0,5,0)
-
 With weight: 4
 pt[4]:    location: -0.75  0.75 -1.75
    idx:     (2,5,0)
-
 With weight: 4
 pt[5]:    location: -1.25  1.25 -1.75
    idx:     (1,6,0)
-
 With weight: 4
 pt[6]:    location: -1.25  0.75 -1.25
    idx:     (1,5,1)
-
 With weight: 4
 
 On point:    location: -0.75  0.75 -1.75
    idx:     (2,5,0)
-
 pt[0]:    location: -0.75  0.75 -1.75
    idx:     (2,5,0)
-
 With weight: -18.6667
 pt[1]:    location: -0.75  0.75 -2.25
    idx:     (2,5,-1)
-
 With weight: 2.66667
 pt[2]:    location: -0.75  0.25 -1.75
    idx:     (2,4,0)
-
 With weight: 4
 pt[3]:    location: -1.25  0.75 -1.75
    idx:     (1,5,0)
-
 With weight: 4
 pt[4]:    location: -0.25  0.75 -1.75
    idx:     (3,5,0)
-
 With weight: 4
 pt[5]:    location: -0.75  1.25 -1.75
    idx:     (2,6,0)
-
 With weight: 4
 pt[6]:    location: -0.75  0.25 -2.25
    idx:     (2,4,-1)
-
 With weight: -5.7285e-16
 
 On point:    location: -0.25  0.75 -1.75
    idx:     (3,5,0)
-
 pt[0]:    location: -0.25  0.75 -1.75
    idx:     (3,5,0)
-
 With weight: -18.6667
 pt[1]:    location: -0.25  0.75 -2.25
    idx:     (3,5,-1)
-
 With weight: 2.66667
 pt[2]:    location: -0.25  0.25 -1.75
    idx:     (3,4,0)
-
 With weight: 4
 pt[3]:    location: -0.75  0.75 -1.75
    idx:     (2,5,0)
-
 With weight: 4
 pt[4]:    location:  0.25  0.75 -1.75
    idx:     (4,5,0)
-
 With weight: 4
 pt[5]:    location: -0.25  1.25 -1.75
    idx:     (3,6,0)
-
 With weight: 4
 pt[6]:    location: -0.25  0.25 -2.25
    idx:     (3,4,-1)
-
 With weight: -5.7285e-16
 
 On point:    location:  0.25  0.75 -1.75
    idx:     (4,5,0)
-
 pt[0]:    location:  0.25  0.75 -1.75
    idx:     (4,5,0)
-
 With weight: -18.6667
 pt[1]:    location:  0.25  0.75 -2.25
    idx:     (4,5,-1)
-
 With weight: 2.66667
 pt[2]:    location:  0.25  0.25 -1.75
    idx:     (4,4,0)
-
 With weight: 4
 pt[3]:    location: -0.25  0.75 -1.75
    idx:     (3,5,0)
-
 With weight: 4
 pt[4]:    location:  0.75  0.75 -1.75
    idx:     (5,5,0)
-
 With weight: 4
 pt[5]:    location:  0.25  1.25 -1.75
    idx:     (4,6,0)
-
 With weight: 4
 pt[6]:    location:  0.25  0.25 -2.25
    idx:     (4,4,-1)
-
 With weight: -5.7285e-16
 
 On point:    location:  0.75  0.75 -1.75
    idx:     (5,5,0)
-
 pt[0]:    location:  0.75  0.75 -1.75
    idx:     (5,5,0)
-
 With weight: -18.6667
 pt[1]:    location:  0.75  0.75 -2.25
    idx:     (5,5,-1)
-
 With weight: 2.66667
 pt[2]:    location:  0.75  0.25 -1.75
    idx:     (5,4,0)
-
 With weight: 4
 pt[3]:    location:  0.25  0.75 -1.75
    idx:     (4,5,0)
-
 With weight: 4
 pt[4]:    location:  1.25  0.75 -1.75
    idx:     (6,5,0)
-
 With weight: 4
 pt[5]:    location:  0.75  1.25 -1.75
    idx:     (5,6,0)
-
 With weight: 4
 pt[6]:    location:  0.75  0.25 -2.25
    idx:     (5,4,-1)
-
 With weight: -5.7285e-16
 
 On point:    location:  1.25  0.75 -1.75
    idx:     (6,5,0)
-
 pt[0]:    location:  1.25  0.75 -1.75
    idx:     (6,5,0)
-
 With weight: -24
 pt[1]:    location:  1.25  0.75 -2.25
    idx:     (6,5,-1)
-
 With weight: 4
 pt[2]:    location:  1.25  0.25 -1.75
    idx:     (6,4,0)
-
 With weight: 4
 pt[3]:    location:  0.75  0.75 -1.75
    idx:     (5,5,0)
-
 With weight: 4
 pt[4]:    location:  1.75  0.75 -1.75
    idx:     (7,5,0)
-
 With weight: 4
 pt[5]:    location:  1.25  1.25 -1.75
    idx:     (6,6,0)
-
 With weight: 4
 pt[6]:    location:  1.25  0.75 -1.25
    idx:     (6,5,1)
-
 With weight: 4
 
 On point:    location:  1.75  0.75 -1.75
    idx:     (7,5,0)
-
 pt[0]:    location:  1.75  0.75 -1.75
    idx:     (7,5,0)
-
 With weight: -24
 pt[1]:    location:  1.75  0.75 -2.25
    idx:     (7,5,-1)
-
 With weight: 4
 pt[2]:    location:  1.75  0.25 -1.75
    idx:     (7,4,0)
-
 With weight: 4
 pt[3]:    location:  1.25  0.75 -1.75
    idx:     (6,5,0)
-
 With weight: 4
 pt[4]:    location:  2.25  0.75 -1.75
    idx:     (8,5,0)
-
 With weight: 4
 pt[5]:    location:  1.75  1.25 -1.75
    idx:     (7,6,0)
-
 With weight: 4
 pt[6]:    location:  1.75  0.75 -1.25
    idx:     (7,5,1)
-
 With weight: 4
 
 On point:    location: -1.75  1.25 -1.75
    idx:     (0,6,0)
-
 pt[0]:    location: -1.75  1.25 -1.75
    idx:     (0,6,0)
-
 With weight: -24
 pt[1]:    location: -1.75  1.25 -2.25
    idx:     (0,6,-1)
-
 With weight: 4
 pt[2]:    location: -1.75  0.75 -1.75
    idx:     (0,5,0)
-
 With weight: 4
 pt[3]:    location: -2.25  1.25 -1.75
    idx:     (-1,6,0)
-
 With weight: 4
 pt[4]:    location: -1.25  1.25 -1.75
    idx:     (1,6,0)
-
 With weight: 4
 pt[5]:    location: -1.75  1.75 -1.75
    idx:     (0,7,0)
-
 With weight: 4
 pt[6]:    location: -1.75  1.25 -1.25
    idx:     (0,6,1)
-
 With weight: 4
 
 On point:    location: -1.25  1.25 -1.75
    idx:     (1,6,0)
-
 pt[0]:    location: -1.25  1.25 -1.75
    idx:     (1,6,0)
-
 With weight: -24
 pt[1]:    location: -1.25  1.25 -2.25
    idx:     (1,6,-1)
-
 With weight: 4
 pt[2]:    location: -1.25  0.75 -1.75
    idx:     (1,5,0)
-
 With weight: 4
 pt[3]:    location: -1.75  1.25 -1.75
    idx:     (0,6,0)
-
 With weight: 4
 pt[4]:    location: -0.75  1.25 -1.75
    idx:     (2,6,0)
-
 With weight: 4
 pt[5]:    location: -1.25  1.75 -1.75
    idx:     (1,7,0)
-
 With weight: 4
 pt[6]:    location: -1.25  1.25 -1.25
    idx:     (1,6,1)
-
 With weight: 4
 
 On point:    location: -0.75  1.25 -1.75
    idx:     (2,6,0)
-
 pt[0]:    location: -0.75  1.25 -1.75
    idx:     (2,6,0)
-
 With weight: -24
 pt[1]:    location: -0.75  1.25 -2.25
    idx:     (2,6,-1)
-
 With weight: 4
 pt[2]:    location: -0.75  0.75 -1.75
    idx:     (2,5,0)
-
 With weight: 4
 pt[3]:    location: -1.25  1.25 -1.75
    idx:     (1,6,0)
-
 With weight: 4
 pt[4]:    location: -0.25  1.25 -1.75
    idx:     (3,6,0)
-
 With weight: 4
 pt[5]:    location: -0.75  1.75 -1.75
    idx:     (2,7,0)
-
 With weight: 4
 pt[6]:    location: -0.75  1.25 -1.25
    idx:     (2,6,1)
-
 With weight: 4
 
 On point:    location: -0.25  1.25 -1.75
    idx:     (3,6,0)
-
 pt[0]:    location: -0.25  1.25 -1.75
    idx:     (3,6,0)
-
 With weight: -24
 pt[1]:    location: -0.25  1.25 -2.25
    idx:     (3,6,-1)
-
 With weight: 4
 pt[2]:    location: -0.25  0.75 -1.75
    idx:     (3,5,0)
-
 With weight: 4
 pt[3]:    location: -0.75  1.25 -1.75
    idx:     (2,6,0)
-
 With weight: 4
 pt[4]:    location:  0.25  1.25 -1.75
    idx:     (4,6,0)
-
 With weight: 4
 pt[5]:    location: -0.25  1.75 -1.75
    idx:     (3,7,0)
-
 With weight: 4
 pt[6]:    location: -0.25  1.25 -1.25
    idx:     (3,6,1)
-
 With weight: 4
 
 On point:    location:  0.25  1.25 -1.75
    idx:     (4,6,0)
-
 pt[0]:    location:  0.25  1.25 -1.75
    idx:     (4,6,0)
-
 With weight: -24
 pt[1]:    location:  0.25  1.25 -2.25
    idx:     (4,6,-1)
-
 With weight: 4
 pt[2]:    location:  0.25  0.75 -1.75
    idx:     (4,5,0)
-
 With weight: 4
 pt[3]:    location: -0.25  1.25 -1.75
    idx:     (3,6,0)
-
 With weight: 4
 pt[4]:    location:  0.75  1.25 -1.75
    idx:     (5,6,0)
-
 With weight: 4
 pt[5]:    location:  0.25  1.75 -1.75
    idx:     (4,7,0)
-
 With weight: 4
 pt[6]:    location:  0.25  1.25 -1.25
    idx:     (4,6,1)
-
 With weight: 4
 
 On point:    location:  0.75  1.25 -1.75
    idx:     (5,6,0)
-
 pt[0]:    location:  0.75  1.25 -1.75
    idx:     (5,6,0)
-
 With weight: -24
 pt[1]:    location:  0.75  1.25 -2.25
    idx:     (5,6,-1)
-
 With weight: 4
 pt[2]:    location:  0.75  0.75 -1.75
    idx:     (5,5,0)
-
 With weight: 4
 pt[3]:    location:  0.25  1.25 -1.75
    idx:     (4,6,0)
-
 With weight: 4
 pt[4]:    location:  1.25  1.25 -1.75
    idx:     (6,6,0)
-
 With weight: 4
 pt[5]:    location:  0.75  1.75 -1.75
    idx:     (5,7,0)
-
 With weight: 4
 pt[6]:    location:  0.75  1.25 -1.25
    idx:     (5,6,1)
-
 With weight: 4
 
 On point:    location:  1.25  1.25 -1.75
    idx:     (6,6,0)
-
 pt[0]:    location:  1.25  1.25 -1.75
    idx:     (6,6,0)
-
 With weight: -24
 pt[1]:    location:  1.25  1.25 -2.25
    idx:     (6,6,-1)
-
 With weight: 4
 pt[2]:    location:  1.25  0.75 -1.75
    idx:     (6,5,0)
-
 With weight: 4
 pt[3]:    location:  0.75  1.25 -1.75
    idx:     (5,6,0)
-
 With weight: 4
 pt[4]:    location:  1.75  1.25 -1.75
    idx:     (7,6,0)
-
 With weight: 4
 pt[5]:    location:  1.25  1.75 -1.75
    idx:     (6,7,0)
-
 With weight: 4
 pt[6]:    location:  1.25  1.25 -1.25
    idx:     (6,6,1)
-
 With weight: 4
 
 On point:    location:  1.75  1.25 -1.75
    idx:     (7,6,0)
-
 pt[0]:    location:  1.75  1.25 -1.75
    idx:     (7,6,0)
-
 With weight: -24
 pt[1]:    location:  1.75  1.25 -2.25
    idx:     (7,6,-1)
-
 With weight: 4
 pt[2]:    location:  1.75  0.75 -1.75
    idx:     (7,5,0)
-
 With weight: 4
 pt[3]:    location:  1.25  1.25 -1.75
    idx:     (6,6,0)
-
 With weight: 4
 pt[4]:    location:  2.25  1.25 -1.75
    idx:     (8,6,0)
-
 With weight: 4
 pt[5]:    location:  1.75  1.75 -1.75
    idx:     (7,7,0)
-
 With weight: 4
 pt[6]:    location:  1.75  1.25 -1.25
    idx:     (7,6,1)
-
 With weight: 4
 
 On point:    location: -1.75  1.75 -1.75
    idx:     (0,7,0)
-
 pt[0]:    location: -1.75  1.75 -1.75
    idx:     (0,7,0)
-
 With weight: -24
 pt[1]:    location: -1.75  1.75 -2.25
    idx:     (0,7,-1)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25 -1.75
    idx:     (0,6,0)
-
 With weight: 4
 pt[3]:    location: -2.25  1.75 -1.75
    idx:     (-1,7,0)
-
 With weight: 4
 pt[4]:    location: -1.25  1.75 -1.75
    idx:     (1,7,0)
-
 With weight: 4
 pt[5]:    location: -1.75  2.25 -1.75
    idx:     (0,8,0)
-
 With weight: 4
 pt[6]:    location: -1.75  1.75 -1.25
    idx:     (0,7,1)
-
 With weight: 4
 
 On point:    location: -1.25  1.75 -1.75
    idx:     (1,7,0)
-
 pt[0]:    location: -1.25  1.75 -1.75
    idx:     (1,7,0)
-
 With weight: -24
 pt[1]:    location: -1.25  1.75 -2.25
    idx:     (1,7,-1)
-
 With weight: 4
 pt[2]:    location: -1.25  1.25 -1.75
    idx:     (1,6,0)
-
 With weight: 4
 pt[3]:    location: -1.75  1.75 -1.75
    idx:     (0,7,0)
-
 With weight: 4
 pt[4]:    location: -0.75  1.75 -1.75
    idx:     (2,7,0)
-
 With weight: 4
 pt[5]:    location: -1.25  2.25 -1.75
    idx:     (1,8,0)
-
 With weight: 4
 pt[6]:    location: -1.25  1.75 -1.25
    idx:     (1,7,1)
-
 With weight: 4
 
 On point:    location: -0.75  1.75 -1.75
    idx:     (2,7,0)
-
 pt[0]:    location: -0.75  1.75 -1.75
    idx:     (2,7,0)
-
 With weight: -24
 pt[1]:    location: -0.75  1.75 -2.25
    idx:     (2,7,-1)
-
 With weight: 4
 pt[2]:    location: -0.75  1.25 -1.75
    idx:     (2,6,0)
-
 With weight: 4
 pt[3]:    location: -1.25  1.75 -1.75
    idx:     (1,7,0)
-
 With weight: 4
 pt[4]:    location: -0.25  1.75 -1.75
    idx:     (3,7,0)
-
 With weight: 4
 pt[5]:    location: -0.75  2.25 -1.75
    idx:     (2,8,0)
-
 With weight: 4
 pt[6]:    location: -0.75  1.75 -1.25
    idx:     (2,7,1)
-
 With weight: 4
 
 On point:    location: -0.25  1.75 -1.75
    idx:     (3,7,0)
-
 pt[0]:    location: -0.25  1.75 -1.75
    idx:     (3,7,0)
-
 With weight: -24
 pt[1]:    location: -0.25  1.75 -2.25
    idx:     (3,7,-1)
-
 With weight: 4
 pt[2]:    location: -0.25  1.25 -1.75
    idx:     (3,6,0)
-
 With weight: 4
 pt[3]:    location: -0.75  1.75 -1.75
    idx:     (2,7,0)
-
 With weight: 4
 pt[4]:    location:  0.25  1.75 -1.75
    idx:     (4,7,0)
-
 With weight: 4
 pt[5]:    location: -0.25  2.25 -1.75
    idx:     (3,8,0)
-
 With weight: 4
 pt[6]:    location: -0.25  1.75 -1.25
    idx:     (3,7,1)
-
 With weight: 4
 
 On point:    location:  0.25  1.75 -1.75
    idx:     (4,7,0)
-
 pt[0]:    location:  0.25  1.75 -1.75
    idx:     (4,7,0)
-
 With weight: -24
 pt[1]:    location:  0.25  1.75 -2.25
    idx:     (4,7,-1)
-
 With weight: 4
 pt[2]:    location:  0.25  1.25 -1.75
    idx:     (4,6,0)
-
 With weight: 4
 pt[3]:    location: -0.25  1.75 -1.75
    idx:     (3,7,0)
-
 With weight: 4
 pt[4]:    location:  0.75  1.75 -1.75
    idx:     (5,7,0)
-
 With weight: 4
 pt[5]:    location:  0.25  2.25 -1.75
    idx:     (4,8,0)
-
 With weight: 4
 pt[6]:    location:  0.25  1.75 -1.25
    idx:     (4,7,1)
-
 With weight: 4
 
 On point:    location:  0.75  1.75 -1.75
    idx:     (5,7,0)
-
 pt[0]:    location:  0.75  1.75 -1.75
    idx:     (5,7,0)
-
 With weight: -24
 pt[1]:    location:  0.75  1.75 -2.25
    idx:     (5,7,-1)
-
 With weight: 4
 pt[2]:    location:  0.75  1.25 -1.75
    idx:     (5,6,0)
-
 With weight: 4
 pt[3]:    location:  0.25  1.75 -1.75
    idx:     (4,7,0)
-
 With weight: 4
 pt[4]:    location:  1.25  1.75 -1.75
    idx:     (6,7,0)
-
 With weight: 4
 pt[5]:    location:  0.75  2.25 -1.75
    idx:     (5,8,0)
-
 With weight: 4
 pt[6]:    location:  0.75  1.75 -1.25
    idx:     (5,7,1)
-
 With weight: 4
 
 On point:    location:  1.25  1.75 -1.75
    idx:     (6,7,0)
-
 pt[0]:    location:  1.25  1.75 -1.75
    idx:     (6,7,0)
-
 With weight: -24
 pt[1]:    location:  1.25  1.75 -2.25
    idx:     (6,7,-1)
-
 With weight: 4
 pt[2]:    location:  1.25  1.25 -1.75
    idx:     (6,6,0)
-
 With weight: 4
 pt[3]:    location:  0.75  1.75 -1.75
    idx:     (5,7,0)
-
 With weight: 4
 pt[4]:    location:  1.75  1.75 -1.75
    idx:     (7,7,0)
-
 With weight: 4
 pt[5]:    location:  1.25  2.25 -1.75
    idx:     (6,8,0)
-
 With weight: 4
 pt[6]:    location:  1.25  1.75 -1.25
    idx:     (6,7,1)
-
 With weight: 4
 
 On point:    location:  1.75  1.75 -1.75
    idx:     (7,7,0)
-
 pt[0]:    location:  1.75  1.75 -1.75
    idx:     (7,7,0)
-
 With weight: -24
 pt[1]:    location:  1.75  1.75 -2.25
    idx:     (7,7,-1)
-
 With weight: 4
 pt[2]:    location:  1.75  1.25 -1.75
    idx:     (7,6,0)
-
 With weight: 4
 pt[3]:    location:  1.25  1.75 -1.75
    idx:     (6,7,0)
-
 With weight: 4
 pt[4]:    location:  2.25  1.75 -1.75
    idx:     (8,7,0)
-
 With weight: 4
 pt[5]:    location:  1.75  2.25 -1.75
    idx:     (7,8,0)
-
 With weight: 4
 pt[6]:    location:  1.75  1.75 -1.25
    idx:     (7,7,1)
-
 With weight: 4
 
 On point:    location: -1.75 -1.75 -1.25
    idx:     (0,0,1)
-
 pt[0]:    location: -1.75 -1.75 -1.25
    idx:     (0,0,1)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -1.75
    idx:     (0,0,0)
-
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -1.25
    idx:     (0,-1,1)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -1.25
    idx:     (-1,0,1)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -1.25
    idx:     (1,0,1)
-
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -1.25
    idx:     (0,1,1)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.75 -0.75
    idx:     (0,0,2)
-
 With weight: 4
 
 On point:    location: -1.25 -1.75 -1.25
    idx:     (1,0,1)
-
 pt[0]:    location: -1.25 -1.75 -1.25
    idx:     (1,0,1)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -1.75
    idx:     (1,0,0)
-
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -1.25
    idx:     (1,-1,1)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -1.25
    idx:     (0,0,1)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -1.25
    idx:     (2,0,1)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -1.25
    idx:     (1,1,1)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.75 -0.75
    idx:     (1,0,2)
-
 With weight: 4
 
 On point:    location: -0.75 -1.75 -1.25
    idx:     (2,0,1)
-
 pt[0]:    location: -0.75 -1.75 -1.25
    idx:     (2,0,1)
-
 With weight: -24
 pt[1]:    location: -0.75 -1.75 -1.75
    idx:     (2,0,0)
-
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -1.25
    idx:     (2,-1,1)
-
 With weight: 4
 pt[3]:    location: -1.25 -1.75 -1.25
    idx:     (1,0,1)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -1.25
    idx:     (3,0,1)
-
 With weight: 4
 pt[5]:    location: -0.75 -1.25 -1.25
    idx:     (2,1,1)
-
 With weight: 4
 pt[6]:    location: -0.75 -1.75 -0.75
    idx:     (2,0,2)
-
 With weight: 4
 
 On point:    location: -0.25 -1.75 -1.25
    idx:     (3,0,1)
-
 pt[0]:    location: -0.25 -1.75 -1.25
    idx:     (3,0,1)
-
 With weight: -24
 pt[1]:    location: -0.25 -1.75 -1.75
    idx:     (3,0,0)
-
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -1.25
    idx:     (3,-1,1)
-
 With weight: 4
 pt[3]:    location: -0.75 -1.75 -1.25
    idx:     (2,0,1)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -1.25
    idx:     (4,0,1)
-
 With weight: 4
 pt[5]:    location: -0.25 -1.25 -1.25
    idx:     (3,1,1)
-
 With weight: 4
 pt[6]:    location: -0.25 -1.75 -0.75
    idx:     (3,0,2)
-
 With weight: 4
 
 On point:    location:  0.25 -1.75 -1.25
    idx:     (4,0,1)
-
 pt[0]:    location:  0.25 -1.75 -1.25
    idx:     (4,0,1)
-
 With weight: -24
 pt[1]:    location:  0.25 -1.75 -1.75
    idx:     (4,0,0)
-
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -1.25
    idx:     (4,-1,1)
-
 With weight: 4
 pt[3]:    location: -0.25 -1.75 -1.25
    idx:     (3,0,1)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -1.25
    idx:     (5,0,1)
-
 With weight: 4
 pt[5]:    location:  0.25 -1.25 -1.25
    idx:     (4,1,1)
-
 With weight: 4
 pt[6]:    location:  0.25 -1.75 -0.75
    idx:     (4,0,2)
-
 With weight: 4
 
 On point:    location:  0.75 -1.75 -1.25
    idx:     (5,0,1)
-
 pt[0]:    location:  0.75 -1.75 -1.25
    idx:     (5,0,1)
-
 With weight: -24
 pt[1]:    location:  0.75 -1.75 -1.75
    idx:     (5,0,0)
-
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -1.25
    idx:     (5,-1,1)
-
 With weight: 4
 pt[3]:    location:  0.25 -1.75 -1.25
    idx:     (4,0,1)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -1.25
    idx:     (6,0,1)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.25
    idx:     (5,1,1)
-
 With weight: 4
 pt[6]:    location:  0.75 -1.75 -0.75
    idx:     (5,0,2)
-
 With weight: 4
 
 On point:    location:  1.25 -1.75 -1.25
    idx:     (6,0,1)
-
 pt[0]:    location:  1.25 -1.75 -1.25
    idx:     (6,0,1)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -1.75
    idx:     (6,0,0)
-
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -1.25
    idx:     (6,-1,1)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -1.25
    idx:     (5,0,1)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -1.25
    idx:     (7,0,1)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -1.25
    idx:     (6,1,1)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.75 -0.75
    idx:     (6,0,2)
-
 With weight: 4
 
 On point:    location:  1.75 -1.75 -1.25
    idx:     (7,0,1)
-
 pt[0]:    location:  1.75 -1.75 -1.25
    idx:     (7,0,1)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -1.75
    idx:     (7,0,0)
-
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -1.25
    idx:     (7,-1,1)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -1.25
    idx:     (6,0,1)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -1.25
    idx:     (8,0,1)
-
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -1.25
    idx:     (7,1,1)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.75 -0.75
    idx:     (7,0,2)
-
 With weight: 4
 
 On point:    location: -1.75 -1.25 -1.25
    idx:     (0,1,1)
-
 pt[0]:    location: -1.75 -1.25 -1.25
    idx:     (0,1,1)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -1.75
    idx:     (0,1,0)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -1.25
    idx:     (0,0,1)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -1.25
    idx:     (-1,1,1)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -1.25
    idx:     (1,1,1)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -1.25
    idx:     (0,2,1)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -0.75
    idx:     (0,1,2)
-
 With weight: 4
 
 On point:    location: -1.25 -1.25 -1.25
    idx:     (1,1,1)
-
 pt[0]:    location: -1.25 -1.25 -1.25
    idx:     (1,1,1)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.25 -1.75
    idx:     (1,1,0)
-
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -1.25
    idx:     (1,0,1)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.25 -1.25
    idx:     (0,1,1)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.25 -1.25
    idx:     (2,1,1)
-
 With weight: 4
 pt[5]:    location: -1.25 -0.75 -1.25
    idx:     (1,2,1)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.25 -0.75
    idx:     (1,1,2)
-
 With weight: 4
 
 On point:    location: -0.75 -1.25 -1.25
    idx:     (2,1,1)
-
 pt[0]:    location: -0.75 -1.25 -1.25
    idx:     (2,1,1)
-
 With weight: -13.9608
 pt[1]:    location: -0.75 -1.25 -1.75
    idx:     (2,1,0)
-
 With weight: 0.784314
 pt[2]:    location: -0.75 -1.75 -1.25
    idx:     (2,0,1)
-
 With weight: 3.29412
 pt[3]:    location: -1.25 -1.25 -1.25
    idx:     (1,1,1)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.25 -1.25
    idx:     (3,1,1)
-
 With weight: 4
 pt[5]:    location: -0.25 -1.25 -1.75
    idx:     (3,1,0)
-
 With weight: -1.78054e-15
 pt[6]:    location: -0.75 -0.75 -1.75
    idx:     (2,2,0)
-
 With weight: 1.88235
 
 On point:    location: -0.25 -1.25 -1.25
    idx:     (3,1,1)
-
 pt[0]:    location: -0.25 -1.25 -1.25
    idx:     (3,1,1)
-
 With weight: -13.9608
 pt[1]:    location: -0.25 -1.25 -1.75
    idx:     (3,1,0)
-
 With weight: 0.784314
 pt[2]:    location: -0.25 -1.75 -1.25
    idx:     (3,0,1)
-
 With weight: 3.29412
 pt[3]:    location: -0.75 -1.25 -1.25
    idx:     (2,1,1)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.25 -1.25
    idx:     (4,1,1)
-
 With weight: 4
 pt[5]:    location: -0.75 -1.25 -1.75
    idx:     (2,1,0)
-
 With weight: -8.73475e-16
 pt[6]:    location: -0.25 -0.75 -1.75
    idx:     (3,2,0)
-
 With weight: 1.88235
 
 On point:    location:  0.25 -1.25 -1.25
    idx:     (4,1,1)
-
 pt[0]:    location:  0.25 -1.25 -1.25
    idx:     (4,1,1)
-
 With weight: -13.3333
 pt[1]:    location:  0.25 -1.25 -1.75
    idx:     (4,1,0)
-
 With weight: 2.66667
 pt[2]:    location:  0.25 -1.75 -1.25
    idx:     (4,0,1)
-
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.25 -1.25
    idx:     (3,1,1)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.25 -1.25
    idx:     (5,1,1)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.75
    idx:     (5,1,0)
-
 With weight: 5.16489e-16
 pt[6]:    location:  0.75 -1.75 -1.25
    idx:     (5,0,1)
-
 With weight: 5.20671e-16
 
 On point:    location:  0.75 -1.25 -1.25
    idx:     (5,1,1)
-
 pt[0]:    location:  0.75 -1.25 -1.25
    idx:     (5,1,1)
-
 With weight: -13.3333
 pt[1]:    location:  0.75 -1.25 -1.75
    idx:     (5,1,0)
-
 With weight: 2.66667
 pt[2]:    location:  0.75 -1.75 -1.25
    idx:     (5,0,1)
-
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.25 -1.25
    idx:     (4,1,1)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.25 -1.25
    idx:     (6,1,1)
-
 With weight: 4
 pt[5]:    location:  0.25 -1.25 -1.75
    idx:     (4,1,0)
-
 With weight: 5.38239e-16
 pt[6]:    location:  1.25 -1.25 -1.75
    idx:     (6,1,0)
-
 With weight: 1.1751e-15
 
 On point:    location:  1.25 -1.25 -1.25
    idx:     (6,1,1)
-
 pt[0]:    location:  1.25 -1.25 -1.25
    idx:     (6,1,1)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.25 -1.75
    idx:     (6,1,0)
-
 With weight: 4
 pt[2]:    location:  1.25 -1.75 -1.25
    idx:     (6,0,1)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.25 -1.25
    idx:     (5,1,1)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.25 -1.25
    idx:     (7,1,1)
-
 With weight: 4
 pt[5]:    location:  1.25 -0.75 -1.25
    idx:     (6,2,1)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.25 -0.75
    idx:     (6,1,2)
-
 With weight: 4
 
 On point:    location:  1.75 -1.25 -1.25
    idx:     (7,1,1)
-
 pt[0]:    location:  1.75 -1.25 -1.25
    idx:     (7,1,1)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -1.75
    idx:     (7,1,0)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -1.25
    idx:     (7,0,1)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -1.25
    idx:     (6,1,1)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -1.25
    idx:     (8,1,1)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -1.25
    idx:     (7,2,1)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -0.75
    idx:     (7,1,2)
-
 With weight: 4
 
 On point:    location: -1.75 -0.75 -1.25
    idx:     (0,2,1)
-
 pt[0]:    location: -1.75 -0.75 -1.25
    idx:     (0,2,1)
-
 With weight: -24
 pt[1]:    location: -1.75 -0.75 -1.75
    idx:     (0,2,0)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -1.25
    idx:     (0,1,1)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -1.25
    idx:     (-1,2,1)
-
 With weight: 4
 pt[4]:    location: -1.25 -0.75 -1.25
    idx:     (1,2,1)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.25 -1.25
    idx:     (0,3,1)
-
 With weight: 4
 pt[6]:    location: -1.75 -0.75 -0.75
    idx:     (0,2,2)
-
 With weight: 4
 
 On point:    location: -1.25 -0.75 -1.25
    idx:     (1,2,1)
-
 pt[0]:    location: -1.25 -0.75 -1.25
    idx:     (1,2,1)
-
 With weight: -13.3333
 pt[1]:    location: -1.25 -0.75 -1.75
    idx:     (1,2,0)
-
 With weight: 2.66667
 pt[2]:    location: -1.25 -1.25 -1.25
    idx:     (1,1,1)
-
 With weight: 4
 pt[3]:    location: -1.75 -0.75 -1.25
    idx:     (0,2,1)
-
 With weight: 2.66667
 pt[4]:    location: -1.25 -0.25 -1.25
    idx:     (1,3,1)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -1.75
    idx:     (1,1,0)
-
 With weight: -4.09907e-16
 pt[6]:    location: -1.75 -0.75 -1.75
    idx:     (0,2,0)
-
 With weight: 1.05205e-15
 
 On point:    location:  1.25 -0.75 -1.25
    idx:     (6,2,1)
-
 pt[0]:    location:  1.25 -0.75 -1.25
    idx:     (6,2,1)
-
 With weight: -13.9608
 pt[1]:    location:  1.25 -0.75 -1.75
    idx:     (6,2,0)
-
 With weight: 0.784314
 pt[2]:    location:  1.25 -1.25 -1.25
    idx:     (6,1,1)
-
 With weight: 4
 pt[3]:    location:  1.75 -0.75 -1.25
    idx:     (7,2,1)
-
 With weight: 3.29412
 pt[4]:    location:  1.25 -0.25 -1.25
    idx:     (6,3,1)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -1.75
    idx:     (6,1,0)
-
 With weight: 3.35952e-17
 pt[6]:    location:  0.75 -0.75 -1.75
    idx:     (5,2,0)
-
 With weight: 1.88235
 
 On point:    location:  1.75 -0.75 -1.25
    idx:     (7,2,1)
-
 pt[0]:    location:  1.75 -0.75 -1.25
    idx:     (7,2,1)
-
 With weight: -24
 pt[1]:    location:  1.75 -0.75 -1.75
    idx:     (7,2,0)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.25 -1.25
    idx:     (7,1,1)
-
 With weight: 4
 pt[3]:    location:  1.25 -0.75 -1.25
    idx:     (6,2,1)
-
 With weight: 4
 pt[4]:    location:  2.25 -0.75 -1.25
    idx:     (8,2,1)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.25 -1.25
    idx:     (7,3,1)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -0.75
    idx:     (7,2,2)
-
 With weight: 4
 
 On point:    location: -1.75 -0.25 -1.25
    idx:     (0,3,1)
-
 pt[0]:    location: -1.75 -0.25 -1.25
    idx:     (0,3,1)
-
 With weight: -24
 pt[1]:    location: -1.75 -0.25 -1.75
    idx:     (0,3,0)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -1.25
    idx:     (0,2,1)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -1.25
    idx:     (-1,3,1)
-
 With weight: 4
 pt[4]:    location: -1.25 -0.25 -1.25
    idx:     (1,3,1)
-
 With weight: 4
 pt[5]:    location: -1.75  0.25 -1.25
    idx:     (0,4,1)
-
 With weight: 4
 pt[6]:    location: -1.75 -0.25 -0.75
    idx:     (0,3,2)
-
 With weight: 4
 
 On point:    location: -1.25 -0.25 -1.25
    idx:     (1,3,1)
-
 pt[0]:    location: -1.25 -0.25 -1.25
    idx:     (1,3,1)
-
 With weight: -13.3333
 pt[1]:    location: -1.25 -0.25 -1.75
    idx:     (1,3,0)
-
 With weight: 2.66667
 pt[2]:    location: -1.25 -0.75 -1.25
    idx:     (1,2,1)
-
 With weight: 4
 pt[3]:    location: -1.75 -0.25 -1.25
    idx:     (0,3,1)
-
 With weight: 2.66667
 pt[4]:    location: -1.25  0.25 -1.25
    idx:     (1,4,1)
-
 With weight: 4
 pt[5]:    location: -1.25 -0.75 -1.75
    idx:     (1,2,0)
-
 With weight: -4.09907e-16
 pt[6]:    location: -1.75 -0.25 -1.75
    idx:     (0,3,0)
-
 With weight: 1.05205e-15
 
 On point:    location:  1.25 -0.25 -1.25
    idx:     (6,3,1)
-
 pt[0]:    location:  1.25 -0.25 -1.25
    idx:     (6,3,1)
-
 With weight: -13.9608
 pt[1]:    location:  1.25 -0.25 -1.75
    idx:     (6,3,0)
-
 With weight: 0.784314
 pt[2]:    location:  1.25 -0.75 -1.25
    idx:     (6,2,1)
-
 With weight: 4
 pt[3]:    location:  1.75 -0.25 -1.25
    idx:     (7,3,1)
-
 With weight: 3.29412
 pt[4]:    location:  1.25  0.25 -1.25
    idx:     (6,4,1)
-
 With weight: 4
 pt[5]:    location:  1.25 -0.75 -1.75
    idx:     (6,2,0)
-
 With weight: 3.35952e-17
 pt[6]:    location:  0.75 -0.25 -1.75
    idx:     (5,3,0)
-
 With weight: 1.88235
 
 On point:    location:  1.75 -0.25 -1.25
    idx:     (7,3,1)
-
 pt[0]:    location:  1.75 -0.25 -1.25
    idx:     (7,3,1)
-
 With weight: -24
 pt[1]:    location:  1.75 -0.25 -1.75
    idx:     (7,3,0)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -1.25
    idx:     (7,2,1)
-
 With weight: 4
 pt[3]:    location:  1.25 -0.25 -1.25
    idx:     (6,3,1)
-
 With weight: 4
 pt[4]:    location:  2.25 -0.25 -1.25
    idx:     (8,3,1)
-
 With weight: 4
 pt[5]:    location:  1.75  0.25 -1.25
    idx:     (7,4,1)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.25 -0.75
    idx:     (7,3,2)
-
 With weight: 4
 
 On point:    location: -1.75  0.25 -1.25
    idx:     (0,4,1)
-
 pt[0]:    location: -1.75  0.25 -1.25
    idx:     (0,4,1)
-
 With weight: -24
 pt[1]:    location: -1.75  0.25 -1.75
    idx:     (0,4,0)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -1.25
    idx:     (0,3,1)
-
 With weight: 4
 pt[3]:    location: -2.25  0.25 -1.25
    idx:     (-1,4,1)
-
 With weight: 4
 pt[4]:    location: -1.25  0.25 -1.25
    idx:     (1,4,1)
-
 With weight: 4
 pt[5]:    location: -1.75  0.75 -1.25
    idx:     (0,5,1)
-
 With weight: 4
 pt[6]:    location: -1.75  0.25 -0.75
    idx:     (0,4,2)
-
 With weight: 4
 
 On point:    location: -1.25  0.25 -1.25
    idx:     (1,4,1)
-
 pt[0]:    location: -1.25  0.25 -1.25
    idx:     (1,4,1)
-
 With weight: -13.3333
 pt[1]:    location: -1.25  0.25 -1.75
    idx:     (1,4,0)
-
 With weight: 2.66667
 pt[2]:    location: -1.25 -0.25 -1.25
    idx:     (1,3,1)
-
 With weight: 4
 pt[3]:    location: -1.75  0.25 -1.25
    idx:     (0,4,1)
-
 With weight: 2.66667
 pt[4]:    location: -1.25  0.75 -1.25
    idx:     (1,5,1)
-
 With weight: 4
 pt[5]:    location: -1.75  0.25 -1.75
    idx:     (0,4,0)
-
 With weight: -1.50293e-16
 pt[6]:    location: -1.25  0.75 -1.75
    idx:     (1,5,0)
-
 With weight: -7.34622e-16
 
 On point:    location:  1.25  0.25 -1.25
    idx:     (6,4,1)
-
 pt[0]:    location:  1.25  0.25 -1.25
    idx:     (6,4,1)
-
 With weight: -13.3333
 pt[1]:    location:  1.25  0.25 -1.75
    idx:     (6,4,0)
-
 With weight: -1.30741e-15
 pt[2]:    location:  1.25 -0.25 -1.25
    idx:     (6,3,1)
-
 With weight: 4
 pt[3]:    location:  1.75  0.25 -1.25
    idx:     (7,4,1)
-
 With weight: 2.66667
 pt[4]:    location:  1.25  0.75 -1.25
    idx:     (6,5,1)
-
 With weight: 4
 pt[5]:    location:  0.75  0.25 -1.75
    idx:     (5,4,0)
-
 With weight: 2
 pt[6]:    location:  1.75  0.25 -1.75
    idx:     (7,4,0)
-
 With weight: 0.666667
 
 On point:    location:  1.75  0.25 -1.25
    idx:     (7,4,1)
-
 pt[0]:    location:  1.75  0.25 -1.25
    idx:     (7,4,1)
-
 With weight: -24
 pt[1]:    location:  1.75  0.25 -1.75
    idx:     (7,4,0)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.25 -1.25
    idx:     (7,3,1)
-
 With weight: 4
 pt[3]:    location:  1.25  0.25 -1.25
    idx:     (6,4,1)
-
 With weight: 4
 pt[4]:    location:  2.25  0.25 -1.25
    idx:     (8,4,1)
-
 With weight: 4
 pt[5]:    location:  1.75  0.75 -1.25
    idx:     (7,5,1)
-
 With weight: 4
 pt[6]:    location:  1.75  0.25 -0.75
    idx:     (7,4,2)
-
 With weight: 4
 
 On point:    location: -1.75  0.75 -1.25
    idx:     (0,5,1)
-
 pt[0]:    location: -1.75  0.75 -1.25
    idx:     (0,5,1)
-
 With weight: -24
 pt[1]:    location: -1.75  0.75 -1.75
    idx:     (0,5,0)
-
 With weight: 4
 pt[2]:    location: -1.75  0.25 -1.25
    idx:     (0,4,1)
-
 With weight: 4
 pt[3]:    location: -2.25  0.75 -1.25
    idx:     (-1,5,1)
-
 With weight: 4
 pt[4]:    location: -1.25  0.75 -1.25
    idx:     (1,5,1)
-
 With weight: 4
 pt[5]:    location: -1.75  1.25 -1.25
    idx:     (0,6,1)
-
 With weight: 4
 pt[6]:    location: -1.75  0.75 -0.75
    idx:     (0,5,2)
-
 With weight: 4
 
 On point:    location: -1.25  0.75 -1.25
    idx:     (1,5,1)
-
 pt[0]:    location: -1.25  0.75 -1.25
    idx:     (1,5,1)
-
 With weight: -13.3333
 pt[1]:    location: -1.25  0.75 -1.75
    idx:     (1,5,0)
-
 With weight: 2.66667
 pt[2]:    location: -1.25  0.25 -1.25
    idx:     (1,4,1)
-
 With weight: 4
 pt[3]:    location: -1.75  0.75 -1.25
    idx:     (0,5,1)
-
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25 -1.25
    idx:     (1,6,1)
-
 With weight: 4
 pt[5]:    location: -1.75  0.75 -1.75
    idx:     (0,5,0)
-
 With weight: 1.50293e-16
 pt[6]:    location: -1.75  0.25 -1.25
    idx:     (0,4,1)
-
 With weight: -1.24779e-15
 
 On point:    location:  1.25  0.75 -1.25
    idx:     (6,5,1)
-
 pt[0]:    location:  1.25  0.75 -1.25
    idx:     (6,5,1)
-
 With weight: -13.9608
 pt[1]:    location:  1.25  0.75 -1.75
    idx:     (6,5,0)
-
 With weight: 0.784314
 pt[2]:    location:  1.25  0.25 -1.25
    idx:     (6,4,1)
-
 With weight: 4
 pt[3]:    location:  1.75  0.75 -1.25
    idx:     (7,5,1)
-
 With weight: 3.29412
 pt[4]:    location:  1.25  1.25 -1.25
    idx:     (6,6,1)
-
 With weight: 4
 pt[5]:    location:  1.25  0.25 -1.75
    idx:     (6,4,0)
-
 With weight: 3.35952e-17
 pt[6]:    location:  0.75  0.75 -1.75
    idx:     (5,5,0)
-
 With weight: 1.88235
 
 On point:    location:  1.75  0.75 -1.25
    idx:     (7,5,1)
-
 pt[0]:    location:  1.75  0.75 -1.25
    idx:     (7,5,1)
-
 With weight: -24
 pt[1]:    location:  1.75  0.75 -1.75
    idx:     (7,5,0)
-
 With weight: 4
 pt[2]:    location:  1.75  0.25 -1.25
    idx:     (7,4,1)
-
 With weight: 4
 pt[3]:    location:  1.25  0.75 -1.25
    idx:     (6,5,1)
-
 With weight: 4
 pt[4]:    location:  2.25  0.75 -1.25
    idx:     (8,5,1)
-
 With weight: 4
 pt[5]:    location:  1.75  1.25 -1.25
    idx:     (7,6,1)
-
 With weight: 4
 pt[6]:    location:  1.75  0.75 -0.75
    idx:     (7,5,2)
-
 With weight: 4
 
 On point:    location: -1.75  1.25 -1.25
    idx:     (0,6,1)
-
 pt[0]:    location: -1.75  1.25 -1.25
    idx:     (0,6,1)
-
 With weight: -24
 pt[1]:    location: -1.75  1.25 -1.75
    idx:     (0,6,0)
-
 With weight: 4
 pt[2]:    location: -1.75  0.75 -1.25
    idx:     (0,5,1)
-
 With weight: 4
 pt[3]:    location: -2.25  1.25 -1.25
    idx:     (-1,6,1)
-
 With weight: 4
 pt[4]:    location: -1.25  1.25 -1.25
    idx:     (1,6,1)
-
 With weight: 4
 pt[5]:    location: -1.75  1.75 -1.25
    idx:     (0,7,1)
-
 With weight: 4
 pt[6]:    location: -1.75  1.25 -0.75
    idx:     (0,6,2)
-
 With weight: 4
 
 On point:    location: -1.25  1.25 -1.25
    idx:     (1,6,1)
-
 pt[0]:    location: -1.25  1.25 -1.25
    idx:     (1,6,1)
-
 With weight: -24
 pt[1]:    location: -1.25  1.25 -1.75
    idx:     (1,6,0)
-
 With weight: 4
 pt[2]:    location: -1.25  0.75 -1.25
    idx:     (1,5,1)
-
 With weight: 4
 pt[3]:    location: -1.75  1.25 -1.25
    idx:     (0,6,1)
-
 With weight: 4
 pt[4]:    location: -0.75  1.25 -1.25
    idx:     (2,6,1)
-
 With weight: 4
 pt[5]:    location: -1.25  1.75 -1.25
    idx:     (1,7,1)
-
 With weight: 4
 pt[6]:    location: -1.25  1.25 -0.75
    idx:     (1,6,2)
-
 With weight: 4
 
 On point:    location: -0.75  1.25 -1.25
    idx:     (2,6,1)
-
 pt[0]:    location: -0.75  1.25 -1.25
    idx:     (2,6,1)
-
 With weight: -13.9608
 pt[1]:    location: -0.75  1.25 -1.75
    idx:     (2,6,0)
-
 With weight: 0.784314
 pt[2]:    location: -1.25  1.25 -1.25
    idx:     (1,6,1)
-
 With weight: 4
 pt[3]:    location: -0.25  1.25 -1.25
    idx:     (3,6,1)
-
 With weight: 4
 pt[4]:    location: -0.75  1.75 -1.25
    idx:     (2,7,1)
-
 With weight: 3.29412
 pt[5]:    location: -0.75  0.75 -1.75
    idx:     (2,5,0)
-
 With weight: 1.88235
 pt[6]:    location: -0.25  1.25 -1.75
    idx:     (3,6,0)
-
 With weight: 2.01571e-16
 
 On point:    location: -0.25  1.25 -1.25
    idx:     (3,6,1)
-
 pt[0]:    location: -0.25  1.25 -1.25
    idx:     (3,6,1)
-
 With weight: -13.9608
 pt[1]:    location: -0.25  1.25 -1.75
    idx:     (3,6,0)
-
 With weight: 0.784314
 pt[2]:    location: -0.75  1.25 -1.25
    idx:     (2,6,1)
-
 With weight: 4
 pt[3]:    location:  0.25  1.25 -1.25
    idx:     (4,6,1)
-
 With weight: 4
 pt[4]:    location: -0.25  1.75 -1.25
    idx:     (3,7,1)
-
 With weight: 3.29412
 pt[5]:    location: -0.25  0.75 -1.75
    idx:     (3,5,0)
-
 With weight: 1.88235
 pt[6]:    location: -0.75  1.25 -1.75
    idx:     (2,6,0)
-
 With weight: -1.94852e-15
 
 On point:    location:  0.25  1.25 -1.25
    idx:     (4,6,1)
-
 pt[0]:    location:  0.25  1.25 -1.25
    idx:     (4,6,1)
-
 With weight: -13.9608
 pt[1]:    location:  0.25  1.25 -1.75
    idx:     (4,6,0)
-
 With weight: 0.784314
 pt[2]:    location: -0.25  1.25 -1.25
    idx:     (3,6,1)
-
 With weight: 4
 pt[3]:    location:  0.75  1.25 -1.25
    idx:     (5,6,1)
-
 With weight: 4
 pt[4]:    location:  0.25  1.75 -1.25
    idx:     (4,7,1)
-
 With weight: 3.29412
 pt[5]:    location:  0.25  0.75 -1.75
    idx:     (4,5,0)
-
 With weight: 1.88235
 pt[6]:    location:  0.75  1.25 -1.75
    idx:     (5,6,0)
-
 With weight: 2.01571e-16
 
 On point:    location:  0.75  1.25 -1.25
    idx:     (5,6,1)
-
 pt[0]:    location:  0.75  1.25 -1.25
    idx:     (5,6,1)
-
 With weight: -13.9608
 pt[1]:    location:  0.75  1.25 -1.75
    idx:     (5,6,0)
-
 With weight: 0.784314
 pt[2]:    location:  0.25  1.25 -1.25
    idx:     (4,6,1)
-
 With weight: 4
 pt[3]:    location:  1.25  1.25 -1.25
    idx:     (6,6,1)
-
 With weight: 4
 pt[4]:    location:  0.75  1.75 -1.25
    idx:     (5,7,1)
-
 With weight: 3.29412
 pt[5]:    location:  0.75  0.75 -1.75
    idx:     (5,5,0)
-
 With weight: 1.88235
 pt[6]:    location:  0.25  1.25 -1.75
    idx:     (4,6,0)
-
 With weight: -1.94852e-15
 
 On point:    location:  1.25  1.25 -1.25
    idx:     (6,6,1)
-
 pt[0]:    location:  1.25  1.25 -1.25
    idx:     (6,6,1)
-
 With weight: -24
 pt[1]:    location:  1.25  1.25 -1.75
    idx:     (6,6,0)
-
 With weight: 4
 pt[2]:    location:  1.25  0.75 -1.25
    idx:     (6,5,1)
-
 With weight: 4
 pt[3]:    location:  0.75  1.25 -1.25
    idx:     (5,6,1)
-
 With weight: 4
 pt[4]:    location:  1.75  1.25 -1.25
    idx:     (7,6,1)
-
 With weight: 4
 pt[5]:    location:  1.25  1.75 -1.25
    idx:     (6,7,1)
-
 With weight: 4
 pt[6]:    location:  1.25  1.25 -0.75
    idx:     (6,6,2)
-
 With weight: 4
 
 On point:    location:  1.75  1.25 -1.25
    idx:     (7,6,1)
-
 pt[0]:    location:  1.75  1.25 -1.25
    idx:     (7,6,1)
-
 With weight: -24
 pt[1]:    location:  1.75  1.25 -1.75
    idx:     (7,6,0)
-
 With weight: 4
 pt[2]:    location:  1.75  0.75 -1.25
    idx:     (7,5,1)
-
 With weight: 4
 pt[3]:    location:  1.25  1.25 -1.25
    idx:     (6,6,1)
-
 With weight: 4
 pt[4]:    location:  2.25  1.25 -1.25
    idx:     (8,6,1)
-
 With weight: 4
 pt[5]:    location:  1.75  1.75 -1.25
    idx:     (7,7,1)
-
 With weight: 4
 pt[6]:    location:  1.75  1.25 -0.75
    idx:     (7,6,2)
-
 With weight: 4
 
 On point:    location: -1.75  1.75 -1.25
    idx:     (0,7,1)
-
 pt[0]:    location: -1.75  1.75 -1.25
    idx:     (0,7,1)
-
 With weight: -24
 pt[1]:    location: -1.75  1.75 -1.75
    idx:     (0,7,0)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25 -1.25
    idx:     (0,6,1)
-
 With weight: 4
 pt[3]:    location: -2.25  1.75 -1.25
    idx:     (-1,7,1)
-
 With weight: 4
 pt[4]:    location: -1.25  1.75 -1.25
    idx:     (1,7,1)
-
 With weight: 4
 pt[5]:    location: -1.75  2.25 -1.25
    idx:     (0,8,1)
-
 With weight: 4
 pt[6]:    location: -1.75  1.75 -0.75
    idx:     (0,7,2)
-
 With weight: 4
 
 On point:    location: -1.25  1.75 -1.25
    idx:     (1,7,1)
-
 pt[0]:    location: -1.25  1.75 -1.25
    idx:     (1,7,1)
-
 With weight: -24
 pt[1]:    location: -1.25  1.75 -1.75
    idx:     (1,7,0)
-
 With weight: 4
 pt[2]:    location: -1.25  1.25 -1.25
    idx:     (1,6,1)
-
 With weight: 4
 pt[3]:    location: -1.75  1.75 -1.25
    idx:     (0,7,1)
-
 With weight: 4
 pt[4]:    location: -0.75  1.75 -1.25
    idx:     (2,7,1)
-
 With weight: 4
 pt[5]:    location: -1.25  2.25 -1.25
    idx:     (1,8,1)
-
 With weight: 4
 pt[6]:    location: -1.25  1.75 -0.75
    idx:     (1,7,2)
-
 With weight: 4
 
 On point:    location: -0.75  1.75 -1.25
    idx:     (2,7,1)
-
 pt[0]:    location: -0.75  1.75 -1.25
    idx:     (2,7,1)
-
 With weight: -24
 pt[1]:    location: -0.75  1.75 -1.75
    idx:     (2,7,0)
-
 With weight: 4
 pt[2]:    location: -0.75  1.25 -1.25
    idx:     (2,6,1)
-
 With weight: 4
 pt[3]:    location: -1.25  1.75 -1.25
    idx:     (1,7,1)
-
 With weight: 4
 pt[4]:    location: -0.25  1.75 -1.25
    idx:     (3,7,1)
-
 With weight: 4
 pt[5]:    location: -0.75  2.25 -1.25
    idx:     (2,8,1)
-
 With weight: 4
 pt[6]:    location: -0.75  1.75 -0.75
    idx:     (2,7,2)
-
 With weight: 4
 
 On point:    location: -0.25  1.75 -1.25
    idx:     (3,7,1)
-
 pt[0]:    location: -0.25  1.75 -1.25
    idx:     (3,7,1)
-
 With weight: -24
 pt[1]:    location: -0.25  1.75 -1.75
    idx:     (3,7,0)
-
 With weight: 4
 pt[2]:    location: -0.25  1.25 -1.25
    idx:     (3,6,1)
-
 With weight: 4
 pt[3]:    location: -0.75  1.75 -1.25
    idx:     (2,7,1)
-
 With weight: 4
 pt[4]:    location:  0.25  1.75 -1.25
    idx:     (4,7,1)
-
 With weight: 4
 pt[5]:    location: -0.25  2.25 -1.25
    idx:     (3,8,1)
-
 With weight: 4
 pt[6]:    location: -0.25  1.75 -0.75
    idx:     (3,7,2)
-
 With weight: 4
 
 On point:    location:  0.25  1.75 -1.25
    idx:     (4,7,1)
-
 pt[0]:    location:  0.25  1.75 -1.25
    idx:     (4,7,1)
-
 With weight: -24
 pt[1]:    location:  0.25  1.75 -1.75
    idx:     (4,7,0)
-
 With weight: 4
 pt[2]:    location:  0.25  1.25 -1.25
    idx:     (4,6,1)
-
 With weight: 4
 pt[3]:    location: -0.25  1.75 -1.25
    idx:     (3,7,1)
-
 With weight: 4
 pt[4]:    location:  0.75  1.75 -1.25
    idx:     (5,7,1)
-
 With weight: 4
 pt[5]:    location:  0.25  2.25 -1.25
    idx:     (4,8,1)
-
 With weight: 4
 pt[6]:    location:  0.25  1.75 -0.75
    idx:     (4,7,2)
-
 With weight: 4
 
 On point:    location:  0.75  1.75 -1.25
    idx:     (5,7,1)
-
 pt[0]:    location:  0.75  1.75 -1.25
    idx:     (5,7,1)
-
 With weight: -24
 pt[1]:    location:  0.75  1.75 -1.75
    idx:     (5,7,0)
-
 With weight: 4
 pt[2]:    location:  0.75  1.25 -1.25
    idx:     (5,6,1)
-
 With weight: 4
 pt[3]:    location:  0.25  1.75 -1.25
    idx:     (4,7,1)
-
 With weight: 4
 pt[4]:    location:  1.25  1.75 -1.25
    idx:     (6,7,1)
-
 With weight: 4
 pt[5]:    location:  0.75  2.25 -1.25
    idx:     (5,8,1)
-
 With weight: 4
 pt[6]:    location:  0.75  1.75 -0.75
    idx:     (5,7,2)
-
 With weight: 4
 
 On point:    location:  1.25  1.75 -1.25
    idx:     (6,7,1)
-
 pt[0]:    location:  1.25  1.75 -1.25
    idx:     (6,7,1)
-
 With weight: -24
 pt[1]:    location:  1.25  1.75 -1.75
    idx:     (6,7,0)
-
 With weight: 4
 pt[2]:    location:  1.25  1.25 -1.25
    idx:     (6,6,1)
-
 With weight: 4
 pt[3]:    location:  0.75  1.75 -1.25
    idx:     (5,7,1)
-
 With weight: 4
 pt[4]:    location:  1.75  1.75 -1.25
    idx:     (7,7,1)
-
 With weight: 4
 pt[5]:    location:  1.25  2.25 -1.25
    idx:     (6,8,1)
-
 With weight: 4
 pt[6]:    location:  1.25  1.75 -0.75
    idx:     (6,7,2)
-
 With weight: 4
 
 On point:    location:  1.75  1.75 -1.25
    idx:     (7,7,1)
-
 pt[0]:    location:  1.75  1.75 -1.25
    idx:     (7,7,1)
-
 With weight: -24
 pt[1]:    location:  1.75  1.75 -1.75
    idx:     (7,7,0)
-
 With weight: 4
 pt[2]:    location:  1.75  1.25 -1.25
    idx:     (7,6,1)
-
 With weight: 4
 pt[3]:    location:  1.25  1.75 -1.25
    idx:     (6,7,1)
-
 With weight: 4
 pt[4]:    location:  2.25  1.75 -1.25
    idx:     (8,7,1)
-
 With weight: 4
 pt[5]:    location:  1.75  2.25 -1.25
    idx:     (7,8,1)
-
 With weight: 4
 pt[6]:    location:  1.75  1.75 -0.75
    idx:     (7,7,2)
-
 With weight: 4
 
 On point:    location: -1.75 -1.75 -0.75
    idx:     (0,0,2)
-
 pt[0]:    location: -1.75 -1.75 -0.75
    idx:     (0,0,2)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -1.25
    idx:     (0,0,1)
-
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -0.75
    idx:     (0,-1,2)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -0.75
    idx:     (-1,0,2)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -0.75
    idx:     (1,0,2)
-
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -0.75
    idx:     (0,1,2)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.75 -0.25
    idx:     (0,0,3)
-
 With weight: 4
 
 On point:    location: -1.25 -1.75 -0.75
    idx:     (1,0,2)
-
 pt[0]:    location: -1.25 -1.75 -0.75
    idx:     (1,0,2)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -1.25
    idx:     (1,0,1)
-
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -0.75
    idx:     (1,-1,2)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -0.75
    idx:     (0,0,2)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -0.75
    idx:     (2,0,2)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -0.75
    idx:     (1,1,2)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.75 -0.25
    idx:     (1,0,3)
-
 With weight: 4
 
 On point:    location: -0.75 -1.75 -0.75
    idx:     (2,0,2)
-
 pt[0]:    location: -0.75 -1.75 -0.75
    idx:     (2,0,2)
-
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75 -1.25
    idx:     (2,0,1)
-
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -0.75
    idx:     (2,-1,2)
-
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75 -0.75
    idx:     (1,0,2)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -0.75
    idx:     (3,0,2)
-
 With weight: 4
 pt[5]:    location: -0.75 -1.75 -0.25
    idx:     (2,0,3)
-
 With weight: 4
 pt[6]:    location: -0.75 -2.25 -1.25
    idx:     (2,-1,1)
-
 With weight: 1.05525e-15
 
 On point:    location: -0.25 -1.75 -0.75
    idx:     (3,0,2)
-
 pt[0]:    location: -0.25 -1.75 -0.75
    idx:     (3,0,2)
-
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75 -1.25
    idx:     (3,0,1)
-
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -0.75
    idx:     (3,-1,2)
-
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75 -0.75
    idx:     (2,0,2)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -0.75
    idx:     (4,0,2)
-
 With weight: 4
 pt[5]:    location: -0.25 -1.75 -0.25
    idx:     (3,0,3)
-
 With weight: 4
 pt[6]:    location: -0.25 -2.25 -1.25
    idx:     (3,-1,1)
-
 With weight: 1.05525e-15
 
 On point:    location:  0.25 -1.75 -0.75
    idx:     (4,0,2)
-
 pt[0]:    location:  0.25 -1.75 -0.75
    idx:     (4,0,2)
-
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75 -1.25
    idx:     (4,0,1)
-
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -0.75
    idx:     (4,-1,2)
-
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75 -0.75
    idx:     (3,0,2)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -0.75
    idx:     (5,0,2)
-
 With weight: 4
 pt[5]:    location:  0.25 -1.75 -0.25
    idx:     (4,0,3)
-
 With weight: 4
 pt[6]:    location:  0.25 -2.25 -1.25
    idx:     (4,-1,1)
-
 With weight: 1.05525e-15
 
 On point:    location:  0.75 -1.75 -0.75
    idx:     (5,0,2)
-
 pt[0]:    location:  0.75 -1.75 -0.75
    idx:     (5,0,2)
-
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75 -1.25
    idx:     (5,0,1)
-
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -0.75
    idx:     (5,-1,2)
-
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75 -0.75
    idx:     (4,0,2)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -0.75
    idx:     (6,0,2)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.75 -0.25
    idx:     (5,0,3)
-
 With weight: 4
 pt[6]:    location:  0.75 -2.25 -1.25
    idx:     (5,-1,1)
-
 With weight: 1.05525e-15
 
 On point:    location:  1.25 -1.75 -0.75
    idx:     (6,0,2)
-
 pt[0]:    location:  1.25 -1.75 -0.75
    idx:     (6,0,2)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -1.25
    idx:     (6,0,1)
-
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -0.75
    idx:     (6,-1,2)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -0.75
    idx:     (5,0,2)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -0.75
    idx:     (7,0,2)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -0.75
    idx:     (6,1,2)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.75 -0.25
    idx:     (6,0,3)
-
 With weight: 4
 
 On point:    location:  1.75 -1.75 -0.75
    idx:     (7,0,2)
-
 pt[0]:    location:  1.75 -1.75 -0.75
    idx:     (7,0,2)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -1.25
    idx:     (7,0,1)
-
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -0.75
    idx:     (7,-1,2)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -0.75
    idx:     (6,0,2)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -0.75
    idx:     (8,0,2)
-
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -0.75
    idx:     (7,1,2)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.75 -0.25
    idx:     (7,0,3)
-
 With weight: 4
 
 On point:    location: -1.75 -1.25 -0.75
    idx:     (0,1,2)
-
 pt[0]:    location: -1.75 -1.25 -0.75
    idx:     (0,1,2)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -1.25
    idx:     (0,1,1)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -0.75
    idx:     (0,0,2)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -0.75
    idx:     (-1,1,2)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -0.75
    idx:     (1,1,2)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -0.75
    idx:     (0,2,2)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -0.25
    idx:     (0,1,3)
-
 With weight: 4
 
 On point:    location: -1.25 -1.25 -0.75
    idx:     (1,1,2)
-
 pt[0]:    location: -1.25 -1.25 -0.75
    idx:     (1,1,2)
-
 With weight: -13.3333
 pt[1]:    location: -1.25 -1.25 -1.25
    idx:     (1,1,1)
-
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -0.75
    idx:     (1,0,2)
-
 With weight: 2.66667
 pt[3]:    location: -1.75 -1.25 -0.75
    idx:     (0,1,2)
-
 With weight: 2.66667
 pt[4]:    location: -1.25 -1.25 -0.25
    idx:     (1,1,3)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.75 -1.25
    idx:     (1,0,1)
-
 With weight: -9.11452e-17
 pt[6]:    location: -1.75 -1.25 -1.25
    idx:     (0,1,1)
-
 With weight: -7.36121e-16
 
 On point:    location:  1.25 -1.25 -0.75
    idx:     (6,1,2)
-
 pt[0]:    location:  1.25 -1.25 -0.75
    idx:     (6,1,2)
-
 With weight: -14.1867
 pt[1]:    location:  1.25 -1.25 -1.25
    idx:     (6,1,1)
-
 With weight: 2.72
 pt[2]:    location:  1.25 -1.75 -0.75
    idx:     (6,0,2)
-
 With weight: 1.38667
 pt[3]:    location:  1.75 -1.25 -0.75
    idx:     (7,1,2)
-
 With weight: 3.52
 pt[4]:    location:  1.25 -1.25 -0.25
    idx:     (6,1,3)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.25
    idx:     (5,1,1)
-
 With weight: 1.28
 pt[6]:    location:  0.75 -1.75 -0.75
    idx:     (5,0,2)
-
 With weight: 1.28
 
 On point:    location:  1.75 -1.25 -0.75
    idx:     (7,1,2)
-
 pt[0]:    location:  1.75 -1.25 -0.75
    idx:     (7,1,2)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -1.25
    idx:     (7,1,1)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -0.75
    idx:     (7,0,2)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -0.75
    idx:     (6,1,2)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -0.75
    idx:     (8,1,2)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -0.75
    idx:     (7,2,2)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -0.25
    idx:     (7,1,3)
-
 With weight: 4
 
 On point:    location: -1.75 -0.75 -0.75
    idx:     (0,2,2)
-
 pt[0]:    location: -1.75 -0.75 -0.75
    idx:     (0,2,2)
-
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75 -1.25
    idx:     (0,2,1)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -0.75
    idx:     (0,1,2)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -0.75
    idx:     (-1,2,2)
-
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25 -0.75
    idx:     (0,3,2)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -0.25
    idx:     (0,2,3)
-
 With weight: 4
 pt[6]:    location: -2.25 -0.75 -1.25
    idx:     (-1,2,1)
-
 With weight: 1.13062e-15
 
 On point:    location:  1.75 -0.75 -0.75
    idx:     (7,2,2)
-
 pt[0]:    location:  1.75 -0.75 -0.75
    idx:     (7,2,2)
-
 With weight: -19.2941
 pt[1]:    location:  1.75 -0.75 -1.25
    idx:     (7,2,1)
-
 With weight: 2.11765
 pt[2]:    location:  1.75 -1.25 -0.75
    idx:     (7,1,2)
-
 With weight: 4
 pt[3]:    location:  2.25 -0.75 -0.75
    idx:     (8,2,2)
-
 With weight: 3.29412
 pt[4]:    location:  1.75 -0.25 -0.75
    idx:     (7,3,2)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -0.25
    idx:     (7,2,3)
-
 With weight: 4
 pt[6]:    location:  1.25 -0.75 -1.25
    idx:     (6,2,1)
-
 With weight: 1.88235
 
 On point:    location: -1.75 -0.25 -0.75
    idx:     (0,3,2)
-
 pt[0]:    location: -1.75 -0.25 -0.75
    idx:     (0,3,2)
-
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25 -1.25
    idx:     (0,3,1)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -0.75
    idx:     (0,2,2)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -0.75
    idx:     (-1,3,2)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25 -0.75
    idx:     (0,4,2)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.25 -0.25
    idx:     (0,3,3)
-
 With weight: 4
 pt[6]:    location: -2.25 -0.25 -1.25
    idx:     (-1,3,1)
-
 With weight: 1.13062e-15
 
 On point:    location:  1.75 -0.25 -0.75
    idx:     (7,3,2)
-
 pt[0]:    location:  1.75 -0.25 -0.75
    idx:     (7,3,2)
-
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25 -1.25
    idx:     (7,3,1)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -0.75
    idx:     (7,2,2)
-
 With weight: 4
 pt[3]:    location:  2.25 -0.25 -0.75
    idx:     (8,3,2)
-
 With weight: 2.66667
 pt[4]:    location:  1.75  0.25 -0.75
    idx:     (7,4,2)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.25 -0.25
    idx:     (7,3,3)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -1.25
    idx:     (7,2,1)
-
 With weight: -7.27074e-16
 
 On point:    location: -1.75  0.25 -0.75
    idx:     (0,4,2)
-
 pt[0]:    location: -1.75  0.25 -0.75
    idx:     (0,4,2)
-
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25 -1.25
    idx:     (0,4,1)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -0.75
    idx:     (0,3,2)
-
 With weight: 4
 pt[3]:    location: -2.25  0.25 -0.75
    idx:     (-1,4,2)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75 -0.75
    idx:     (0,5,2)
-
 With weight: 4
 pt[5]:    location: -1.75  0.25 -0.25
    idx:     (0,4,3)
-
 With weight: 4
 pt[6]:    location: -2.25  0.25 -1.25
    idx:     (-1,4,1)
-
 With weight: 1.13062e-15
 
 On point:    location:  1.75  0.25 -0.75
    idx:     (7,4,2)
-
 pt[0]:    location:  1.75  0.25 -0.75
    idx:     (7,4,2)
-
 With weight: -19.2941
 pt[1]:    location:  1.75  0.25 -1.25
    idx:     (7,4,1)
-
 With weight: 2.11765
 pt[2]:    location:  1.75 -0.25 -0.75
    idx:     (7,3,2)
-
 With weight: 4
 pt[3]:    location:  2.25  0.25 -0.75
    idx:     (8,4,2)
-
 With weight: 3.29412
 pt[4]:    location:  1.75  0.75 -0.75
    idx:     (7,5,2)
-
 With weight: 4
 pt[5]:    location:  1.75  0.25 -0.25
    idx:     (7,4,3)
-
 With weight: 4
 pt[6]:    location:  1.25  0.25 -1.25
    idx:     (6,4,1)
-
 With weight: 1.88235
 
 On point:    location: -1.75  0.75 -0.75
    idx:     (0,5,2)
-
 pt[0]:    location: -1.75  0.75 -0.75
    idx:     (0,5,2)
-
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75 -1.25
    idx:     (0,5,1)
-
 With weight: 4
 pt[2]:    location: -1.75  0.25 -0.75
    idx:     (0,4,2)
-
 With weight: 4
 pt[3]:    location: -2.25  0.75 -0.75
    idx:     (-1,5,2)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25 -0.75
    idx:     (0,6,2)
-
 With weight: 4
 pt[5]:    location: -1.75  0.75 -0.25
    idx:     (0,5,3)
-
 With weight: 4
 pt[6]:    location: -2.25  0.75 -1.25
    idx:     (-1,5,1)
-
 With weight: 1.13062e-15
 
 On point:    location:  1.75  0.75 -0.75
    idx:     (7,5,2)
-
 pt[0]:    location:  1.75  0.75 -0.75
    idx:     (7,5,2)
-
 With weight: -18.6667
 pt[1]:    location:  1.75  0.75 -1.25
    idx:     (7,5,1)
-
 With weight: 4
 pt[2]:    location:  1.75  0.25 -0.75
    idx:     (7,4,2)
-
 With weight: 4
 pt[3]:    location:  2.25  0.75 -0.75
    idx:     (8,5,2)
-
 With weight: 2.66667
 pt[4]:    location:  1.75  1.25 -0.75
    idx:     (7,6,2)
-
 With weight: 4
 pt[5]:    location:  1.75  0.75 -0.25
    idx:     (7,5,3)
-
 With weight: 4
 pt[6]:    location:  1.75  0.25 -1.25
    idx:     (7,4,1)
-
 With weight: -7.27074e-16
 
 On point:    location: -1.75  1.25 -0.75
    idx:     (0,6,2)
-
 pt[0]:    location: -1.75  1.25 -0.75
    idx:     (0,6,2)
-
 With weight: -24
 pt[1]:    location: -1.75  1.25 -1.25
    idx:     (0,6,1)
-
 With weight: 4
 pt[2]:    location: -1.75  0.75 -0.75
    idx:     (0,5,2)
-
 With weight: 4
 pt[3]:    location: -2.25  1.25 -0.75
    idx:     (-1,6,2)
-
 With weight: 4
 pt[4]:    location: -1.25  1.25 -0.75
    idx:     (1,6,2)
-
 With weight: 4
 pt[5]:    location: -1.75  1.75 -0.75
    idx:     (0,7,2)
-
 With weight: 4
 pt[6]:    location: -1.75  1.25 -0.25
    idx:     (0,6,3)
-
 With weight: 4
 
 On point:    location: -1.25  1.25 -0.75
    idx:     (1,6,2)
-
 pt[0]:    location: -1.25  1.25 -0.75
    idx:     (1,6,2)
-
 With weight: -13.3333
 pt[1]:    location: -1.25  1.25 -1.25
    idx:     (1,6,1)
-
 With weight: 1.33333
 pt[2]:    location: -1.75  1.25 -0.75
    idx:     (0,6,2)
-
 With weight: 2.66667
 pt[3]:    location: -1.25  1.75 -0.75
    idx:     (1,7,2)
-
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25 -0.25
    idx:     (1,6,3)
-
 With weight: 4
 pt[5]:    location: -1.25  0.75 -1.25
    idx:     (1,5,1)
-
 With weight: 2
 pt[6]:    location: -1.25  1.75 -1.25
    idx:     (1,7,1)
-
 With weight: 0.666667
 
 On point:    location:  1.25  1.25 -0.75
    idx:     (6,6,2)
-
 pt[0]:    location:  1.25  1.25 -0.75
    idx:     (6,6,2)
-
 With weight: -14.5882
 pt[1]:    location:  1.25  1.25 -1.25
    idx:     (6,6,1)
-
 With weight: 0.235294
 pt[2]:    location:  1.75  1.25 -0.75
    idx:     (7,6,2)
-
 With weight: 3.29412
 pt[3]:    location:  1.25  1.75 -0.75
    idx:     (6,7,2)
-
 With weight: 3.29412
 pt[4]:    location:  1.25  1.25 -0.25
    idx:     (6,6,3)
-
 With weight: 4
 pt[5]:    location:  1.25  0.75 -1.25
    idx:     (6,5,1)
-
 With weight: 1.88235
 pt[6]:    location:  0.75  1.25 -1.25
    idx:     (5,6,1)
-
 With weight: 1.88235
 
 On point:    location:  1.75  1.25 -0.75
    idx:     (7,6,2)
-
 pt[0]:    location:  1.75  1.25 -0.75
    idx:     (7,6,2)
-
 With weight: -24
 pt[1]:    location:  1.75  1.25 -1.25
    idx:     (7,6,1)
-
 With weight: 4
 pt[2]:    location:  1.75  0.75 -0.75
    idx:     (7,5,2)
-
 With weight: 4
 pt[3]:    location:  1.25  1.25 -0.75
    idx:     (6,6,2)
-
 With weight: 4
 pt[4]:    location:  2.25  1.25 -0.75
    idx:     (8,6,2)
-
 With weight: 4
 pt[5]:    location:  1.75  1.75 -0.75
    idx:     (7,7,2)
-
 With weight: 4
 pt[6]:    location:  1.75  1.25 -0.25
    idx:     (7,6,3)
-
 With weight: 4
 
 On point:    location: -1.75  1.75 -0.75
    idx:     (0,7,2)
-
 pt[0]:    location: -1.75  1.75 -0.75
    idx:     (0,7,2)
-
 With weight: -24
 pt[1]:    location: -1.75  1.75 -1.25
    idx:     (0,7,1)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25 -0.75
    idx:     (0,6,2)
-
 With weight: 4
 pt[3]:    location: -2.25  1.75 -0.75
    idx:     (-1,7,2)
-
 With weight: 4
 pt[4]:    location: -1.25  1.75 -0.75
    idx:     (1,7,2)
-
 With weight: 4
 pt[5]:    location: -1.75  2.25 -0.75
    idx:     (0,8,2)
-
 With weight: 4
 pt[6]:    location: -1.75  1.75 -0.25
    idx:     (0,7,3)
-
 With weight: 4
 
 On point:    location: -1.25  1.75 -0.75
    idx:     (1,7,2)
-
 pt[0]:    location: -1.25  1.75 -0.75
    idx:     (1,7,2)
-
 With weight: -24
 pt[1]:    location: -1.25  1.75 -1.25
    idx:     (1,7,1)
-
 With weight: 4
 pt[2]:    location: -1.25  1.25 -0.75
    idx:     (1,6,2)
-
 With weight: 4
 pt[3]:    location: -1.75  1.75 -0.75
    idx:     (0,7,2)
-
 With weight: 4
 pt[4]:    location: -0.75  1.75 -0.75
    idx:     (2,7,2)
-
 With weight: 4
 pt[5]:    location: -1.25  2.25 -0.75
    idx:     (1,8,2)
-
 With weight: 4
 pt[6]:    location: -1.25  1.75 -0.25
    idx:     (1,7,3)
-
 With weight: 4
 
 On point:    location: -0.75  1.75 -0.75
    idx:     (2,7,2)
-
 pt[0]:    location: -0.75  1.75 -0.75
    idx:     (2,7,2)
-
 With weight: -18.6667
 pt[1]:    location: -0.75  1.75 -1.25
    idx:     (2,7,1)
-
 With weight: 4
 pt[2]:    location: -1.25  1.75 -0.75
    idx:     (1,7,2)
-
 With weight: 4
 pt[3]:    location: -0.25  1.75 -0.75
    idx:     (3,7,2)
-
 With weight: 4
 pt[4]:    location: -0.75  2.25 -0.75
    idx:     (2,8,2)
-
 With weight: 2.66667
 pt[5]:    location: -0.75  1.75 -0.25
    idx:     (2,7,3)
-
 With weight: 4
 pt[6]:    location: -0.25  1.75 -1.25
    idx:     (3,7,1)
-
 With weight: 1.09747e-15
 
 On point:    location: -0.25  1.75 -0.75
    idx:     (3,7,2)
-
 pt[0]:    location: -0.25  1.75 -0.75
    idx:     (3,7,2)
-
 With weight: -19.2941
 pt[1]:    location: -0.25  1.75 -1.25
    idx:     (3,7,1)
-
 With weight: 2.11765
 pt[2]:    location: -0.75  1.75 -0.75
    idx:     (2,7,2)
-
 With weight: 4
 pt[3]:    location:  0.25  1.75 -0.75
    idx:     (4,7,2)
-
 With weight: 4
 pt[4]:    location: -0.25  2.25 -0.75
    idx:     (3,8,2)
-
 With weight: 3.29412
 pt[5]:    location: -0.25  1.75 -0.25
    idx:     (3,7,3)
-
 With weight: 4
 pt[6]:    location: -0.25  1.25 -1.25
    idx:     (3,6,1)
-
 With weight: 1.88235
 
 On point:    location:  0.25  1.75 -0.75
    idx:     (4,7,2)
-
 pt[0]:    location:  0.25  1.75 -0.75
    idx:     (4,7,2)
-
 With weight: -19.2941
 pt[1]:    location:  0.25  1.75 -1.25
    idx:     (4,7,1)
-
 With weight: 2.11765
 pt[2]:    location: -0.25  1.75 -0.75
    idx:     (3,7,2)
-
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.75
    idx:     (5,7,2)
-
 With weight: 4
 pt[4]:    location:  0.25  2.25 -0.75
    idx:     (4,8,2)
-
 With weight: 3.29412
 pt[5]:    location:  0.25  1.75 -0.25
    idx:     (4,7,3)
-
 With weight: 4
 pt[6]:    location:  0.25  1.25 -1.25
    idx:     (4,6,1)
-
 With weight: 1.88235
 
 On point:    location:  0.75  1.75 -0.75
    idx:     (5,7,2)
-
 pt[0]:    location:  0.75  1.75 -0.75
    idx:     (5,7,2)
-
 With weight: -19.2941
 pt[1]:    location:  0.75  1.75 -1.25
    idx:     (5,7,1)
-
 With weight: 2.11765
 pt[2]:    location:  0.25  1.75 -0.75
    idx:     (4,7,2)
-
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.75
    idx:     (6,7,2)
-
 With weight: 4
 pt[4]:    location:  0.75  2.25 -0.75
    idx:     (5,8,2)
-
 With weight: 3.29412
 pt[5]:    location:  0.75  1.75 -0.25
    idx:     (5,7,3)
-
 With weight: 4
 pt[6]:    location:  0.75  1.25 -1.25
    idx:     (5,6,1)
-
 With weight: 1.88235
 
 On point:    location:  1.25  1.75 -0.75
    idx:     (6,7,2)
-
 pt[0]:    location:  1.25  1.75 -0.75
    idx:     (6,7,2)
-
 With weight: -24
 pt[1]:    location:  1.25  1.75 -1.25
    idx:     (6,7,1)
-
 With weight: 4
 pt[2]:    location:  1.25  1.25 -0.75
    idx:     (6,6,2)
-
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.75
    idx:     (5,7,2)
-
 With weight: 4
 pt[4]:    location:  1.75  1.75 -0.75
    idx:     (7,7,2)
-
 With weight: 4
 pt[5]:    location:  1.25  2.25 -0.75
    idx:     (6,8,2)
-
 With weight: 4
 pt[6]:    location:  1.25  1.75 -0.25
    idx:     (6,7,3)
-
 With weight: 4
 
 On point:    location:  1.75  1.75 -0.75
    idx:     (7,7,2)
-
 pt[0]:    location:  1.75  1.75 -0.75
    idx:     (7,7,2)
-
 With weight: -24
 pt[1]:    location:  1.75  1.75 -1.25
    idx:     (7,7,1)
-
 With weight: 4
 pt[2]:    location:  1.75  1.25 -0.75
    idx:     (7,6,2)
-
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.75
    idx:     (6,7,2)
-
 With weight: 4
 pt[4]:    location:  2.25  1.75 -0.75
    idx:     (8,7,2)
-
 With weight: 4
 pt[5]:    location:  1.75  2.25 -0.75
    idx:     (7,8,2)
-
 With weight: 4
 pt[6]:    location:  1.75  1.75 -0.25
    idx:     (7,7,3)
-
 With weight: 4
 
 On point:    location: -1.75 -1.75 -0.25
    idx:     (0,0,3)
-
 pt[0]:    location: -1.75 -1.75 -0.25
    idx:     (0,0,3)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -0.75
    idx:     (0,0,2)
-
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -0.25
    idx:     (0,-1,3)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -0.25
    idx:     (-1,0,3)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -0.25
    idx:     (1,0,3)
-
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -0.25
    idx:     (0,1,3)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.75  0.25
    idx:     (0,0,4)
-
 With weight: 4
 
 On point:    location: -1.25 -1.75 -0.25
    idx:     (1,0,3)
-
 pt[0]:    location: -1.25 -1.75 -0.25
    idx:     (1,0,3)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -0.75
    idx:     (1,0,2)
-
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -0.25
    idx:     (1,-1,3)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -0.25
    idx:     (0,0,3)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -0.25
    idx:     (2,0,3)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -0.25
    idx:     (1,1,3)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.75  0.25
    idx:     (1,0,4)
-
 With weight: 4
 
 On point:    location: -0.75 -1.75 -0.25
    idx:     (2,0,3)
-
 pt[0]:    location: -0.75 -1.75 -0.25
    idx:     (2,0,3)
-
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75 -0.75
    idx:     (2,0,2)
-
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -0.25
    idx:     (2,-1,3)
-
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75 -0.25
    idx:     (1,0,3)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -0.25
    idx:     (3,0,3)
-
 With weight: 4
 pt[5]:    location: -0.75 -1.75  0.25
    idx:     (2,0,4)
-
 With weight: 4
 pt[6]:    location: -0.75 -2.25 -0.75
    idx:     (2,-1,2)
-
 With weight: 1.05525e-15
 
 On point:    location: -0.25 -1.75 -0.25
    idx:     (3,0,3)
-
 pt[0]:    location: -0.25 -1.75 -0.25
    idx:     (3,0,3)
-
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75 -0.75
    idx:     (3,0,2)
-
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -0.25
    idx:     (3,-1,3)
-
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75 -0.25
    idx:     (2,0,3)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -0.25
    idx:     (4,0,3)
-
 With weight: 4
 pt[5]:    location: -0.25 -1.75  0.25
    idx:     (3,0,4)
-
 With weight: 4
 pt[6]:    location: -0.25 -2.25 -0.75
    idx:     (3,-1,2)
-
 With weight: 1.05525e-15
 
 On point:    location:  0.25 -1.75 -0.25
    idx:     (4,0,3)
-
 pt[0]:    location:  0.25 -1.75 -0.25
    idx:     (4,0,3)
-
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75 -0.75
    idx:     (4,0,2)
-
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -0.25
    idx:     (4,-1,3)
-
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75 -0.25
    idx:     (3,0,3)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -0.25
    idx:     (5,0,3)
-
 With weight: 4
 pt[5]:    location:  0.25 -1.75  0.25
    idx:     (4,0,4)
-
 With weight: 4
 pt[6]:    location:  0.25 -2.25 -0.75
    idx:     (4,-1,2)
-
 With weight: 1.05525e-15
 
 On point:    location:  0.75 -1.75 -0.25
    idx:     (5,0,3)
-
 pt[0]:    location:  0.75 -1.75 -0.25
    idx:     (5,0,3)
-
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75 -0.75
    idx:     (5,0,2)
-
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -0.25
    idx:     (5,-1,3)
-
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75 -0.25
    idx:     (4,0,3)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -0.25
    idx:     (6,0,3)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.75  0.25
    idx:     (5,0,4)
-
 With weight: 4
 pt[6]:    location:  0.75 -2.25 -0.75
    idx:     (5,-1,2)
-
 With weight: 1.05525e-15
 
 On point:    location:  1.25 -1.75 -0.25
    idx:     (6,0,3)
-
 pt[0]:    location:  1.25 -1.75 -0.25
    idx:     (6,0,3)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -0.75
    idx:     (6,0,2)
-
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -0.25
    idx:     (6,-1,3)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -0.25
    idx:     (5,0,3)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -0.25
    idx:     (7,0,3)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -0.25
    idx:     (6,1,3)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.75  0.25
    idx:     (6,0,4)
-
 With weight: 4
 
 On point:    location:  1.75 -1.75 -0.25
    idx:     (7,0,3)
-
 pt[0]:    location:  1.75 -1.75 -0.25
    idx:     (7,0,3)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -0.75
    idx:     (7,0,2)
-
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -0.25
    idx:     (7,-1,3)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -0.25
    idx:     (6,0,3)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -0.25
    idx:     (8,0,3)
-
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -0.25
    idx:     (7,1,3)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.75  0.25
    idx:     (7,0,4)
-
 With weight: 4
 
 On point:    location: -1.75 -1.25 -0.25
    idx:     (0,1,3)
-
 pt[0]:    location: -1.75 -1.25 -0.25
    idx:     (0,1,3)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -0.75
    idx:     (0,1,2)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -0.25
    idx:     (0,0,3)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -0.25
    idx:     (-1,1,3)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -0.25
    idx:     (1,1,3)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -0.25
    idx:     (0,2,3)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.25  0.25
    idx:     (0,1,4)
-
 With weight: 4
 
 On point:    location: -1.25 -1.25 -0.25
    idx:     (1,1,3)
-
 pt[0]:    location: -1.25 -1.25 -0.25
    idx:     (1,1,3)
-
 With weight: -13.3333
 pt[1]:    location: -1.25 -1.25 -0.75
    idx:     (1,1,2)
-
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -0.25
    idx:     (1,0,3)
-
 With weight: 2.66667
 pt[3]:    location: -1.75 -1.25 -0.25
    idx:     (0,1,3)
-
 With weight: 2.66667
 pt[4]:    location: -1.25 -1.25  0.25
    idx:     (1,1,4)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.75 -0.75
    idx:     (1,0,2)
-
 With weight: -9.11452e-17
 pt[6]:    location: -1.75 -1.25 -0.75
    idx:     (0,1,2)
-
 With weight: -7.36121e-16
 
 On point:    location:  1.25 -1.25 -0.25
    idx:     (6,1,3)
-
 pt[0]:    location:  1.25 -1.25 -0.25
    idx:     (6,1,3)
-
 With weight: -13.3333
 pt[1]:    location:  1.25 -1.25 -0.75
    idx:     (6,1,2)
-
 With weight: 4
 pt[2]:    location:  1.25 -1.75 -0.25
    idx:     (6,0,3)
-
 With weight: 2.66667
 pt[3]:    location:  1.75 -1.25 -0.25
    idx:     (7,1,3)
-
 With weight: 2.66667
 pt[4]:    location:  1.25 -1.25  0.25
    idx:     (6,1,4)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.75 -0.75
    idx:     (6,0,2)
-
 With weight: -9.11452e-17
 pt[6]:    location:  1.75 -1.25 -0.75
    idx:     (7,1,2)
-
 With weight: -7.36121e-16
 
 On point:    location:  1.75 -1.25 -0.25
    idx:     (7,1,3)
-
 pt[0]:    location:  1.75 -1.25 -0.25
    idx:     (7,1,3)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -0.75
    idx:     (7,1,2)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -0.25
    idx:     (7,0,3)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -0.25
    idx:     (6,1,3)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -0.25
    idx:     (8,1,3)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -0.25
    idx:     (7,2,3)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.25  0.25
    idx:     (7,1,4)
-
 With weight: 4
 
 On point:    location: -1.75 -0.75 -0.25
    idx:     (0,2,3)
-
 pt[0]:    location: -1.75 -0.75 -0.25
    idx:     (0,2,3)
-
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75 -0.75
    idx:     (0,2,2)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -0.25
    idx:     (0,1,3)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -0.25
    idx:     (-1,2,3)
-
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25 -0.25
    idx:     (0,3,3)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.25
    idx:     (0,2,4)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -0.75
    idx:     (0,1,2)
-
 With weight: -7.27074e-16
 
 On point:    location:  1.75 -0.75 -0.25
    idx:     (7,2,3)
-
 pt[0]:    location:  1.75 -0.75 -0.25
    idx:     (7,2,3)
-
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.75 -0.75
    idx:     (7,2,2)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.25 -0.25
    idx:     (7,1,3)
-
 With weight: 4
 pt[3]:    location:  2.25 -0.75 -0.25
    idx:     (8,2,3)
-
 With weight: 2.66667
 pt[4]:    location:  1.75 -0.25 -0.25
    idx:     (7,3,3)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.25
    idx:     (7,2,4)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -0.75
    idx:     (7,1,2)
-
 With weight: -7.27074e-16
 
 On point:    location: -1.75 -0.25 -0.25
    idx:     (0,3,3)
-
 pt[0]:    location: -1.75 -0.25 -0.25
    idx:     (0,3,3)
-
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25 -0.75
    idx:     (0,3,2)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -0.25
    idx:     (0,2,3)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -0.25
    idx:     (-1,3,3)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25 -0.25
    idx:     (0,4,3)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.25  0.25
    idx:     (0,3,4)
-
 With weight: 4
 pt[6]:    location: -1.75 -0.75 -0.75
    idx:     (0,2,2)
-
 With weight: -7.27074e-16
 
 On point:    location:  1.75 -0.25 -0.25
    idx:     (7,3,3)
-
 pt[0]:    location:  1.75 -0.25 -0.25
    idx:     (7,3,3)
-
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25 -0.75
    idx:     (7,3,2)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -0.25
    idx:     (7,2,3)
-
 With weight: 4
 pt[3]:    location:  2.25 -0.25 -0.25
    idx:     (8,3,3)
-
 With weight: 2.66667
 pt[4]:    location:  1.75  0.25 -0.25
    idx:     (7,4,3)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.25  0.25
    idx:     (7,3,4)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -0.75
    idx:     (7,2,2)
-
 With weight: -7.27074e-16
 
 On point:    location: -1.75  0.25 -0.25
    idx:     (0,4,3)
-
 pt[0]:    location: -1.75  0.25 -0.25
    idx:     (0,4,3)
-
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25 -0.75
    idx:     (0,4,2)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -0.25
    idx:     (0,3,3)
-
 With weight: 4
 pt[3]:    location: -2.25  0.25 -0.25
    idx:     (-1,4,3)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75 -0.25
    idx:     (0,5,3)
-
 With weight: 4
 pt[5]:    location: -1.75  0.25  0.25
    idx:     (0,4,4)
-
 With weight: 4
 pt[6]:    location: -2.25  0.25 -0.75
    idx:     (-1,4,2)
-
 With weight: 1.13062e-15
 
 On point:    location:  1.75  0.25 -0.25
    idx:     (7,4,3)
-
 pt[0]:    location:  1.75  0.25 -0.25
    idx:     (7,4,3)
-
 With weight: -18.6667
 pt[1]:    location:  1.75  0.25 -0.75
    idx:     (7,4,2)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.25 -0.25
    idx:     (7,3,3)
-
 With weight: 4
 pt[3]:    location:  2.25  0.25 -0.25
    idx:     (8,4,3)
-
 With weight: 2.66667
 pt[4]:    location:  1.75  0.75 -0.25
    idx:     (7,5,3)
-
 With weight: 4
 pt[5]:    location: 1.75 0.25 0.25
    idx:     (7,4,4)
-
 With weight: 4
 pt[6]:    location:  2.25  0.25 -0.75
    idx:     (8,4,2)
-
 With weight: 1.13062e-15
 
 On point:    location: -1.75  0.75 -0.25
    idx:     (0,5,3)
-
 pt[0]:    location: -1.75  0.75 -0.25
    idx:     (0,5,3)
-
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75 -0.75
    idx:     (0,5,2)
-
 With weight: 4
 pt[2]:    location: -1.75  0.25 -0.25
    idx:     (0,4,3)
-
 With weight: 4
 pt[3]:    location: -2.25  0.75 -0.25
    idx:     (-1,5,3)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25 -0.25
    idx:     (0,6,3)
-
 With weight: 4
 pt[5]:    location: -1.75  0.75  0.25
    idx:     (0,5,4)
-
 With weight: 4
 pt[6]:    location: -1.75  0.25 -0.75
    idx:     (0,4,2)
-
 With weight: -7.27074e-16
 
 On point:    location:  1.75  0.75 -0.25
    idx:     (7,5,3)
-
 pt[0]:    location:  1.75  0.75 -0.25
    idx:     (7,5,3)
-
 With weight: -18.6667
 pt[1]:    location:  1.75  0.75 -0.75
    idx:     (7,5,2)
-
 With weight: 4
 pt[2]:    location:  1.75  0.25 -0.25
    idx:     (7,4,3)
-
 With weight: 4
 pt[3]:    location:  2.25  0.75 -0.25
    idx:     (8,5,3)
-
 With weight: 2.66667
 pt[4]:    location:  1.75  1.25 -0.25
    idx:     (7,6,3)
-
 With weight: 4
 pt[5]:    location: 1.75 0.75 0.25
    idx:     (7,5,4)
-
 With weight: 4
 pt[6]:    location:  1.75  0.25 -0.75
    idx:     (7,4,2)
-
 With weight: -7.27074e-16
 
 On point:    location: -1.75  1.25 -0.25
    idx:     (0,6,3)
-
 pt[0]:    location: -1.75  1.25 -0.25
    idx:     (0,6,3)
-
 With weight: -24
 pt[1]:    location: -1.75  1.25 -0.75
    idx:     (0,6,2)
-
 With weight: 4
 pt[2]:    location: -1.75  0.75 -0.25
    idx:     (0,5,3)
-
 With weight: 4
 pt[3]:    location: -2.25  1.25 -0.25
    idx:     (-1,6,3)
-
 With weight: 4
 pt[4]:    location: -1.25  1.25 -0.25
    idx:     (1,6,3)
-
 With weight: 4
 pt[5]:    location: -1.75  1.75 -0.25
    idx:     (0,7,3)
-
 With weight: 4
 pt[6]:    location: -1.75  1.25  0.25
    idx:     (0,6,4)
-
 With weight: 4
 
 On point:    location: -1.25  1.25 -0.25
    idx:     (1,6,3)
-
 pt[0]:    location: -1.25  1.25 -0.25
    idx:     (1,6,3)
-
 With weight: -13.9608
 pt[1]:    location: -1.25  1.25 -0.75
    idx:     (1,6,2)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25 -0.25
    idx:     (0,6,3)
-
 With weight: 0.784314
 pt[3]:    location: -1.25  1.75 -0.25
    idx:     (1,7,3)
-
 With weight: 3.29412
 pt[4]:    location: -1.25  1.25  0.25
    idx:     (1,6,4)
-
 With weight: 4
 pt[5]:    location: -1.75  1.25 -0.75
    idx:     (0,6,2)
-
 With weight: -7.39094e-16
 pt[6]:    location: -1.75  0.75 -0.25
    idx:     (0,5,3)
-
 With weight: 1.88235
 
 On point:    location:  1.25  1.25 -0.25
    idx:     (6,6,3)
-
 pt[0]:    location:  1.25  1.25 -0.25
    idx:     (6,6,3)
-
 With weight: -13.3333
 pt[1]:    location:  1.25  1.25 -0.75
    idx:     (6,6,2)
-
 With weight: 4
 pt[2]:    location:  1.75  1.25 -0.25
    idx:     (7,6,3)
-
 With weight: 2.66667
 pt[3]:    location:  1.25  1.75 -0.25
    idx:     (6,7,3)
-
 With weight: 2.66667
 pt[4]:    location: 1.25 1.25 0.25
    idx:     (6,6,4)
-
 With weight: 4
 pt[5]:    location:  1.75  1.25 -0.75
    idx:     (7,6,2)
-
 With weight: 3.03817e-17
 pt[6]:    location:  1.25  1.75 -0.75
    idx:     (6,7,2)
-
 With weight: -3.14198e-16
 
 On point:    location:  1.75  1.25 -0.25
    idx:     (7,6,3)
-
 pt[0]:    location:  1.75  1.25 -0.25
    idx:     (7,6,3)
-
 With weight: -24
 pt[1]:    location:  1.75  1.25 -0.75
    idx:     (7,6,2)
-
 With weight: 4
 pt[2]:    location:  1.75  0.75 -0.25
    idx:     (7,5,3)
-
 With weight: 4
 pt[3]:    location:  1.25  1.25 -0.25
    idx:     (6,6,3)
-
 With weight: 4
 pt[4]:    location:  2.25  1.25 -0.25
    idx:     (8,6,3)
-
 With weight: 4
 pt[5]:    location:  1.75  1.75 -0.25
    idx:     (7,7,3)
-
 With weight: 4
 pt[6]:    location: 1.75 1.25 0.25
    idx:     (7,6,4)
-
 With weight: 4
 
 On point:    location: -1.75  1.75 -0.25
    idx:     (0,7,3)
-
 pt[0]:    location: -1.75  1.75 -0.25
    idx:     (0,7,3)
-
 With weight: -24
 pt[1]:    location: -1.75  1.75 -0.75
    idx:     (0,7,2)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25 -0.25
    idx:     (0,6,3)
-
 With weight: 4
 pt[3]:    location: -2.25  1.75 -0.25
    idx:     (-1,7,3)
-
 With weight: 4
 pt[4]:    location: -1.25  1.75 -0.25
    idx:     (1,7,3)
-
 With weight: 4
 pt[5]:    location: -1.75  2.25 -0.25
    idx:     (0,8,3)
-
 With weight: 4
 pt[6]:    location: -1.75  1.75  0.25
    idx:     (0,7,4)
-
 With weight: 4
 
 On point:    location: -1.25  1.75 -0.25
    idx:     (1,7,3)
-
 pt[0]:    location: -1.25  1.75 -0.25
    idx:     (1,7,3)
-
 With weight: -24
 pt[1]:    location: -1.25  1.75 -0.75
    idx:     (1,7,2)
-
 With weight: 4
 pt[2]:    location: -1.25  1.25 -0.25
    idx:     (1,6,3)
-
 With weight: 4
 pt[3]:    location: -1.75  1.75 -0.25
    idx:     (0,7,3)
-
 With weight: 4
 pt[4]:    location: -0.75  1.75 -0.25
    idx:     (2,7,3)
-
 With weight: 4
 pt[5]:    location: -1.25  2.25 -0.25
    idx:     (1,8,3)
-
 With weight: 4
 pt[6]:    location: -1.25  1.75  0.25
    idx:     (1,7,4)
-
 With weight: 4
 
 On point:    location: -0.75  1.75 -0.25
    idx:     (2,7,3)
-
 pt[0]:    location: -0.75  1.75 -0.25
    idx:     (2,7,3)
-
 With weight: -18.6667
 pt[1]:    location: -0.75  1.75 -0.75
    idx:     (2,7,2)
-
 With weight: 4
 pt[2]:    location: -1.25  1.75 -0.25
    idx:     (1,7,3)
-
 With weight: 4
 pt[3]:    location: -0.25  1.75 -0.25
    idx:     (3,7,3)
-
 With weight: 4
 pt[4]:    location: -0.75  2.25 -0.25
    idx:     (2,8,3)
-
 With weight: 2.66667
 pt[5]:    location: -0.75  1.75  0.25
    idx:     (2,7,4)
-
 With weight: 4
 pt[6]:    location: -1.25  1.75 -0.75
    idx:     (1,7,2)
-
 With weight: 8.23102e-16
 
 On point:    location: -0.25  1.75 -0.25
    idx:     (3,7,3)
-
 pt[0]:    location: -0.25  1.75 -0.25
    idx:     (3,7,3)
-
 With weight: -18.6667
 pt[1]:    location: -0.25  1.75 -0.75
    idx:     (3,7,2)
-
 With weight: 4
 pt[2]:    location: -0.75  1.75 -0.25
    idx:     (2,7,3)
-
 With weight: 4
 pt[3]:    location:  0.25  1.75 -0.25
    idx:     (4,7,3)
-
 With weight: 4
 pt[4]:    location: -0.25  2.25 -0.25
    idx:     (3,8,3)
-
 With weight: 2.66667
 pt[5]:    location: -0.25  1.75  0.25
    idx:     (3,7,4)
-
 With weight: 4
 pt[6]:    location: -0.75  1.75 -0.75
    idx:     (2,7,2)
-
 With weight: 8.23102e-16
 
 On point:    location:  0.25  1.75 -0.25
    idx:     (4,7,3)
-
 pt[0]:    location:  0.25  1.75 -0.25
    idx:     (4,7,3)
-
 With weight: -18.6667
 pt[1]:    location:  0.25  1.75 -0.75
    idx:     (4,7,2)
-
 With weight: 4
 pt[2]:    location: -0.25  1.75 -0.25
    idx:     (3,7,3)
-
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.25
    idx:     (5,7,3)
-
 With weight: 4
 pt[4]:    location:  0.25  2.25 -0.25
    idx:     (4,8,3)
-
 With weight: 2.66667
 pt[5]:    location: 0.25 1.75 0.25
    idx:     (4,7,4)
-
 With weight: 4
 pt[6]:    location:  0.75  1.75 -0.75
    idx:     (5,7,2)
-
 With weight: 1.09747e-15
 
 On point:    location:  0.75  1.75 -0.25
    idx:     (5,7,3)
-
 pt[0]:    location:  0.75  1.75 -0.25
    idx:     (5,7,3)
-
 With weight: -18.6667
 pt[1]:    location:  0.75  1.75 -0.75
    idx:     (5,7,2)
-
 With weight: 4
 pt[2]:    location:  0.25  1.75 -0.25
    idx:     (4,7,3)
-
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.25
    idx:     (6,7,3)
-
 With weight: 4
 pt[4]:    location:  0.75  2.25 -0.25
    idx:     (5,8,3)
-
 With weight: 2.66667
 pt[5]:    location: 0.75 1.75 0.25
    idx:     (5,7,4)
-
 With weight: 4
 pt[6]:    location:  0.25  1.75 -0.75
    idx:     (4,7,2)
-
 With weight: 8.23102e-16
 
 On point:    location:  1.25  1.75 -0.25
    idx:     (6,7,3)
-
 pt[0]:    location:  1.25  1.75 -0.25
    idx:     (6,7,3)
-
 With weight: -24
 pt[1]:    location:  1.25  1.75 -0.75
    idx:     (6,7,2)
-
 With weight: 4
 pt[2]:    location:  1.25  1.25 -0.25
    idx:     (6,6,3)
-
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.25
    idx:     (5,7,3)
-
 With weight: 4
 pt[4]:    location:  1.75  1.75 -0.25
    idx:     (7,7,3)
-
 With weight: 4
 pt[5]:    location:  1.25  2.25 -0.25
    idx:     (6,8,3)
-
 With weight: 4
 pt[6]:    location: 1.25 1.75 0.25
    idx:     (6,7,4)
-
 With weight: 4
 
 On point:    location:  1.75  1.75 -0.25
    idx:     (7,7,3)
-
 pt[0]:    location:  1.75  1.75 -0.25
    idx:     (7,7,3)
-
 With weight: -24
 pt[1]:    location:  1.75  1.75 -0.75
    idx:     (7,7,2)
-
 With weight: 4
 pt[2]:    location:  1.75  1.25 -0.25
    idx:     (7,6,3)
-
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.25
    idx:     (6,7,3)
-
 With weight: 4
 pt[4]:    location:  2.25  1.75 -0.25
    idx:     (8,7,3)
-
 With weight: 4
 pt[5]:    location:  1.75  2.25 -0.25
    idx:     (7,8,3)
-
 With weight: 4
 pt[6]:    location: 1.75 1.75 0.25
    idx:     (7,7,4)
-
 With weight: 4
 
 On point:    location: -1.75 -1.75  0.25
    idx:     (0,0,4)
-
 pt[0]:    location: -1.75 -1.75  0.25
    idx:     (0,0,4)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -0.25
    idx:     (0,0,3)
-
 With weight: 4
 pt[2]:    location: -1.75 -2.25  0.25
    idx:     (0,-1,4)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.75  0.25
    idx:     (-1,0,4)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.75  0.25
    idx:     (1,0,4)
-
 With weight: 4
 pt[5]:    location: -1.75 -1.25  0.25
    idx:     (0,1,4)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.75  0.75
    idx:     (0,0,5)
-
 With weight: 4
 
 On point:    location: -1.25 -1.75  0.25
    idx:     (1,0,4)
-
 pt[0]:    location: -1.25 -1.75  0.25
    idx:     (1,0,4)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -0.25
    idx:     (1,0,3)
-
 With weight: 4
 pt[2]:    location: -1.25 -2.25  0.25
    idx:     (1,-1,4)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.75  0.25
    idx:     (0,0,4)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.75  0.25
    idx:     (2,0,4)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.25  0.25
    idx:     (1,1,4)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.75  0.75
    idx:     (1,0,5)
-
 With weight: 4
 
 On point:    location: -0.75 -1.75  0.25
    idx:     (2,0,4)
-
 pt[0]:    location: -0.75 -1.75  0.25
    idx:     (2,0,4)
-
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75 -0.25
    idx:     (2,0,3)
-
 With weight: 4
 pt[2]:    location: -0.75 -2.25  0.25
    idx:     (2,-1,4)
-
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75  0.25
    idx:     (1,0,4)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.75  0.25
    idx:     (3,0,4)
-
 With weight: 4
 pt[5]:    location: -0.75 -1.75  0.75
    idx:     (2,0,5)
-
 With weight: 4
 pt[6]:    location: -1.25 -2.25  0.25
    idx:     (1,-1,4)
-
 With weight: 6.03e-16
 
 On point:    location: -0.25 -1.75  0.25
    idx:     (3,0,4)
-
 pt[0]:    location: -0.25 -1.75  0.25
    idx:     (3,0,4)
-
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75 -0.25
    idx:     (3,0,3)
-
 With weight: 4
 pt[2]:    location: -0.25 -2.25  0.25
    idx:     (3,-1,4)
-
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75  0.25
    idx:     (2,0,4)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.75  0.25
    idx:     (4,0,4)
-
 With weight: 4
 pt[5]:    location: -0.25 -1.75  0.75
    idx:     (3,0,5)
-
 With weight: 4
 pt[6]:    location: -0.75 -2.25  0.25
    idx:     (2,-1,4)
-
 With weight: 6.03e-16
 
 On point:    location:  0.25 -1.75  0.25
    idx:     (4,0,4)
-
 pt[0]:    location:  0.25 -1.75  0.25
    idx:     (4,0,4)
-
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75 -0.25
    idx:     (4,0,3)
-
 With weight: 4
 pt[2]:    location:  0.25 -2.25  0.25
    idx:     (4,-1,4)
-
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75  0.25
    idx:     (3,0,4)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.75  0.25
    idx:     (5,0,4)
-
 With weight: 4
 pt[5]:    location:  0.25 -1.75  0.75
    idx:     (4,0,5)
-
 With weight: 4
 pt[6]:    location:  0.75 -2.25  0.25
    idx:     (5,-1,4)
-
 With weight: -6.85912e-16
 
 On point:    location:  0.75 -1.75  0.25
    idx:     (5,0,4)
-
 pt[0]:    location:  0.75 -1.75  0.25
    idx:     (5,0,4)
-
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75 -0.25
    idx:     (5,0,3)
-
 With weight: 4
 pt[2]:    location:  0.75 -2.25  0.25
    idx:     (5,-1,4)
-
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75  0.25
    idx:     (4,0,4)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.75  0.25
    idx:     (6,0,4)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.75  0.75
    idx:     (5,0,5)
-
 With weight: 4
 pt[6]:    location:  0.25 -2.25  0.25
    idx:     (4,-1,4)
-
 With weight: 6.03e-16
 
 On point:    location:  1.25 -1.75  0.25
    idx:     (6,0,4)
-
 pt[0]:    location:  1.25 -1.75  0.25
    idx:     (6,0,4)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -0.25
    idx:     (6,0,3)
-
 With weight: 4
 pt[2]:    location:  1.25 -2.25  0.25
    idx:     (6,-1,4)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.75  0.25
    idx:     (5,0,4)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.75  0.25
    idx:     (7,0,4)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.25  0.25
    idx:     (6,1,4)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.75  0.75
    idx:     (6,0,5)
-
 With weight: 4
 
 On point:    location:  1.75 -1.75  0.25
    idx:     (7,0,4)
-
 pt[0]:    location:  1.75 -1.75  0.25
    idx:     (7,0,4)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -0.25
    idx:     (7,0,3)
-
 With weight: 4
 pt[2]:    location:  1.75 -2.25  0.25
    idx:     (7,-1,4)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.75  0.25
    idx:     (6,0,4)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.75  0.25
    idx:     (8,0,4)
-
 With weight: 4
 pt[5]:    location:  1.75 -1.25  0.25
    idx:     (7,1,4)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.75  0.75
    idx:     (7,0,5)
-
 With weight: 4
 
 On point:    location: -1.75 -1.25  0.25
    idx:     (0,1,4)
-
 pt[0]:    location: -1.75 -1.25  0.25
    idx:     (0,1,4)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -0.25
    idx:     (0,1,3)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.75  0.25
    idx:     (0,0,4)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.25  0.25
    idx:     (-1,1,4)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.25  0.25
    idx:     (1,1,4)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.25
    idx:     (0,2,4)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.25  0.75
    idx:     (0,1,5)
-
 With weight: 4
 
 On point:    location: -1.25 -1.25  0.25
    idx:     (1,1,4)
-
 pt[0]:    location: -1.25 -1.25  0.25
    idx:     (1,1,4)
-
 With weight: -13.9608
 pt[1]:    location: -1.25 -1.25 -0.25
    idx:     (1,1,3)
-
 With weight: 4
 pt[2]:    location: -1.25 -1.75  0.25
    idx:     (1,0,4)
-
 With weight: 3.29412
 pt[3]:    location: -1.75 -1.25  0.25
    idx:     (0,1,4)
-
 With weight: 0.784314
 pt[4]:    location: -1.25 -1.25  0.75
    idx:     (1,1,5)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.25
    idx:     (0,2,4)
-
 With weight: 1.88235
 pt[6]:    location: -1.25 -1.75  0.75
    idx:     (1,0,5)
-
 With weight: -1.55529e-15
 
 On point:    location:  1.25 -1.25  0.25
    idx:     (6,1,4)
-
 pt[0]:    location:  1.25 -1.25  0.25
    idx:     (6,1,4)
-
 With weight: -13.3333
 pt[1]:    location:  1.25 -1.25 -0.25
    idx:     (6,1,3)
-
 With weight: 4
 pt[2]:    location:  1.25 -1.75  0.25
    idx:     (6,0,4)
-
 With weight: 6.03419e-16
 pt[3]:    location:  1.75 -1.25  0.25
    idx:     (7,1,4)
-
 With weight: 2.66667
 pt[4]:    location:  1.25 -1.25  0.75
    idx:     (6,1,5)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.75  0.25
    idx:     (5,0,4)
-
 With weight: 2
 pt[6]:    location:  1.75 -1.75  0.25
    idx:     (7,0,4)
-
 With weight: 0.666667
 
 On point:    location:  1.75 -1.25  0.25
    idx:     (7,1,4)
-
 pt[0]:    location:  1.75 -1.25  0.25
    idx:     (7,1,4)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -0.25
    idx:     (7,1,3)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.75  0.25
    idx:     (7,0,4)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.25  0.25
    idx:     (6,1,4)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.25  0.25
    idx:     (8,1,4)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.25
    idx:     (7,2,4)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.25  0.75
    idx:     (7,1,5)
-
 With weight: 4
 
 On point:    location: -1.75 -0.75  0.25
    idx:     (0,2,4)
-
 pt[0]:    location: -1.75 -0.75  0.25
    idx:     (0,2,4)
-
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75 -0.25
    idx:     (0,2,3)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.25  0.25
    idx:     (0,1,4)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.75  0.25
    idx:     (-1,2,4)
-
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25  0.25
    idx:     (0,3,4)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.75
    idx:     (0,2,5)
-
 With weight: 4
 pt[6]:    location: -2.25 -1.25  0.25
    idx:     (-1,1,4)
-
 With weight: 1.3869e-15
 
 On point:    location:  1.75 -0.75  0.25
    idx:     (7,2,4)
-
 pt[0]:    location:  1.75 -0.75  0.25
    idx:     (7,2,4)
-
 With weight: -19.2941
 pt[1]:    location:  1.75 -0.75 -0.25
    idx:     (7,2,3)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.25  0.25
    idx:     (7,1,4)
-
 With weight: 2.11765
 pt[3]:    location:  2.25 -0.75  0.25
    idx:     (8,2,4)
-
 With weight: 3.29412
 pt[4]:    location:  1.75 -0.25  0.25
    idx:     (7,3,4)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.75
    idx:     (7,2,5)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.25  0.25
    idx:     (6,1,4)
-
 With weight: 1.88235
 
 On point:    location: -1.75 -0.25  0.25
    idx:     (0,3,4)
-
 pt[0]:    location: -1.75 -0.25  0.25
    idx:     (0,3,4)
-
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25 -0.25
    idx:     (0,3,3)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.75  0.25
    idx:     (0,2,4)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.25  0.25
    idx:     (-1,3,4)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25  0.25
    idx:     (0,4,4)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.25  0.75
    idx:     (0,3,5)
-
 With weight: 4
 pt[6]:    location: -2.25 -0.75  0.25
    idx:     (-1,2,4)
-
 With weight: 1.3869e-15
 
 On point:    location:  1.75 -0.25  0.25
    idx:     (7,3,4)
-
 pt[0]:    location:  1.75 -0.25  0.25
    idx:     (7,3,4)
-
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25 -0.25
    idx:     (7,3,3)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.75  0.25
    idx:     (7,2,4)
-
 With weight: 4
 pt[3]:    location:  2.25 -0.25  0.25
    idx:     (8,3,4)
-
 With weight: 2.66667
 pt[4]:    location: 1.75 0.25 0.25
    idx:     (7,4,4)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.25  0.75
    idx:     (7,3,5)
-
 With weight: 4
 pt[6]:    location:  2.25 -0.75  0.25
    idx:     (8,2,4)
-
 With weight: 1.3869e-15
 
 On point:    location: -1.75  0.25  0.25
    idx:     (0,4,4)
-
 pt[0]:    location: -1.75  0.25  0.25
    idx:     (0,4,4)
-
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25 -0.25
    idx:     (0,4,3)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.25  0.25
    idx:     (0,3,4)
-
 With weight: 4
 pt[3]:    location: -2.25  0.25  0.25
    idx:     (-1,4,4)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75  0.25
    idx:     (0,5,4)
-
 With weight: 4
 pt[5]:    location: -1.75  0.25  0.75
    idx:     (0,4,5)
-
 With weight: 4
 pt[6]:    location: -2.25  0.75  0.25
    idx:     (-1,5,4)
-
 With weight: -1.47735e-15
 
 On point:    location: 1.75 0.25 0.25
    idx:     (7,4,4)
-
 pt[0]:    location: 1.75 0.25 0.25
    idx:     (7,4,4)
-
 With weight: -18.6667
 pt[1]:    location:  1.75  0.25 -0.25
    idx:     (7,4,3)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.25  0.25
    idx:     (7,3,4)
-
 With weight: 4
 pt[3]:    location: 2.25 0.25 0.25
    idx:     (8,4,4)
-
 With weight: 2.66667
 pt[4]:    location: 1.75 0.75 0.25
    idx:     (7,5,4)
-
 With weight: 4
 pt[5]:    location: 1.75 0.25 0.75
    idx:     (7,4,5)
-
 With weight: 4
 pt[6]:    location: 2.25 0.75 0.25
    idx:     (8,5,4)
-
 With weight: -1.47735e-15
 
 On point:    location: -1.75  0.75  0.25
    idx:     (0,5,4)
-
 pt[0]:    location: -1.75  0.75  0.25
    idx:     (0,5,4)
-
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75 -0.25
    idx:     (0,5,3)
-
 With weight: 4
 pt[2]:    location: -1.75  0.25  0.25
    idx:     (0,4,4)
-
 With weight: 4
 pt[3]:    location: -2.25  0.75  0.25
    idx:     (-1,5,4)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25  0.25
    idx:     (0,6,4)
-
 With weight: 4
 pt[5]:    location: -1.75  0.75  0.75
    idx:     (0,5,5)
-
 With weight: 4
 pt[6]:    location: -2.25  0.25  0.25
    idx:     (-1,4,4)
-
 With weight: 1.3869e-15
 
 On point:    location: 1.75 0.75 0.25
    idx:     (7,5,4)
-
 pt[0]:    location: 1.75 0.75 0.25
    idx:     (7,5,4)
-
 With weight: -19.2941
 pt[1]:    location:  1.75  0.75 -0.25
    idx:     (7,5,3)
-
 With weight: 4
 pt[2]:    location: 1.75 0.25 0.25
    idx:     (7,4,4)
-
 With weight: 4
 pt[3]:    location: 2.25 0.75 0.25
    idx:     (8,5,4)
-
 With weight: 3.29412
 pt[4]:    location: 1.75 1.25 0.25
    idx:     (7,6,4)
-
 With weight: 2.11765
 pt[5]:    location: 1.75 0.75 0.75
    idx:     (7,5,5)
-
 With weight: 4
 pt[6]:    location: 1.25 1.25 0.25
    idx:     (6,6,4)
-
 With weight: 1.88235
 
 On point:    location: -1.75  1.25  0.25
    idx:     (0,6,4)
-
 pt[0]:    location: -1.75  1.25  0.25
    idx:     (0,6,4)
-
 With weight: -24
 pt[1]:    location: -1.75  1.25 -0.25
    idx:     (0,6,3)
-
 With weight: 4
 pt[2]:    location: -1.75  0.75  0.25
    idx:     (0,5,4)
-
 With weight: 4
 pt[3]:    location: -2.25  1.25  0.25
    idx:     (-1,6,4)
-
 With weight: 4
 pt[4]:    location: -1.25  1.25  0.25
    idx:     (1,6,4)
-
 With weight: 4
 pt[5]:    location: -1.75  1.75  0.25
    idx:     (0,7,4)
-
 With weight: 4
 pt[6]:    location: -1.75  1.25  0.75
    idx:     (0,6,5)
-
 With weight: 4
 
 On point:    location: -1.25  1.25  0.25
    idx:     (1,6,4)
-
 pt[0]:    location: -1.25  1.25  0.25
    idx:     (1,6,4)
-
 With weight: -13.3333
 pt[1]:    location: -1.25  1.25 -0.25
    idx:     (1,6,3)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.25
    idx:     (0,6,4)
-
 With weight: 2.66667
 pt[3]:    location: -1.25  1.75  0.25
    idx:     (1,7,4)
-
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25  0.75
    idx:     (1,6,5)
-
 With weight: 4
 pt[5]:    location: -1.75  1.75  0.25
    idx:     (0,7,4)
-
 With weight: 4.50879e-16
 pt[6]:    location: -1.75  1.25  0.75
    idx:     (0,6,5)
-
 With weight: 1.30313e-16
 
 On point:    location: 1.25 1.25 0.25
    idx:     (6,6,4)
-
 pt[0]:    location: 1.25 1.25 0.25
    idx:     (6,6,4)
-
 With weight: -13.3333
 pt[1]:    location:  1.25  1.25 -0.25
    idx:     (6,6,3)
-
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.25
    idx:     (7,6,4)
-
 With weight: 2.66667
 pt[3]:    location: 1.25 1.75 0.25
    idx:     (6,7,4)
-
 With weight: -2.16225e-15
 pt[4]:    location: 1.25 1.25 0.75
    idx:     (6,6,5)
-
 With weight: 4
 pt[5]:    location: 0.75 1.75 0.25
    idx:     (5,7,4)
-
 With weight: 2
 pt[6]:    location: 1.75 1.75 0.25
    idx:     (7,7,4)
-
 With weight: 0.666667
 
 On point:    location: 1.75 1.25 0.25
    idx:     (7,6,4)
-
 pt[0]:    location: 1.75 1.25 0.25
    idx:     (7,6,4)
-
 With weight: -24
 pt[1]:    location:  1.75  1.25 -0.25
    idx:     (7,6,3)
-
 With weight: 4
 pt[2]:    location: 1.75 0.75 0.25
    idx:     (7,5,4)
-
 With weight: 4
 pt[3]:    location: 1.25 1.25 0.25
    idx:     (6,6,4)
-
 With weight: 4
 pt[4]:    location: 2.25 1.25 0.25
    idx:     (8,6,4)
-
 With weight: 4
 pt[5]:    location: 1.75 1.75 0.25
    idx:     (7,7,4)
-
 With weight: 4
 pt[6]:    location: 1.75 1.25 0.75
    idx:     (7,6,5)
-
 With weight: 4
 
 On point:    location: -1.75  1.75  0.25
    idx:     (0,7,4)
-
 pt[0]:    location: -1.75  1.75  0.25
    idx:     (0,7,4)
-
 With weight: -24
 pt[1]:    location: -1.75  1.75 -0.25
    idx:     (0,7,3)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.25
    idx:     (0,6,4)
-
 With weight: 4
 pt[3]:    location: -2.25  1.75  0.25
    idx:     (-1,7,4)
-
 With weight: 4
 pt[4]:    location: -1.25  1.75  0.25
    idx:     (1,7,4)
-
 With weight: 4
 pt[5]:    location: -1.75  2.25  0.25
    idx:     (0,8,4)
-
 With weight: 4
 pt[6]:    location: -1.75  1.75  0.75
    idx:     (0,7,5)
-
 With weight: 4
 
 On point:    location: -1.25  1.75  0.25
    idx:     (1,7,4)
-
 pt[0]:    location: -1.25  1.75  0.25
    idx:     (1,7,4)
-
 With weight: -24
 pt[1]:    location: -1.25  1.75 -0.25
    idx:     (1,7,3)
-
 With weight: 4
 pt[2]:    location: -1.25  1.25  0.25
    idx:     (1,6,4)
-
 With weight: 4
 pt[3]:    location: -1.75  1.75  0.25
    idx:     (0,7,4)
-
 With weight: 4
 pt[4]:    location: -0.75  1.75  0.25
    idx:     (2,7,4)
-
 With weight: 4
 pt[5]:    location: -1.25  2.25  0.25
    idx:     (1,8,4)
-
 With weight: 4
 pt[6]:    location: -1.25  1.75  0.75
    idx:     (1,7,5)
-
 With weight: 4
 
 On point:    location: -0.75  1.75  0.25
    idx:     (2,7,4)
-
 pt[0]:    location: -0.75  1.75  0.25
    idx:     (2,7,4)
-
 With weight: -19.2941
 pt[1]:    location: -0.75  1.75 -0.25
    idx:     (2,7,3)
-
 With weight: 4
 pt[2]:    location: -1.25  1.75  0.25
    idx:     (1,7,4)
-
 With weight: 2.11765
 pt[3]:    location: -0.25  1.75  0.25
    idx:     (3,7,4)
-
 With weight: 4
 pt[4]:    location: -0.75  2.25  0.25
    idx:     (2,8,4)
-
 With weight: 3.29412
 pt[5]:    location: -0.75  1.75  0.75
    idx:     (2,7,5)
-
 With weight: 4
 pt[6]:    location: -1.25  1.25  0.25
    idx:     (1,6,4)
-
 With weight: 1.88235
 
 On point:    location: -0.25  1.75  0.25
    idx:     (3,7,4)
-
 pt[0]:    location: -0.25  1.75  0.25
    idx:     (3,7,4)
-
 With weight: -18.6667
 pt[1]:    location: -0.25  1.75 -0.25
    idx:     (3,7,3)
-
 With weight: 4
 pt[2]:    location: -0.75  1.75  0.25
    idx:     (2,7,4)
-
 With weight: 4
 pt[3]:    location: 0.25 1.75 0.25
    idx:     (4,7,4)
-
 With weight: 4
 pt[4]:    location: -0.25  2.25  0.25
    idx:     (3,8,4)
-
 With weight: 2.66667
 pt[5]:    location: -0.25  1.75  0.75
    idx:     (3,7,5)
-
 With weight: 4
 pt[6]:    location: -0.75  2.25  0.25
    idx:     (2,8,4)
-
 With weight: -5.87925e-16
 
 On point:    location: 0.25 1.75 0.25
    idx:     (4,7,4)
-
 pt[0]:    location: 0.25 1.75 0.25
    idx:     (4,7,4)
-
 With weight: -18.6667
 pt[1]:    location:  0.25  1.75 -0.25
    idx:     (4,7,3)
-
 With weight: 4
 pt[2]:    location: -0.25  1.75  0.25
    idx:     (3,7,4)
-
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.25
    idx:     (5,7,4)
-
 With weight: 4
 pt[4]:    location: 0.25 2.25 0.25
    idx:     (4,8,4)
-
 With weight: 2.66667
 pt[5]:    location: 0.25 1.75 0.75
    idx:     (4,7,5)
-
 With weight: 4
 pt[6]:    location: 0.75 2.25 0.25
    idx:     (5,8,4)
-
 With weight: -7.31137e-16
 
 On point:    location: 0.75 1.75 0.25
    idx:     (5,7,4)
-
 pt[0]:    location: 0.75 1.75 0.25
    idx:     (5,7,4)
-
 With weight: -19.2941
 pt[1]:    location:  0.75  1.75 -0.25
    idx:     (5,7,3)
-
 With weight: 4
 pt[2]:    location: 0.25 1.75 0.25
    idx:     (4,7,4)
-
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.25
    idx:     (6,7,4)
-
 With weight: 2.11765
 pt[4]:    location: 0.75 2.25 0.25
    idx:     (5,8,4)
-
 With weight: 3.29412
 pt[5]:    location: 0.75 1.75 0.75
    idx:     (5,7,5)
-
 With weight: 4
 pt[6]:    location: 1.25 1.25 0.25
    idx:     (6,6,4)
-
 With weight: 1.88235
 
 On point:    location: 1.25 1.75 0.25
    idx:     (6,7,4)
-
 pt[0]:    location: 1.25 1.75 0.25
    idx:     (6,7,4)
-
 With weight: -24
 pt[1]:    location:  1.25  1.75 -0.25
    idx:     (6,7,3)
-
 With weight: 4
 pt[2]:    location: 1.25 1.25 0.25
    idx:     (6,6,4)
-
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.25
    idx:     (5,7,4)
-
 With weight: 4
 pt[4]:    location: 1.75 1.75 0.25
    idx:     (7,7,4)
-
 With weight: 4
 pt[5]:    location: 1.25 2.25 0.25
    idx:     (6,8,4)
-
 With weight: 4
 pt[6]:    location: 1.25 1.75 0.75
    idx:     (6,7,5)
-
 With weight: 4
 
 On point:    location: 1.75 1.75 0.25
    idx:     (7,7,4)
-
 pt[0]:    location: 1.75 1.75 0.25
    idx:     (7,7,4)
-
 With weight: -24
 pt[1]:    location:  1.75  1.75 -0.25
    idx:     (7,7,3)
-
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.25
    idx:     (7,6,4)
-
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.25
    idx:     (6,7,4)
-
 With weight: 4
 pt[4]:    location: 2.25 1.75 0.25
    idx:     (8,7,4)
-
 With weight: 4
 pt[5]:    location: 1.75 2.25 0.25
    idx:     (7,8,4)
-
 With weight: 4
 pt[6]:    location: 1.75 1.75 0.75
    idx:     (7,7,5)
-
 With weight: 4
 
 On point:    location: -1.75 -1.75  0.75
    idx:     (0,0,5)
-
 pt[0]:    location: -1.75 -1.75  0.75
    idx:     (0,0,5)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.75  0.25
    idx:     (0,0,4)
-
 With weight: 4
 pt[2]:    location: -1.75 -2.25  0.75
    idx:     (0,-1,5)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.75  0.75
    idx:     (-1,0,5)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.75  0.75
    idx:     (1,0,5)
-
 With weight: 4
 pt[5]:    location: -1.75 -1.25  0.75
    idx:     (0,1,5)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.75  1.25
    idx:     (0,0,6)
-
 With weight: 4
 
 On point:    location: -1.25 -1.75  0.75
    idx:     (1,0,5)
-
 pt[0]:    location: -1.25 -1.75  0.75
    idx:     (1,0,5)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.75  0.25
    idx:     (1,0,4)
-
 With weight: 4
 pt[2]:    location: -1.25 -2.25  0.75
    idx:     (1,-1,5)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.75  0.75
    idx:     (0,0,5)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.75  0.75
    idx:     (2,0,5)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.25  0.75
    idx:     (1,1,5)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.75  1.25
    idx:     (1,0,6)
-
 With weight: 4
 
 On point:    location: -0.75 -1.75  0.75
    idx:     (2,0,5)
-
 pt[0]:    location: -0.75 -1.75  0.75
    idx:     (2,0,5)
-
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75  0.25
    idx:     (2,0,4)
-
 With weight: 4
 pt[2]:    location: -0.75 -2.25  0.75
    idx:     (2,-1,5)
-
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75  0.75
    idx:     (1,0,5)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.75  0.75
    idx:     (3,0,5)
-
 With weight: 4
 pt[5]:    location: -0.75 -1.75  1.25
    idx:     (2,0,6)
-
 With weight: 4
 pt[6]:    location: -0.75 -2.25  0.25
    idx:     (2,-1,4)
-
 With weight: 1.05525e-15
 
 On point:    location: -0.25 -1.75  0.75
    idx:     (3,0,5)
-
 pt[0]:    location: -0.25 -1.75  0.75
    idx:     (3,0,5)
-
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75  0.25
    idx:     (3,0,4)
-
 With weight: 4
 pt[2]:    location: -0.25 -2.25  0.75
    idx:     (3,-1,5)
-
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75  0.75
    idx:     (2,0,5)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.75  0.75
    idx:     (4,0,5)
-
 With weight: 4
 pt[5]:    location: -0.25 -1.75  1.25
    idx:     (3,0,6)
-
 With weight: 4
 pt[6]:    location: -0.25 -2.25  0.25
    idx:     (3,-1,4)
-
 With weight: 1.05525e-15
 
 On point:    location:  0.25 -1.75  0.75
    idx:     (4,0,5)
-
 pt[0]:    location:  0.25 -1.75  0.75
    idx:     (4,0,5)
-
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75  0.25
    idx:     (4,0,4)
-
 With weight: 4
 pt[2]:    location:  0.25 -2.25  0.75
    idx:     (4,-1,5)
-
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75  0.75
    idx:     (3,0,5)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.75  0.75
    idx:     (5,0,5)
-
 With weight: 4
 pt[5]:    location:  0.25 -1.75  1.25
    idx:     (4,0,6)
-
 With weight: 4
 pt[6]:    location:  0.25 -2.25  0.25
    idx:     (4,-1,4)
-
 With weight: 1.05525e-15
 
 On point:    location:  0.75 -1.75  0.75
    idx:     (5,0,5)
-
 pt[0]:    location:  0.75 -1.75  0.75
    idx:     (5,0,5)
-
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75  0.25
    idx:     (5,0,4)
-
 With weight: 4
 pt[2]:    location:  0.75 -2.25  0.75
    idx:     (5,-1,5)
-
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75  0.75
    idx:     (4,0,5)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.75  0.75
    idx:     (6,0,5)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.75  1.25
    idx:     (5,0,6)
-
 With weight: 4
 pt[6]:    location:  0.75 -2.25  0.25
    idx:     (5,-1,4)
-
 With weight: 1.05525e-15
 
 On point:    location:  1.25 -1.75  0.75
    idx:     (6,0,5)
-
 pt[0]:    location:  1.25 -1.75  0.75
    idx:     (6,0,5)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.75  0.25
    idx:     (6,0,4)
-
 With weight: 4
 pt[2]:    location:  1.25 -2.25  0.75
    idx:     (6,-1,5)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.75  0.75
    idx:     (5,0,5)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.75  0.75
    idx:     (7,0,5)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.25  0.75
    idx:     (6,1,5)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.75  1.25
    idx:     (6,0,6)
-
 With weight: 4
 
 On point:    location:  1.75 -1.75  0.75
    idx:     (7,0,5)
-
 pt[0]:    location:  1.75 -1.75  0.75
    idx:     (7,0,5)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.75  0.25
    idx:     (7,0,4)
-
 With weight: 4
 pt[2]:    location:  1.75 -2.25  0.75
    idx:     (7,-1,5)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.75  0.75
    idx:     (6,0,5)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.75  0.75
    idx:     (8,0,5)
-
 With weight: 4
 pt[5]:    location:  1.75 -1.25  0.75
    idx:     (7,1,5)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.75  1.25
    idx:     (7,0,6)
-
 With weight: 4
 
 On point:    location: -1.75 -1.25  0.75
    idx:     (0,1,5)
-
 pt[0]:    location: -1.75 -1.25  0.75
    idx:     (0,1,5)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.25  0.25
    idx:     (0,1,4)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.75  0.75
    idx:     (0,0,5)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.25  0.75
    idx:     (-1,1,5)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.25  0.75
    idx:     (1,1,5)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.75
    idx:     (0,2,5)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.25  1.25
    idx:     (0,1,6)
-
 With weight: 4
 
 On point:    location: -1.25 -1.25  0.75
    idx:     (1,1,5)
-
 pt[0]:    location: -1.25 -1.25  0.75
    idx:     (1,1,5)
-
 With weight: -13.3333
 pt[1]:    location: -1.25 -1.25  0.25
    idx:     (1,1,4)
-
 With weight: 4
 pt[2]:    location: -1.25 -1.75  0.75
    idx:     (1,0,5)
-
 With weight: 2.66667
 pt[3]:    location: -1.75 -1.25  0.75
    idx:     (0,1,5)
-
 With weight: 2.66667
 pt[4]:    location: -1.25 -1.25  1.25
    idx:     (1,1,6)
-
 With weight: 4
 pt[5]:    location: -1.75 -1.25  0.25
    idx:     (0,1,4)
-
 With weight: -1.19224e-15
 pt[6]:    location: -1.75 -1.75  0.75
    idx:     (0,0,5)
-
 With weight: 1.05205e-15
 
 On point:    location:  1.25 -1.25  0.75
    idx:     (6,1,5)
-
 pt[0]:    location:  1.25 -1.25  0.75
    idx:     (6,1,5)
-
 With weight: -13.9608
 pt[1]:    location:  1.25 -1.25  0.25
    idx:     (6,1,4)
-
 With weight: 4
 pt[2]:    location:  1.25 -1.75  0.75
    idx:     (6,0,5)
-
 With weight: 0.784314
 pt[3]:    location:  1.75 -1.25  0.75
    idx:     (7,1,5)
-
 With weight: 3.29412
 pt[4]:    location:  1.25 -1.25  1.25
    idx:     (6,1,6)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.75  0.25
    idx:     (6,0,4)
-
 With weight: -6.71904e-17
 pt[6]:    location:  0.75 -1.75  0.75
    idx:     (5,0,5)
-
 With weight: 1.88235
 
 On point:    location:  1.75 -1.25  0.75
    idx:     (7,1,5)
-
 pt[0]:    location:  1.75 -1.25  0.75
    idx:     (7,1,5)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.25  0.25
    idx:     (7,1,4)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.75  0.75
    idx:     (7,0,5)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.25  0.75
    idx:     (6,1,5)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.25  0.75
    idx:     (8,1,5)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.75
    idx:     (7,2,5)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.25  1.25
    idx:     (7,1,6)
-
 With weight: 4
 
 On point:    location: -1.75 -0.75  0.75
    idx:     (0,2,5)
-
 pt[0]:    location: -1.75 -0.75  0.75
    idx:     (0,2,5)
-
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75  0.25
    idx:     (0,2,4)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.25  0.75
    idx:     (0,1,5)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.75  0.75
    idx:     (-1,2,5)
-
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25  0.75
    idx:     (0,3,5)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75  1.25
    idx:     (0,2,6)
-
 With weight: 4
 pt[6]:    location: -2.25 -0.75  0.25
    idx:     (-1,2,4)
-
 With weight: 1.13062e-15
 
 On point:    location:  1.75 -0.75  0.75
    idx:     (7,2,5)
-
 pt[0]:    location:  1.75 -0.75  0.75
    idx:     (7,2,5)
-
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.75  0.25
    idx:     (7,2,4)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.25  0.75
    idx:     (7,1,5)
-
 With weight: 4
 pt[3]:    location:  2.25 -0.75  0.75
    idx:     (8,2,5)
-
 With weight: 2.66667
 pt[4]:    location:  1.75 -0.25  0.75
    idx:     (7,3,5)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75  1.25
    idx:     (7,2,6)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.25  0.25
    idx:     (7,3,4)
-
 With weight: 2.60649e-16
 
 On point:    location: -1.75 -0.25  0.75
    idx:     (0,3,5)
-
 pt[0]:    location: -1.75 -0.25  0.75
    idx:     (0,3,5)
-
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25  0.25
    idx:     (0,3,4)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.75  0.75
    idx:     (0,2,5)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.25  0.75
    idx:     (-1,3,5)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25  0.75
    idx:     (0,4,5)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.25  1.25
    idx:     (0,3,6)
-
 With weight: 4
 pt[6]:    location: -1.75 -0.75  0.25
    idx:     (0,2,4)
-
 With weight: -7.27074e-16
 
 On point:    location:  1.75 -0.25  0.75
    idx:     (7,3,5)
-
 pt[0]:    location:  1.75 -0.25  0.75
    idx:     (7,3,5)
-
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25  0.25
    idx:     (7,3,4)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.75  0.75
    idx:     (7,2,5)
-
 With weight: 4
 pt[3]:    location:  2.25 -0.25  0.75
    idx:     (8,3,5)
-
 With weight: 2.66667
 pt[4]:    location: 1.75 0.25 0.75
    idx:     (7,4,5)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.25  1.25
    idx:     (7,3,6)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.75  0.25
    idx:     (7,2,4)
-
 With weight: -7.27074e-16
 
 On point:    location: -1.75  0.25  0.75
    idx:     (0,4,5)
-
 pt[0]:    location: -1.75  0.25  0.75
    idx:     (0,4,5)
-
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25  0.25
    idx:     (0,4,4)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.25  0.75
    idx:     (0,3,5)
-
 With weight: 4
 pt[3]:    location: -2.25  0.25  0.75
    idx:     (-1,4,5)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75  0.75
    idx:     (0,5,5)
-
 With weight: 4
 pt[5]:    location: -1.75  0.25  1.25
    idx:     (0,4,6)
-
 With weight: 4
 pt[6]:    location: -2.25  0.25  0.25
    idx:     (-1,4,4)
-
 With weight: 1.13062e-15
 
 On point:    location: 1.75 0.25 0.75
    idx:     (7,4,5)
-
 pt[0]:    location: 1.75 0.25 0.75
    idx:     (7,4,5)
-
 With weight: -18.6667
 pt[1]:    location: 1.75 0.25 0.25
    idx:     (7,4,4)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.25  0.75
    idx:     (7,3,5)
-
 With weight: 4
 pt[3]:    location: 2.25 0.25 0.75
    idx:     (8,4,5)
-
 With weight: 2.66667
 pt[4]:    location: 1.75 0.75 0.75
    idx:     (7,5,5)
-
 With weight: 4
 pt[5]:    location: 1.75 0.25 1.25
    idx:     (7,4,6)
-
 With weight: 4
 pt[6]:    location: 1.75 0.75 0.25
    idx:     (7,5,4)
-
 With weight: 2.60649e-16
 
 On point:    location: -1.75  0.75  0.75
    idx:     (0,5,5)
-
 pt[0]:    location: -1.75  0.75  0.75
    idx:     (0,5,5)
-
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75  0.25
    idx:     (0,5,4)
-
 With weight: 4
 pt[2]:    location: -1.75  0.25  0.75
    idx:     (0,4,5)
-
 With weight: 4
 pt[3]:    location: -2.25  0.75  0.75
    idx:     (-1,5,5)
-
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25  0.75
    idx:     (0,6,5)
-
 With weight: 4
 pt[5]:    location: -1.75  0.75  1.25
    idx:     (0,5,6)
-
 With weight: 4
 pt[6]:    location: -1.75  0.25  0.25
    idx:     (0,4,4)
-
 With weight: -7.27074e-16
 
 On point:    location: 1.75 0.75 0.75
    idx:     (7,5,5)
-
 pt[0]:    location: 1.75 0.75 0.75
    idx:     (7,5,5)
-
 With weight: -18.6667
 pt[1]:    location: 1.75 0.75 0.25
    idx:     (7,5,4)
-
 With weight: 4
 pt[2]:    location: 1.75 0.25 0.75
    idx:     (7,4,5)
-
 With weight: 4
 pt[3]:    location: 2.25 0.75 0.75
    idx:     (8,5,5)
-
 With weight: 2.66667
 pt[4]:    location: 1.75 1.25 0.75
    idx:     (7,6,5)
-
 With weight: 4
 pt[5]:    location: 1.75 0.75 1.25
    idx:     (7,5,6)
-
 With weight: 4
 pt[6]:    location: 1.75 0.25 0.25
    idx:     (7,4,4)
-
 With weight: -7.27074e-16
 
 On point:    location: -1.75  1.25  0.75
    idx:     (0,6,5)
-
 pt[0]:    location: -1.75  1.25  0.75
    idx:     (0,6,5)
-
 With weight: -24
 pt[1]:    location: -1.75  1.25  0.25
    idx:     (0,6,4)
-
 With weight: 4
 pt[2]:    location: -1.75  0.75  0.75
    idx:     (0,5,5)
-
 With weight: 4
 pt[3]:    location: -2.25  1.25  0.75
    idx:     (-1,6,5)
-
 With weight: 4
 pt[4]:    location: -1.25  1.25  0.75
    idx:     (1,6,5)
-
 With weight: 4
 pt[5]:    location: -1.75  1.75  0.75
    idx:     (0,7,5)
-
 With weight: 4
 pt[6]:    location: -1.75  1.25  1.25
    idx:     (0,6,6)
-
 With weight: 4
 
 On point:    location: -1.25  1.25  0.75
    idx:     (1,6,5)
-
 pt[0]:    location: -1.25  1.25  0.75
    idx:     (1,6,5)
-
 With weight: -13.3333
 pt[1]:    location: -1.25  1.25  0.25
    idx:     (1,6,4)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.75
    idx:     (0,6,5)
-
 With weight: 2.66667
 pt[3]:    location: -1.25  1.75  0.75
    idx:     (1,7,5)
-
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25  1.25
    idx:     (1,6,6)
-
 With weight: 4
 pt[5]:    location: -1.75  1.25  0.25
    idx:     (0,6,4)
-
 With weight: 3.03817e-17
 pt[6]:    location: -1.25  1.75  0.25
    idx:     (1,7,4)
-
 With weight: -3.14198e-16
 
 On point:    location: 1.25 1.25 0.75
    idx:     (6,6,5)
-
 pt[0]:    location: 1.25 1.25 0.75
    idx:     (6,6,5)
-
 With weight: -13.9608
 pt[1]:    location: 1.25 1.25 0.25
    idx:     (6,6,4)
-
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.75
    idx:     (7,6,5)
-
 With weight: 3.29412
 pt[3]:    location: 1.25 1.75 0.75
    idx:     (6,7,5)
-
 With weight: 0.784314
 pt[4]:    location: 1.25 1.25 1.25
    idx:     (6,6,6)
-
 With weight: 4
 pt[5]:    location: 1.25 1.75 0.25
    idx:     (6,7,4)
-
 With weight: 2.01571e-16
 pt[6]:    location: 0.75 1.75 0.75
    idx:     (5,7,5)
-
 With weight: 1.88235
 
 On point:    location: 1.75 1.25 0.75
    idx:     (7,6,5)
-
 pt[0]:    location: 1.75 1.25 0.75
    idx:     (7,6,5)
-
 With weight: -24
 pt[1]:    location: 1.75 1.25 0.25
    idx:     (7,6,4)
-
 With weight: 4
 pt[2]:    location: 1.75 0.75 0.75
    idx:     (7,5,5)
-
 With weight: 4
 pt[3]:    location: 1.25 1.25 0.75
    idx:     (6,6,5)
-
 With weight: 4
 pt[4]:    location: 2.25 1.25 0.75
    idx:     (8,6,5)
-
 With weight: 4
 pt[5]:    location: 1.75 1.75 0.75
    idx:     (7,7,5)
-
 With weight: 4
 pt[6]:    location: 1.75 1.25 1.25
    idx:     (7,6,6)
-
 With weight: 4
 
 On point:    location: -1.75  1.75  0.75
    idx:     (0,7,5)
-
 pt[0]:    location: -1.75  1.75  0.75
    idx:     (0,7,5)
-
 With weight: -24
 pt[1]:    location: -1.75  1.75  0.25
    idx:     (0,7,4)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.75
    idx:     (0,6,5)
-
 With weight: 4
 pt[3]:    location: -2.25  1.75  0.75
    idx:     (-1,7,5)
-
 With weight: 4
 pt[4]:    location: -1.25  1.75  0.75
    idx:     (1,7,5)
-
 With weight: 4
 pt[5]:    location: -1.75  2.25  0.75
    idx:     (0,8,5)
-
 With weight: 4
 pt[6]:    location: -1.75  1.75  1.25
    idx:     (0,7,6)
-
 With weight: 4
 
 On point:    location: -1.25  1.75  0.75
    idx:     (1,7,5)
-
 pt[0]:    location: -1.25  1.75  0.75
    idx:     (1,7,5)
-
 With weight: -24
 pt[1]:    location: -1.25  1.75  0.25
    idx:     (1,7,4)
-
 With weight: 4
 pt[2]:    location: -1.25  1.25  0.75
    idx:     (1,6,5)
-
 With weight: 4
 pt[3]:    location: -1.75  1.75  0.75
    idx:     (0,7,5)
-
 With weight: 4
 pt[4]:    location: -0.75  1.75  0.75
    idx:     (2,7,5)
-
 With weight: 4
 pt[5]:    location: -1.25  2.25  0.75
    idx:     (1,8,5)
-
 With weight: 4
 pt[6]:    location: -1.25  1.75  1.25
    idx:     (1,7,6)
-
 With weight: 4
 
 On point:    location: -0.75  1.75  0.75
    idx:     (2,7,5)
-
 pt[0]:    location: -0.75  1.75  0.75
    idx:     (2,7,5)
-
 With weight: -18.6667
 pt[1]:    location: -0.75  1.75  0.25
    idx:     (2,7,4)
-
 With weight: 4
 pt[2]:    location: -1.25  1.75  0.75
    idx:     (1,7,5)
-
 With weight: 4
 pt[3]:    location: -0.25  1.75  0.75
    idx:     (3,7,5)
-
 With weight: 4
 pt[4]:    location: -0.75  2.25  0.75
    idx:     (2,8,5)
-
 With weight: 2.66667
 pt[5]:    location: -0.75  1.75  1.25
    idx:     (2,7,6)
-
 With weight: 4
 pt[6]:    location: -0.25  1.75  0.25
    idx:     (3,7,4)
-
 With weight: 1.09747e-15
 
 On point:    location: -0.25  1.75  0.75
    idx:     (3,7,5)
-
 pt[0]:    location: -0.25  1.75  0.75
    idx:     (3,7,5)
-
 With weight: -18.6667
 pt[1]:    location: -0.25  1.75  0.25
    idx:     (3,7,4)
-
 With weight: 4
 pt[2]:    location: -0.75  1.75  0.75
    idx:     (2,7,5)
-
 With weight: 4
 pt[3]:    location: 0.25 1.75 0.75
    idx:     (4,7,5)
-
 With weight: 4
 pt[4]:    location: -0.25  2.25  0.75
    idx:     (3,8,5)
-
 With weight: 2.66667
 pt[5]:    location: -0.25  1.75  1.25
    idx:     (3,7,6)
-
 With weight: 4
 pt[6]:    location: -0.75  1.75  0.25
    idx:     (2,7,4)
-
 With weight: 8.23102e-16
 
 On point:    location: 0.25 1.75 0.75
    idx:     (4,7,5)
-
 pt[0]:    location: 0.25 1.75 0.75
    idx:     (4,7,5)
-
 With weight: -18.6667
 pt[1]:    location: 0.25 1.75 0.25
    idx:     (4,7,4)
-
 With weight: 4
 pt[2]:    location: -0.25  1.75  0.75
    idx:     (3,7,5)
-
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.75
    idx:     (5,7,5)
-
 With weight: 4
 pt[4]:    location: 0.25 2.25 0.75
    idx:     (4,8,5)
-
 With weight: 2.66667
 pt[5]:    location: 0.25 1.75 1.25
    idx:     (4,7,6)
-
 With weight: 4
 pt[6]:    location: 0.75 1.75 0.25
    idx:     (5,7,4)
-
 With weight: 1.09747e-15
 
 On point:    location: 0.75 1.75 0.75
    idx:     (5,7,5)
-
 pt[0]:    location: 0.75 1.75 0.75
    idx:     (5,7,5)
-
 With weight: -18.6667
 pt[1]:    location: 0.75 1.75 0.25
    idx:     (5,7,4)
-
 With weight: 4
 pt[2]:    location: 0.25 1.75 0.75
    idx:     (4,7,5)
-
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.75
    idx:     (6,7,5)
-
 With weight: 4
 pt[4]:    location: 0.75 2.25 0.75
    idx:     (5,8,5)
-
 With weight: 2.66667
 pt[5]:    location: 0.75 1.75 1.25
    idx:     (5,7,6)
-
 With weight: 4
 pt[6]:    location: 0.25 1.75 0.25
    idx:     (4,7,4)
-
 With weight: 8.23102e-16
 
 On point:    location: 1.25 1.75 0.75
    idx:     (6,7,5)
-
 pt[0]:    location: 1.25 1.75 0.75
    idx:     (6,7,5)
-
 With weight: -24
 pt[1]:    location: 1.25 1.75 0.25
    idx:     (6,7,4)
-
 With weight: 4
 pt[2]:    location: 1.25 1.25 0.75
    idx:     (6,6,5)
-
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.75
    idx:     (5,7,5)
-
 With weight: 4
 pt[4]:    location: 1.75 1.75 0.75
    idx:     (7,7,5)
-
 With weight: 4
 pt[5]:    location: 1.25 2.25 0.75
    idx:     (6,8,5)
-
 With weight: 4
 pt[6]:    location: 1.25 1.75 1.25
    idx:     (6,7,6)
-
 With weight: 4
 
 On point:    location: 1.75 1.75 0.75
    idx:     (7,7,5)
-
 pt[0]:    location: 1.75 1.75 0.75
    idx:     (7,7,5)
-
 With weight: -24
 pt[1]:    location: 1.75 1.75 0.25
    idx:     (7,7,4)
-
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.75
    idx:     (7,6,5)
-
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.75
    idx:     (6,7,5)
-
 With weight: 4
 pt[4]:    location: 2.25 1.75 0.75
    idx:     (8,7,5)
-
 With weight: 4
 pt[5]:    location: 1.75 2.25 0.75
    idx:     (7,8,5)
-
 With weight: 4
 pt[6]:    location: 1.75 1.75 1.25
    idx:     (7,7,6)
-
 With weight: 4
 
 On point:    location: -1.75 -1.75  1.25
    idx:     (0,0,6)
-
 pt[0]:    location: -1.75 -1.75  1.25
    idx:     (0,0,6)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.75  0.75
    idx:     (0,0,5)
-
 With weight: 4
 pt[2]:    location: -1.75 -2.25  1.25
    idx:     (0,-1,6)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.75  1.25
    idx:     (-1,0,6)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.75  1.25
    idx:     (1,0,6)
-
 With weight: 4
 pt[5]:    location: -1.75 -1.25  1.25
    idx:     (0,1,6)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.75  1.75
    idx:     (0,0,7)
-
 With weight: 4
 
 On point:    location: -1.25 -1.75  1.25
    idx:     (1,0,6)
-
 pt[0]:    location: -1.25 -1.75  1.25
    idx:     (1,0,6)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.75  0.75
    idx:     (1,0,5)
-
 With weight: 4
 pt[2]:    location: -1.25 -2.25  1.25
    idx:     (1,-1,6)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.75  1.25
    idx:     (0,0,6)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.75  1.25
    idx:     (2,0,6)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.25  1.25
    idx:     (1,1,6)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.75  1.75
    idx:     (1,0,7)
-
 With weight: 4
 
 On point:    location: -0.75 -1.75  1.25
    idx:     (2,0,6)
-
 pt[0]:    location: -0.75 -1.75  1.25
    idx:     (2,0,6)
-
 With weight: -24
 pt[1]:    location: -0.75 -1.75  0.75
    idx:     (2,0,5)
-
 With weight: 4
 pt[2]:    location: -0.75 -2.25  1.25
    idx:     (2,-1,6)
-
 With weight: 4
 pt[3]:    location: -1.25 -1.75  1.25
    idx:     (1,0,6)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.75  1.25
    idx:     (3,0,6)
-
 With weight: 4
 pt[5]:    location: -0.75 -1.25  1.25
    idx:     (2,1,6)
-
 With weight: 4
 pt[6]:    location: -0.75 -1.75  1.75
    idx:     (2,0,7)
-
 With weight: 4
 
 On point:    location: -0.25 -1.75  1.25
    idx:     (3,0,6)
-
 pt[0]:    location: -0.25 -1.75  1.25
    idx:     (3,0,6)
-
 With weight: -24
 pt[1]:    location: -0.25 -1.75  0.75
    idx:     (3,0,5)
-
 With weight: 4
 pt[2]:    location: -0.25 -2.25  1.25
    idx:     (3,-1,6)
-
 With weight: 4
 pt[3]:    location: -0.75 -1.75  1.25
    idx:     (2,0,6)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.75  1.25
    idx:     (4,0,6)
-
 With weight: 4
 pt[5]:    location: -0.25 -1.25  1.25
    idx:     (3,1,6)
-
 With weight: 4
 pt[6]:    location: -0.25 -1.75  1.75
    idx:     (3,0,7)
-
 With weight: 4
 
 On point:    location:  0.25 -1.75  1.25
    idx:     (4,0,6)
-
 pt[0]:    location:  0.25 -1.75  1.25
    idx:     (4,0,6)
-
 With weight: -24
 pt[1]:    location:  0.25 -1.75  0.75
    idx:     (4,0,5)
-
 With weight: 4
 pt[2]:    location:  0.25 -2.25  1.25
    idx:     (4,-1,6)
-
 With weight: 4
 pt[3]:    location: -0.25 -1.75  1.25
    idx:     (3,0,6)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.75  1.25
    idx:     (5,0,6)
-
 With weight: 4
 pt[5]:    location:  0.25 -1.25  1.25
    idx:     (4,1,6)
-
 With weight: 4
 pt[6]:    location:  0.25 -1.75  1.75
    idx:     (4,0,7)
-
 With weight: 4
 
 On point:    location:  0.75 -1.75  1.25
    idx:     (5,0,6)
-
 pt[0]:    location:  0.75 -1.75  1.25
    idx:     (5,0,6)
-
 With weight: -24
 pt[1]:    location:  0.75 -1.75  0.75
    idx:     (5,0,5)
-
 With weight: 4
 pt[2]:    location:  0.75 -2.25  1.25
    idx:     (5,-1,6)
-
 With weight: 4
 pt[3]:    location:  0.25 -1.75  1.25
    idx:     (4,0,6)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.75  1.25
    idx:     (6,0,6)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.25  1.25
    idx:     (5,1,6)
-
 With weight: 4
 pt[6]:    location:  0.75 -1.75  1.75
    idx:     (5,0,7)
-
 With weight: 4
 
 On point:    location:  1.25 -1.75  1.25
    idx:     (6,0,6)
-
 pt[0]:    location:  1.25 -1.75  1.25
    idx:     (6,0,6)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.75  0.75
    idx:     (6,0,5)
-
 With weight: 4
 pt[2]:    location:  1.25 -2.25  1.25
    idx:     (6,-1,6)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.75  1.25
    idx:     (5,0,6)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.75  1.25
    idx:     (7,0,6)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.25  1.25
    idx:     (6,1,6)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.75  1.75
    idx:     (6,0,7)
-
 With weight: 4
 
 On point:    location:  1.75 -1.75  1.25
    idx:     (7,0,6)
-
 pt[0]:    location:  1.75 -1.75  1.25
    idx:     (7,0,6)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.75  0.75
    idx:     (7,0,5)
-
 With weight: 4
 pt[2]:    location:  1.75 -2.25  1.25
    idx:     (7,-1,6)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.75  1.25
    idx:     (6,0,6)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.75  1.25
    idx:     (8,0,6)
-
 With weight: 4
 pt[5]:    location:  1.75 -1.25  1.25
    idx:     (7,1,6)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.75  1.75
    idx:     (7,0,7)
-
 With weight: 4
 
 On point:    location: -1.75 -1.25  1.25
    idx:     (0,1,6)
-
 pt[0]:    location: -1.75 -1.25  1.25
    idx:     (0,1,6)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.25  0.75
    idx:     (0,1,5)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.75  1.25
    idx:     (0,0,6)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.25  1.25
    idx:     (-1,1,6)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.25  1.25
    idx:     (1,1,6)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75  1.25
    idx:     (0,2,6)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.25  1.75
    idx:     (0,1,7)
-
 With weight: 4
 
 On point:    location: -1.25 -1.25  1.25
    idx:     (1,1,6)
-
 pt[0]:    location: -1.25 -1.25  1.25
    idx:     (1,1,6)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.25  0.75
    idx:     (1,1,5)
-
 With weight: 4
 pt[2]:    location: -1.25 -1.75  1.25
    idx:     (1,0,6)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.25  1.25
    idx:     (0,1,6)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.25  1.25
    idx:     (2,1,6)
-
 With weight: 4
 pt[5]:    location: -1.25 -0.75  1.25
    idx:     (1,2,6)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.25  1.75
    idx:     (1,1,7)
-
 With weight: 4
 
 On point:    location: -0.75 -1.25  1.25
    idx:     (2,1,6)
-
 pt[0]:    location: -0.75 -1.25  1.25
    idx:     (2,1,6)
-
 With weight: -13.9608
 pt[1]:    location: -0.75 -1.75  1.25
    idx:     (2,0,6)
-
 With weight: 0.784314
 pt[2]:    location: -1.25 -1.25  1.25
    idx:     (1,1,6)
-
 With weight: 4
 pt[3]:    location: -0.25 -1.25  1.25
    idx:     (3,1,6)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.25  1.75
    idx:     (2,1,7)
-
 With weight: 3.29412
 pt[5]:    location: -0.75 -1.75  0.75
    idx:     (2,0,5)
-
 With weight: 1.88235
 pt[6]:    location: -0.25 -1.75  1.25
    idx:     (3,0,6)
-
 With weight: 6.38308e-16
 
 On point:    location: -0.25 -1.25  1.25
    idx:     (3,1,6)
-
 pt[0]:    location: -0.25 -1.25  1.25
    idx:     (3,1,6)
-
 With weight: -13.9608
 pt[1]:    location: -0.25 -1.75  1.25
    idx:     (3,0,6)
-
 With weight: 0.784314
 pt[2]:    location: -0.75 -1.25  1.25
    idx:     (2,1,6)
-
 With weight: 4
 pt[3]:    location:  0.25 -1.25  1.25
    idx:     (4,1,6)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.25  1.75
    idx:     (3,1,7)
-
 With weight: 3.29412
 pt[5]:    location: -0.25 -1.75  0.75
    idx:     (3,0,5)
-
 With weight: 1.88235
 pt[6]:    location: -0.75 -1.75  1.25
    idx:     (2,0,6)
-
 With weight: -7.72689e-16
 
 On point:    location:  0.25 -1.25  1.25
    idx:     (4,1,6)
-
 pt[0]:    location:  0.25 -1.25  1.25
    idx:     (4,1,6)
-
 With weight: -13.9608
 pt[1]:    location:  0.25 -1.75  1.25
    idx:     (4,0,6)
-
 With weight: 0.784314
 pt[2]:    location: -0.25 -1.25  1.25
    idx:     (3,1,6)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.25  1.25
    idx:     (5,1,6)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.25  1.75
    idx:     (4,1,7)
-
 With weight: 3.29412
 pt[5]:    location:  0.25 -1.75  0.75
    idx:     (4,0,5)
-
 With weight: 1.88235
 pt[6]:    location:  0.75 -1.75  1.25
    idx:     (5,0,6)
-
 With weight: 6.38308e-16
 
 On point:    location:  0.75 -1.25  1.25
    idx:     (5,1,6)
-
 pt[0]:    location:  0.75 -1.25  1.25
    idx:     (5,1,6)
-
 With weight: -14.1867
 pt[1]:    location:  0.75 -1.75  1.25
    idx:     (5,0,6)
-
 With weight: 1.38667
 pt[2]:    location:  0.25 -1.25  1.25
    idx:     (4,1,6)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.25  1.25
    idx:     (6,1,6)
-
 With weight: 2.72
 pt[4]:    location:  0.75 -1.25  1.75
    idx:     (5,1,7)
-
 With weight: 3.52
 pt[5]:    location:  0.75 -1.75  0.75
    idx:     (5,0,5)
-
 With weight: 1.28
 pt[6]:    location:  1.25 -1.25  0.75
    idx:     (6,1,5)
-
 With weight: 1.28
 
 On point:    location:  1.25 -1.25  1.25
    idx:     (6,1,6)
-
 pt[0]:    location:  1.25 -1.25  1.25
    idx:     (6,1,6)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.25  0.75
    idx:     (6,1,5)
-
 With weight: 4
 pt[2]:    location:  1.25 -1.75  1.25
    idx:     (6,0,6)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.25  1.25
    idx:     (5,1,6)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.25  1.25
    idx:     (7,1,6)
-
 With weight: 4
 pt[5]:    location:  1.25 -0.75  1.25
    idx:     (6,2,6)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.25  1.75
    idx:     (6,1,7)
-
 With weight: 4
 
 On point:    location:  1.75 -1.25  1.25
    idx:     (7,1,6)
-
 pt[0]:    location:  1.75 -1.25  1.25
    idx:     (7,1,6)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.25  0.75
    idx:     (7,1,5)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.75  1.25
    idx:     (7,0,6)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.25  1.25
    idx:     (6,1,6)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.25  1.25
    idx:     (8,1,6)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75  1.25
    idx:     (7,2,6)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.25  1.75
    idx:     (7,1,7)
-
 With weight: 4
 
 On point:    location: -1.75 -0.75  1.25
    idx:     (0,2,6)
-
 pt[0]:    location: -1.75 -0.75  1.25
    idx:     (0,2,6)
-
 With weight: -24
 pt[1]:    location: -1.75 -0.75  0.75
    idx:     (0,2,5)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.25  1.25
    idx:     (0,1,6)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.75  1.25
    idx:     (-1,2,6)
-
 With weight: 4
 pt[4]:    location: -1.25 -0.75  1.25
    idx:     (1,2,6)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.25  1.25
    idx:     (0,3,6)
-
 With weight: 4
 pt[6]:    location: -1.75 -0.75  1.75
    idx:     (0,2,7)
-
 With weight: 4
 
 On point:    location: -1.25 -0.75  1.25
    idx:     (1,2,6)
-
 pt[0]:    location: -1.25 -0.75  1.25
    idx:     (1,2,6)
-
 With weight: -13.9608
 pt[1]:    location: -1.25 -1.25  1.25
    idx:     (1,1,6)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.75  1.25
    idx:     (0,2,6)
-
 With weight: 0.784314
 pt[3]:    location: -1.25 -0.25  1.25
    idx:     (1,3,6)
-
 With weight: 4
 pt[4]:    location: -1.25 -0.75  1.75
    idx:     (1,2,7)
-
 With weight: 3.29412
 pt[5]:    location: -1.75 -0.75  0.75
    idx:     (0,2,5)
-
 With weight: 1.88235
 pt[6]:    location: -1.75 -0.25  1.25
    idx:     (0,3,6)
-
 With weight: 4.70333e-16
 
 On point:    location:  1.25 -0.75  1.25
    idx:     (6,2,6)
-
 pt[0]:    location:  1.25 -0.75  1.25
    idx:     (6,2,6)
-
 With weight: -14.1867
 pt[1]:    location:  1.25 -1.25  1.25
    idx:     (6,1,6)
-
 With weight: 2.72
 pt[2]:    location:  1.75 -0.75  1.25
    idx:     (7,2,6)
-
 With weight: 1.38667
 pt[3]:    location:  1.25 -0.25  1.25
    idx:     (6,3,6)
-
 With weight: 4
 pt[4]:    location:  1.25 -0.75  1.75
    idx:     (6,2,7)
-
 With weight: 3.52
 pt[5]:    location:  1.25 -1.25  0.75
    idx:     (6,1,5)
-
 With weight: 1.28
 pt[6]:    location:  1.75 -0.75  0.75
    idx:     (7,2,5)
-
 With weight: 1.28
 
 On point:    location:  1.75 -0.75  1.25
    idx:     (7,2,6)
-
 pt[0]:    location:  1.75 -0.75  1.25
    idx:     (7,2,6)
-
 With weight: -24
 pt[1]:    location:  1.75 -0.75  0.75
    idx:     (7,2,5)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.25  1.25
    idx:     (7,1,6)
-
 With weight: 4
 pt[3]:    location:  1.25 -0.75  1.25
    idx:     (6,2,6)
-
 With weight: 4
 pt[4]:    location:  2.25 -0.75  1.25
    idx:     (8,2,6)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.25  1.25
    idx:     (7,3,6)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.75  1.75
    idx:     (7,2,7)
-
 With weight: 4
 
 On point:    location: -1.75 -0.25  1.25
    idx:     (0,3,6)
-
 pt[0]:    location: -1.75 -0.25  1.25
    idx:     (0,3,6)
-
 With weight: -24
 pt[1]:    location: -1.75 -0.25  0.75
    idx:     (0,3,5)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.75  1.25
    idx:     (0,2,6)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.25  1.25
    idx:     (-1,3,6)
-
 With weight: 4
 pt[4]:    location: -1.25 -0.25  1.25
    idx:     (1,3,6)
-
 With weight: 4
 pt[5]:    location: -1.75  0.25  1.25
    idx:     (0,4,6)
-
 With weight: 4
 pt[6]:    location: -1.75 -0.25  1.75
    idx:     (0,3,7)
-
 With weight: 4
 
 On point:    location: -1.25 -0.25  1.25
    idx:     (1,3,6)
-
 pt[0]:    location: -1.25 -0.25  1.25
    idx:     (1,3,6)
-
 With weight: -13.9608
 pt[1]:    location: -1.25 -0.75  1.25
    idx:     (1,2,6)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.25  1.25
    idx:     (0,3,6)
-
 With weight: 0.784314
 pt[3]:    location: -1.25  0.25  1.25
    idx:     (1,4,6)
-
 With weight: 4
 pt[4]:    location: -1.25 -0.25  1.75
    idx:     (1,3,7)
-
 With weight: 3.29412
 pt[5]:    location: -1.75 -0.25  0.75
    idx:     (0,3,5)
-
 With weight: 1.88235
 pt[6]:    location: -1.75 -0.75  1.25
    idx:     (0,2,6)
-
 With weight: -6.71904e-16
 
 On point:    location:  1.25 -0.25  1.25
    idx:     (6,3,6)
-
 pt[0]:    location:  1.25 -0.25  1.25
    idx:     (6,3,6)
-
 With weight: -13.9608
 pt[1]:    location:  1.25 -0.75  1.25
    idx:     (6,2,6)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.25  1.25
    idx:     (7,3,6)
-
 With weight: 0.784314
 pt[3]:    location: 1.25 0.25 1.25
    idx:     (6,4,6)
-
 With weight: 4
 pt[4]:    location:  1.25 -0.25  1.75
    idx:     (6,3,7)
-
 With weight: 3.29412
 pt[5]:    location:  1.75 -0.25  0.75
    idx:     (7,3,5)
-
 With weight: 1.88235
 pt[6]:    location:  1.75 -0.75  1.25
    idx:     (7,2,6)
-
 With weight: -6.71904e-16
 
 On point:    location:  1.75 -0.25  1.25
    idx:     (7,3,6)
-
 pt[0]:    location:  1.75 -0.25  1.25
    idx:     (7,3,6)
-
 With weight: -24
 pt[1]:    location:  1.75 -0.25  0.75
    idx:     (7,3,5)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.75  1.25
    idx:     (7,2,6)
-
 With weight: 4
 pt[3]:    location:  1.25 -0.25  1.25
    idx:     (6,3,6)
-
 With weight: 4
 pt[4]:    location:  2.25 -0.25  1.25
    idx:     (8,3,6)
-
 With weight: 4
 pt[5]:    location: 1.75 0.25 1.25
    idx:     (7,4,6)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.25  1.75
    idx:     (7,3,7)
-
 With weight: 4
 
 On point:    location: -1.75  0.25  1.25
    idx:     (0,4,6)
-
 pt[0]:    location: -1.75  0.25  1.25
    idx:     (0,4,6)
-
 With weight: -24
 pt[1]:    location: -1.75  0.25  0.75
    idx:     (0,4,5)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.25  1.25
    idx:     (0,3,6)
-
 With weight: 4
 pt[3]:    location: -2.25  0.25  1.25
    idx:     (-1,4,6)
-
 With weight: 4
 pt[4]:    location: -1.25  0.25  1.25
    idx:     (1,4,6)
-
 With weight: 4
 pt[5]:    location: -1.75  0.75  1.25
    idx:     (0,5,6)
-
 With weight: 4
 pt[6]:    location: -1.75  0.25  1.75
    idx:     (0,4,7)
-
 With weight: 4
 
 On point:    location: -1.25  0.25  1.25
    idx:     (1,4,6)
-
 pt[0]:    location: -1.25  0.25  1.25
    idx:     (1,4,6)
-
 With weight: -13.9608
 pt[1]:    location: -1.25 -0.25  1.25
    idx:     (1,3,6)
-
 With weight: 4
 pt[2]:    location: -1.75  0.25  1.25
    idx:     (0,4,6)
-
 With weight: 0.784314
 pt[3]:    location: -1.25  0.75  1.25
    idx:     (1,5,6)
-
 With weight: 4
 pt[4]:    location: -1.25  0.25  1.75
    idx:     (1,4,7)
-
 With weight: 3.29412
 pt[5]:    location: -1.75  0.25  0.75
    idx:     (0,4,5)
-
 With weight: 1.88235
 pt[6]:    location: -1.75  0.75  1.25
    idx:     (0,5,6)
-
 With weight: 4.70333e-16
 
 On point:    location: 1.25 0.25 1.25
    idx:     (6,4,6)
-
 pt[0]:    location: 1.25 0.25 1.25
    idx:     (6,4,6)
-
 With weight: -14.8571
 pt[1]:    location:  1.25 -0.25  1.25
    idx:     (6,3,6)
-
 With weight: 4
 pt[2]:    location: 1.75 0.25 1.25
    idx:     (7,4,6)
-
 With weight: 1.14286
 pt[3]:    location: 1.25 0.75 1.25
    idx:     (6,5,6)
-
 With weight: 4
 pt[4]:    location: 1.25 0.25 1.75
    idx:     (6,4,7)
-
 With weight: 1.14286
 pt[5]:    location: 1.75 0.25 0.75
    idx:     (7,4,5)
-
 With weight: 2.28571
 pt[6]:    location: 0.75 0.25 1.75
    idx:     (5,4,7)
-
 With weight: 2.28571
 
 On point:    location: 1.75 0.25 1.25
    idx:     (7,4,6)
-
 pt[0]:    location: 1.75 0.25 1.25
    idx:     (7,4,6)
-
 With weight: -24
 pt[1]:    location: 1.75 0.25 0.75
    idx:     (7,4,5)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.25  1.25
    idx:     (7,3,6)
-
 With weight: 4
 pt[3]:    location: 1.25 0.25 1.25
    idx:     (6,4,6)
-
 With weight: 4
 pt[4]:    location: 2.25 0.25 1.25
    idx:     (8,4,6)
-
 With weight: 4
 pt[5]:    location: 1.75 0.75 1.25
    idx:     (7,5,6)
-
 With weight: 4
 pt[6]:    location: 1.75 0.25 1.75
    idx:     (7,4,7)
-
 With weight: 4
 
 On point:    location: -1.75  0.75  1.25
    idx:     (0,5,6)
-
 pt[0]:    location: -1.75  0.75  1.25
    idx:     (0,5,6)
-
 With weight: -24
 pt[1]:    location: -1.75  0.75  0.75
    idx:     (0,5,5)
-
 With weight: 4
 pt[2]:    location: -1.75  0.25  1.25
    idx:     (0,4,6)
-
 With weight: 4
 pt[3]:    location: -2.25  0.75  1.25
    idx:     (-1,5,6)
-
 With weight: 4
 pt[4]:    location: -1.25  0.75  1.25
    idx:     (1,5,6)
-
 With weight: 4
 pt[5]:    location: -1.75  1.25  1.25
    idx:     (0,6,6)
-
 With weight: 4
 pt[6]:    location: -1.75  0.75  1.75
    idx:     (0,5,7)
-
 With weight: 4
 
 On point:    location: -1.25  0.75  1.25
    idx:     (1,5,6)
-
 pt[0]:    location: -1.25  0.75  1.25
    idx:     (1,5,6)
-
 With weight: -13.9608
 pt[1]:    location: -1.25  0.25  1.25
    idx:     (1,4,6)
-
 With weight: 4
 pt[2]:    location: -1.75  0.75  1.25
    idx:     (0,5,6)
-
 With weight: 0.784314
 pt[3]:    location: -1.25  1.25  1.25
    idx:     (1,6,6)
-
 With weight: 4
 pt[4]:    location: -1.25  0.75  1.75
    idx:     (1,5,7)
-
 With weight: 3.29412
 pt[5]:    location: -1.75  0.75  0.75
    idx:     (0,5,5)
-
 With weight: 1.88235
 pt[6]:    location: -1.75  0.25  1.25
    idx:     (0,4,6)
-
 With weight: -6.71904e-16
 
 On point:    location: 1.25 0.75 1.25
    idx:     (6,5,6)
-
 pt[0]:    location: 1.25 0.75 1.25
    idx:     (6,5,6)
-
 With weight: -14.1867
 pt[1]:    location: 1.25 0.25 1.25
    idx:     (6,4,6)
-
 With weight: 4
 pt[2]:    location: 1.75 0.75 1.25
    idx:     (7,5,6)
-
 With weight: 1.38667
 pt[3]:    location: 1.25 1.25 1.25
    idx:     (6,6,6)
-
 With weight: 2.72
 pt[4]:    location: 1.25 0.75 1.75
    idx:     (6,5,7)
-
 With weight: 3.52
 pt[5]:    location: 1.75 0.75 0.75
    idx:     (7,5,5)
-
 With weight: 1.28
 pt[6]:    location: 1.25 1.25 0.75
    idx:     (6,6,5)
-
 With weight: 1.28
 
 On point:    location: 1.75 0.75 1.25
    idx:     (7,5,6)
-
 pt[0]:    location: 1.75 0.75 1.25
    idx:     (7,5,6)
-
 With weight: -24
 pt[1]:    location: 1.75 0.75 0.75
    idx:     (7,5,5)
-
 With weight: 4
 pt[2]:    location: 1.75 0.25 1.25
    idx:     (7,4,6)
-
 With weight: 4
 pt[3]:    location: 1.25 0.75 1.25
    idx:     (6,5,6)
-
 With weight: 4
 pt[4]:    location: 2.25 0.75 1.25
    idx:     (8,5,6)
-
 With weight: 4
 pt[5]:    location: 1.75 1.25 1.25
    idx:     (7,6,6)
-
 With weight: 4
 pt[6]:    location: 1.75 0.75 1.75
    idx:     (7,5,7)
-
 With weight: 4
 
 On point:    location: -1.75  1.25  1.25
    idx:     (0,6,6)
-
 pt[0]:    location: -1.75  1.25  1.25
    idx:     (0,6,6)
-
 With weight: -24
 pt[1]:    location: -1.75  1.25  0.75
    idx:     (0,6,5)
-
 With weight: 4
 pt[2]:    location: -1.75  0.75  1.25
    idx:     (0,5,6)
-
 With weight: 4
 pt[3]:    location: -2.25  1.25  1.25
    idx:     (-1,6,6)
-
 With weight: 4
 pt[4]:    location: -1.25  1.25  1.25
    idx:     (1,6,6)
-
 With weight: 4
 pt[5]:    location: -1.75  1.75  1.25
    idx:     (0,7,6)
-
 With weight: 4
 pt[6]:    location: -1.75  1.25  1.75
    idx:     (0,6,7)
-
 With weight: 4
 
 On point:    location: -1.25  1.25  1.25
    idx:     (1,6,6)
-
 pt[0]:    location: -1.25  1.25  1.25
    idx:     (1,6,6)
-
 With weight: -24
 pt[1]:    location: -1.25  1.25  0.75
    idx:     (1,6,5)
-
 With weight: 4
 pt[2]:    location: -1.25  0.75  1.25
    idx:     (1,5,6)
-
 With weight: 4
 pt[3]:    location: -1.75  1.25  1.25
    idx:     (0,6,6)
-
 With weight: 4
 pt[4]:    location: -0.75  1.25  1.25
    idx:     (2,6,6)
-
 With weight: 4
 pt[5]:    location: -1.25  1.75  1.25
    idx:     (1,7,6)
-
 With weight: 4
 pt[6]:    location: -1.25  1.25  1.75
    idx:     (1,6,7)
-
 With weight: 4
 
 On point:    location: -0.75  1.25  1.25
    idx:     (2,6,6)
-
 pt[0]:    location: -0.75  1.25  1.25
    idx:     (2,6,6)
-
 With weight: -13.9608
 pt[1]:    location: -1.25  1.25  1.25
    idx:     (1,6,6)
-
 With weight: 4
 pt[2]:    location: -0.25  1.25  1.25
    idx:     (3,6,6)
-
 With weight: 4
 pt[3]:    location: -0.75  1.75  1.25
    idx:     (2,7,6)
-
 With weight: 0.784314
 pt[4]:    location: -0.75  1.25  1.75
    idx:     (2,6,7)
-
 With weight: 3.29412
 pt[5]:    location: -0.75  1.75  0.75
    idx:     (2,7,5)
-
 With weight: 1.88235
 pt[6]:    location: -0.25  1.75  1.25
    idx:     (3,7,6)
-
 With weight: -1.27662e-15
 
 On point:    location: -0.25  1.25  1.25
    idx:     (3,6,6)
-
 pt[0]:    location: -0.25  1.25  1.25
    idx:     (3,6,6)
-
 With weight: -13.9608
 pt[1]:    location: -0.75  1.25  1.25
    idx:     (2,6,6)
-
 With weight: 4
 pt[2]:    location: 0.25 1.25 1.25
    idx:     (4,6,6)
-
 With weight: 4
 pt[3]:    location: -0.25  1.75  1.25
    idx:     (3,7,6)
-
 With weight: 0.784314
 pt[4]:    location: -0.25  1.25  1.75
    idx:     (3,6,7)
-
 With weight: 3.29412
 pt[5]:    location: -0.25  1.75  0.75
    idx:     (3,7,5)
-
 With weight: 1.88235
 pt[6]:    location: -0.75  1.75  1.25
    idx:     (2,7,6)
-
 With weight: 0
 
 On point:    location: 0.25 1.25 1.25
    idx:     (4,6,6)
-
 pt[0]:    location: 0.25 1.25 1.25
    idx:     (4,6,6)
-
 With weight: -13.9608
 pt[1]:    location: -0.25  1.25  1.25
    idx:     (3,6,6)
-
 With weight: 4
 pt[2]:    location: 0.75 1.25 1.25
    idx:     (5,6,6)
-
 With weight: 4
 pt[3]:    location: 0.25 1.75 1.25
    idx:     (4,7,6)
-
 With weight: 3.29412
 pt[4]:    location: 0.25 1.25 1.75
    idx:     (4,6,7)
-
 With weight: 0.784314
 pt[5]:    location: 0.75 1.75 1.25
    idx:     (5,7,6)
-
 With weight: -6.31835e-16
 pt[6]:    location: 0.25 0.75 1.75
    idx:     (4,5,7)
-
 With weight: 1.88235
 
 On point:    location: 0.75 1.25 1.25
    idx:     (5,6,6)
-
 pt[0]:    location: 0.75 1.25 1.25
    idx:     (5,6,6)
-
 With weight: -13.9608
 pt[1]:    location: 0.25 1.25 1.25
    idx:     (4,6,6)
-
 With weight: 4
 pt[2]:    location: 1.25 1.25 1.25
    idx:     (6,6,6)
-
 With weight: 2.11765
 pt[3]:    location: 0.75 1.75 1.25
    idx:     (5,7,6)
-
 With weight: 2.66667
 pt[4]:    location: 0.75 1.25 1.75
    idx:     (5,6,7)
-
 With weight: 3.29412
 pt[5]:    location: 1.25 1.25 0.75
    idx:     (6,6,5)
-
 With weight: 1.88235
 pt[6]:    location: 0.25 1.75 1.25
    idx:     (4,7,6)
-
 With weight: -9.72009e-16
 
 On point:    location: 1.25 1.25 1.25
    idx:     (6,6,6)
-
 pt[0]:    location: 1.25 1.25 1.25
    idx:     (6,6,6)
-
 With weight: -24
 pt[1]:    location: 1.25 1.25 0.75
    idx:     (6,6,5)
-
 With weight: 4
 pt[2]:    location: 1.25 0.75 1.25
    idx:     (6,5,6)
-
 With weight: 4
 pt[3]:    location: 0.75 1.25 1.25
    idx:     (5,6,6)
-
 With weight: 4
 pt[4]:    location: 1.75 1.25 1.25
    idx:     (7,6,6)
-
 With weight: 4
 pt[5]:    location: 1.25 1.75 1.25
    idx:     (6,7,6)
-
 With weight: 4
 pt[6]:    location: 1.25 1.25 1.75
    idx:     (6,6,7)
-
 With weight: 4
 
 On point:    location: 1.75 1.25 1.25
    idx:     (7,6,6)
-
 pt[0]:    location: 1.75 1.25 1.25
    idx:     (7,6,6)
-
 With weight: -24
 pt[1]:    location: 1.75 1.25 0.75
    idx:     (7,6,5)
-
 With weight: 4
 pt[2]:    location: 1.75 0.75 1.25
    idx:     (7,5,6)
-
 With weight: 4
 pt[3]:    location: 1.25 1.25 1.25
    idx:     (6,6,6)
-
 With weight: 4
 pt[4]:    location: 2.25 1.25 1.25
    idx:     (8,6,6)
-
 With weight: 4
 pt[5]:    location: 1.75 1.75 1.25
    idx:     (7,7,6)
-
 With weight: 4
 pt[6]:    location: 1.75 1.25 1.75
    idx:     (7,6,7)
-
 With weight: 4
 
 On point:    location: -1.75  1.75  1.25
    idx:     (0,7,6)
-
 pt[0]:    location: -1.75  1.75  1.25
    idx:     (0,7,6)
-
 With weight: -24
 pt[1]:    location: -1.75  1.75  0.75
    idx:     (0,7,5)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25  1.25
    idx:     (0,6,6)
-
 With weight: 4
 pt[3]:    location: -2.25  1.75  1.25
    idx:     (-1,7,6)
-
 With weight: 4
 pt[4]:    location: -1.25  1.75  1.25
    idx:     (1,7,6)
-
 With weight: 4
 pt[5]:    location: -1.75  2.25  1.25
    idx:     (0,8,6)
-
 With weight: 4
 pt[6]:    location: -1.75  1.75  1.75
    idx:     (0,7,7)
-
 With weight: 4
 
 On point:    location: -1.25  1.75  1.25
    idx:     (1,7,6)
-
 pt[0]:    location: -1.25  1.75  1.25
    idx:     (1,7,6)
-
 With weight: -24
 pt[1]:    location: -1.25  1.75  0.75
    idx:     (1,7,5)
-
 With weight: 4
 pt[2]:    location: -1.25  1.25  1.25
    idx:     (1,6,6)
-
 With weight: 4
 pt[3]:    location: -1.75  1.75  1.25
    idx:     (0,7,6)
-
 With weight: 4
 pt[4]:    location: -0.75  1.75  1.25
    idx:     (2,7,6)
-
 With weight: 4
 pt[5]:    location: -1.25  2.25  1.25
    idx:     (1,8,6)
-
 With weight: 4
 pt[6]:    location: -1.25  1.75  1.75
    idx:     (1,7,7)
-
 With weight: 4
 
 On point:    location: -0.75  1.75  1.25
    idx:     (2,7,6)
-
 pt[0]:    location: -0.75  1.75  1.25
    idx:     (2,7,6)
-
 With weight: -24
 pt[1]:    location: -0.75  1.75  0.75
    idx:     (2,7,5)
-
 With weight: 4
 pt[2]:    location: -0.75  1.25  1.25
    idx:     (2,6,6)
-
 With weight: 4
 pt[3]:    location: -1.25  1.75  1.25
    idx:     (1,7,6)
-
 With weight: 4
 pt[4]:    location: -0.25  1.75  1.25
    idx:     (3,7,6)
-
 With weight: 4
 pt[5]:    location: -0.75  2.25  1.25
    idx:     (2,8,6)
-
 With weight: 4
 pt[6]:    location: -0.75  1.75  1.75
    idx:     (2,7,7)
-
 With weight: 4
 
 On point:    location: -0.25  1.75  1.25
    idx:     (3,7,6)
-
 pt[0]:    location: -0.25  1.75  1.25
    idx:     (3,7,6)
-
 With weight: -24
 pt[1]:    location: -0.25  1.75  0.75
    idx:     (3,7,5)
-
 With weight: 4
 pt[2]:    location: -0.25  1.25  1.25
    idx:     (3,6,6)
-
 With weight: 4
 pt[3]:    location: -0.75  1.75  1.25
    idx:     (2,7,6)
-
 With weight: 4
 pt[4]:    location: 0.25 1.75 1.25
    idx:     (4,7,6)
-
 With weight: 4
 pt[5]:    location: -0.25  2.25  1.25
    idx:     (3,8,6)
-
 With weight: 4
 pt[6]:    location: -0.25  1.75  1.75
    idx:     (3,7,7)
-
 With weight: 4
 
 On point:    location: 0.25 1.75 1.25
    idx:     (4,7,6)
-
 pt[0]:    location: 0.25 1.75 1.25
    idx:     (4,7,6)
-
 With weight: -24
 pt[1]:    location: 0.25 1.75 0.75
    idx:     (4,7,5)
-
 With weight: 4
 pt[2]:    location: 0.25 1.25 1.25
    idx:     (4,6,6)
-
 With weight: 4
 pt[3]:    location: -0.25  1.75  1.25
    idx:     (3,7,6)
-
 With weight: 4
 pt[4]:    location: 0.75 1.75 1.25
    idx:     (5,7,6)
-
 With weight: 4
 pt[5]:    location: 0.25 2.25 1.25
    idx:     (4,8,6)
-
 With weight: 4
 pt[6]:    location: 0.25 1.75 1.75
    idx:     (4,7,7)
-
 With weight: 4
 
 On point:    location: 0.75 1.75 1.25
    idx:     (5,7,6)
-
 pt[0]:    location: 0.75 1.75 1.25
    idx:     (5,7,6)
-
 With weight: -24
 pt[1]:    location: 0.75 1.75 0.75
    idx:     (5,7,5)
-
 With weight: 4
 pt[2]:    location: 0.75 1.25 1.25
    idx:     (5,6,6)
-
 With weight: 4
 pt[3]:    location: 0.25 1.75 1.25
    idx:     (4,7,6)
-
 With weight: 4
 pt[4]:    location: 1.25 1.75 1.25
    idx:     (6,7,6)
-
 With weight: 4
 pt[5]:    location: 0.75 2.25 1.25
    idx:     (5,8,6)
-
 With weight: 4
 pt[6]:    location: 0.75 1.75 1.75
    idx:     (5,7,7)
-
 With weight: 4
 
 On point:    location: 1.25 1.75 1.25
    idx:     (6,7,6)
-
 pt[0]:    location: 1.25 1.75 1.25
    idx:     (6,7,6)
-
 With weight: -24
 pt[1]:    location: 1.25 1.75 0.75
    idx:     (6,7,5)
-
 With weight: 4
 pt[2]:    location: 1.25 1.25 1.25
    idx:     (6,6,6)
-
 With weight: 4
 pt[3]:    location: 0.75 1.75 1.25
    idx:     (5,7,6)
-
 With weight: 4
 pt[4]:    location: 1.75 1.75 1.25
    idx:     (7,7,6)
-
 With weight: 4
 pt[5]:    location: 1.25 2.25 1.25
    idx:     (6,8,6)
-
 With weight: 4
 pt[6]:    location: 1.25 1.75 1.75
    idx:     (6,7,7)
-
 With weight: 4
 
 On point:    location: 1.75 1.75 1.25
    idx:     (7,7,6)
-
 pt[0]:    location: 1.75 1.75 1.25
    idx:     (7,7,6)
-
 With weight: -24
 pt[1]:    location: 1.75 1.75 0.75
    idx:     (7,7,5)
-
 With weight: 4
 pt[2]:    location: 1.75 1.25 1.25
    idx:     (7,6,6)
-
 With weight: 4
 pt[3]:    location: 1.25 1.75 1.25
    idx:     (6,7,6)
-
 With weight: 4
 pt[4]:    location: 2.25 1.75 1.25
    idx:     (8,7,6)
-
 With weight: 4
 pt[5]:    location: 1.75 2.25 1.25
    idx:     (7,8,6)
-
 With weight: 4
 pt[6]:    location: 1.75 1.75 1.75
    idx:     (7,7,7)
-
 With weight: 4
 
 On point:    location: -1.75 -1.75  1.75
    idx:     (0,0,7)
-
 pt[0]:    location: -1.75 -1.75  1.75
    idx:     (0,0,7)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.75  1.25
    idx:     (0,0,6)
-
 With weight: 4
 pt[2]:    location: -1.75 -2.25  1.75
    idx:     (0,-1,7)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.75  1.75
    idx:     (-1,0,7)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.75  1.75
    idx:     (1,0,7)
-
 With weight: 4
 pt[5]:    location: -1.75 -1.25  1.75
    idx:     (0,1,7)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.75  2.25
    idx:     (0,0,8)
-
 With weight: 4
 
 On point:    location: -1.25 -1.75  1.75
    idx:     (1,0,7)
-
 pt[0]:    location: -1.25 -1.75  1.75
    idx:     (1,0,7)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.75  1.25
    idx:     (1,0,6)
-
 With weight: 4
 pt[2]:    location: -1.25 -2.25  1.75
    idx:     (1,-1,7)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.75  1.75
    idx:     (0,0,7)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.75  1.75
    idx:     (2,0,7)
-
 With weight: 4
 pt[5]:    location: -1.25 -1.25  1.75
    idx:     (1,1,7)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.75  2.25
    idx:     (1,0,8)
-
 With weight: 4
 
 On point:    location: -0.75 -1.75  1.75
    idx:     (2,0,7)
-
 pt[0]:    location: -0.75 -1.75  1.75
    idx:     (2,0,7)
-
 With weight: -24
 pt[1]:    location: -0.75 -1.75  1.25
    idx:     (2,0,6)
-
 With weight: 4
 pt[2]:    location: -0.75 -2.25  1.75
    idx:     (2,-1,7)
-
 With weight: 4
 pt[3]:    location: -1.25 -1.75  1.75
    idx:     (1,0,7)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.75  1.75
    idx:     (3,0,7)
-
 With weight: 4
 pt[5]:    location: -0.75 -1.25  1.75
    idx:     (2,1,7)
-
 With weight: 4
 pt[6]:    location: -0.75 -1.75  2.25
    idx:     (2,0,8)
-
 With weight: 4
 
 On point:    location: -0.25 -1.75  1.75
    idx:     (3,0,7)
-
 pt[0]:    location: -0.25 -1.75  1.75
    idx:     (3,0,7)
-
 With weight: -24
 pt[1]:    location: -0.25 -1.75  1.25
    idx:     (3,0,6)
-
 With weight: 4
 pt[2]:    location: -0.25 -2.25  1.75
    idx:     (3,-1,7)
-
 With weight: 4
 pt[3]:    location: -0.75 -1.75  1.75
    idx:     (2,0,7)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.75  1.75
    idx:     (4,0,7)
-
 With weight: 4
 pt[5]:    location: -0.25 -1.25  1.75
    idx:     (3,1,7)
-
 With weight: 4
 pt[6]:    location: -0.25 -1.75  2.25
    idx:     (3,0,8)
-
 With weight: 4
 
 On point:    location:  0.25 -1.75  1.75
    idx:     (4,0,7)
-
 pt[0]:    location:  0.25 -1.75  1.75
    idx:     (4,0,7)
-
 With weight: -24
 pt[1]:    location:  0.25 -1.75  1.25
    idx:     (4,0,6)
-
 With weight: 4
 pt[2]:    location:  0.25 -2.25  1.75
    idx:     (4,-1,7)
-
 With weight: 4
 pt[3]:    location: -0.25 -1.75  1.75
    idx:     (3,0,7)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.75  1.75
    idx:     (5,0,7)
-
 With weight: 4
 pt[5]:    location:  0.25 -1.25  1.75
    idx:     (4,1,7)
-
 With weight: 4
 pt[6]:    location:  0.25 -1.75  2.25
    idx:     (4,0,8)
-
 With weight: 4
 
 On point:    location:  0.75 -1.75  1.75
    idx:     (5,0,7)
-
 pt[0]:    location:  0.75 -1.75  1.75
    idx:     (5,0,7)
-
 With weight: -24
 pt[1]:    location:  0.75 -1.75  1.25
    idx:     (5,0,6)
-
 With weight: 4
 pt[2]:    location:  0.75 -2.25  1.75
    idx:     (5,-1,7)
-
 With weight: 4
 pt[3]:    location:  0.25 -1.75  1.75
    idx:     (4,0,7)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.75  1.75
    idx:     (6,0,7)
-
 With weight: 4
 pt[5]:    location:  0.75 -1.25  1.75
    idx:     (5,1,7)
-
 With weight: 4
 pt[6]:    location:  0.75 -1.75  2.25
    idx:     (5,0,8)
-
 With weight: 4
 
 On point:    location:  1.25 -1.75  1.75
    idx:     (6,0,7)
-
 pt[0]:    location:  1.25 -1.75  1.75
    idx:     (6,0,7)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.75  1.25
    idx:     (6,0,6)
-
 With weight: 4
 pt[2]:    location:  1.25 -2.25  1.75
    idx:     (6,-1,7)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.75  1.75
    idx:     (5,0,7)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.75  1.75
    idx:     (7,0,7)
-
 With weight: 4
 pt[5]:    location:  1.25 -1.25  1.75
    idx:     (6,1,7)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.75  2.25
    idx:     (6,0,8)
-
 With weight: 4
 
 On point:    location:  1.75 -1.75  1.75
    idx:     (7,0,7)
-
 pt[0]:    location:  1.75 -1.75  1.75
    idx:     (7,0,7)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.75  1.25
    idx:     (7,0,6)
-
 With weight: 4
 pt[2]:    location:  1.75 -2.25  1.75
    idx:     (7,-1,7)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.75  1.75
    idx:     (6,0,7)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.75  1.75
    idx:     (8,0,7)
-
 With weight: 4
 pt[5]:    location:  1.75 -1.25  1.75
    idx:     (7,1,7)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.75  2.25
    idx:     (7,0,8)
-
 With weight: 4
 
 On point:    location: -1.75 -1.25  1.75
    idx:     (0,1,7)
-
 pt[0]:    location: -1.75 -1.25  1.75
    idx:     (0,1,7)
-
 With weight: -24
 pt[1]:    location: -1.75 -1.25  1.25
    idx:     (0,1,6)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.75  1.75
    idx:     (0,0,7)
-
 With weight: 4
 pt[3]:    location: -2.25 -1.25  1.75
    idx:     (-1,1,7)
-
 With weight: 4
 pt[4]:    location: -1.25 -1.25  1.75
    idx:     (1,1,7)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.75  1.75
    idx:     (0,2,7)
-
 With weight: 4
 pt[6]:    location: -1.75 -1.25  2.25
    idx:     (0,1,8)
-
 With weight: 4
 
 On point:    location: -1.25 -1.25  1.75
    idx:     (1,1,7)
-
 pt[0]:    location: -1.25 -1.25  1.75
    idx:     (1,1,7)
-
 With weight: -24
 pt[1]:    location: -1.25 -1.25  1.25
    idx:     (1,1,6)
-
 With weight: 4
 pt[2]:    location: -1.25 -1.75  1.75
    idx:     (1,0,7)
-
 With weight: 4
 pt[3]:    location: -1.75 -1.25  1.75
    idx:     (0,1,7)
-
 With weight: 4
 pt[4]:    location: -0.75 -1.25  1.75
    idx:     (2,1,7)
-
 With weight: 4
 pt[5]:    location: -1.25 -0.75  1.75
    idx:     (1,2,7)
-
 With weight: 4
 pt[6]:    location: -1.25 -1.25  2.25
    idx:     (1,1,8)
-
 With weight: 4
 
 On point:    location: -0.75 -1.25  1.75
    idx:     (2,1,7)
-
 pt[0]:    location: -0.75 -1.25  1.75
    idx:     (2,1,7)
-
 With weight: -24
 pt[1]:    location: -0.75 -1.25  1.25
    idx:     (2,1,6)
-
 With weight: 4
 pt[2]:    location: -0.75 -1.75  1.75
    idx:     (2,0,7)
-
 With weight: 4
 pt[3]:    location: -1.25 -1.25  1.75
    idx:     (1,1,7)
-
 With weight: 4
 pt[4]:    location: -0.25 -1.25  1.75
    idx:     (3,1,7)
-
 With weight: 4
 pt[5]:    location: -0.75 -0.75  1.75
    idx:     (2,2,7)
-
 With weight: 4
 pt[6]:    location: -0.75 -1.25  2.25
    idx:     (2,1,8)
-
 With weight: 4
 
 On point:    location: -0.25 -1.25  1.75
    idx:     (3,1,7)
-
 pt[0]:    location: -0.25 -1.25  1.75
    idx:     (3,1,7)
-
 With weight: -24
 pt[1]:    location: -0.25 -1.25  1.25
    idx:     (3,1,6)
-
 With weight: 4
 pt[2]:    location: -0.25 -1.75  1.75
    idx:     (3,0,7)
-
 With weight: 4
 pt[3]:    location: -0.75 -1.25  1.75
    idx:     (2,1,7)
-
 With weight: 4
 pt[4]:    location:  0.25 -1.25  1.75
    idx:     (4,1,7)
-
 With weight: 4
 pt[5]:    location: -0.25 -0.75  1.75
    idx:     (3,2,7)
-
 With weight: 4
 pt[6]:    location: -0.25 -1.25  2.25
    idx:     (3,1,8)
-
 With weight: 4
 
 On point:    location:  0.25 -1.25  1.75
    idx:     (4,1,7)
-
 pt[0]:    location:  0.25 -1.25  1.75
    idx:     (4,1,7)
-
 With weight: -24
 pt[1]:    location:  0.25 -1.25  1.25
    idx:     (4,1,6)
-
 With weight: 4
 pt[2]:    location:  0.25 -1.75  1.75
    idx:     (4,0,7)
-
 With weight: 4
 pt[3]:    location: -0.25 -1.25  1.75
    idx:     (3,1,7)
-
 With weight: 4
 pt[4]:    location:  0.75 -1.25  1.75
    idx:     (5,1,7)
-
 With weight: 4
 pt[5]:    location:  0.25 -0.75  1.75
    idx:     (4,2,7)
-
 With weight: 4
 pt[6]:    location:  0.25 -1.25  2.25
    idx:     (4,1,8)
-
 With weight: 4
 
 On point:    location:  0.75 -1.25  1.75
    idx:     (5,1,7)
-
 pt[0]:    location:  0.75 -1.25  1.75
    idx:     (5,1,7)
-
 With weight: -24
 pt[1]:    location:  0.75 -1.25  1.25
    idx:     (5,1,6)
-
 With weight: 4
 pt[2]:    location:  0.75 -1.75  1.75
    idx:     (5,0,7)
-
 With weight: 4
 pt[3]:    location:  0.25 -1.25  1.75
    idx:     (4,1,7)
-
 With weight: 4
 pt[4]:    location:  1.25 -1.25  1.75
    idx:     (6,1,7)
-
 With weight: 4
 pt[5]:    location:  0.75 -0.75  1.75
    idx:     (5,2,7)
-
 With weight: 4
 pt[6]:    location:  0.75 -1.25  2.25
    idx:     (5,1,8)
-
 With weight: 4
 
 On point:    location:  1.25 -1.25  1.75
    idx:     (6,1,7)
-
 pt[0]:    location:  1.25 -1.25  1.75
    idx:     (6,1,7)
-
 With weight: -24
 pt[1]:    location:  1.25 -1.25  1.25
    idx:     (6,1,6)
-
 With weight: 4
 pt[2]:    location:  1.25 -1.75  1.75
    idx:     (6,0,7)
-
 With weight: 4
 pt[3]:    location:  0.75 -1.25  1.75
    idx:     (5,1,7)
-
 With weight: 4
 pt[4]:    location:  1.75 -1.25  1.75
    idx:     (7,1,7)
-
 With weight: 4
 pt[5]:    location:  1.25 -0.75  1.75
    idx:     (6,2,7)
-
 With weight: 4
 pt[6]:    location:  1.25 -1.25  2.25
    idx:     (6,1,8)
-
 With weight: 4
 
 On point:    location:  1.75 -1.25  1.75
    idx:     (7,1,7)
-
 pt[0]:    location:  1.75 -1.25  1.75
    idx:     (7,1,7)
-
 With weight: -24
 pt[1]:    location:  1.75 -1.25  1.25
    idx:     (7,1,6)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.75  1.75
    idx:     (7,0,7)
-
 With weight: 4
 pt[3]:    location:  1.25 -1.25  1.75
    idx:     (6,1,7)
-
 With weight: 4
 pt[4]:    location:  2.25 -1.25  1.75
    idx:     (8,1,7)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.75  1.75
    idx:     (7,2,7)
-
 With weight: 4
 pt[6]:    location:  1.75 -1.25  2.25
    idx:     (7,1,8)
-
 With weight: 4
 
 On point:    location: -1.75 -0.75  1.75
    idx:     (0,2,7)
-
 pt[0]:    location: -1.75 -0.75  1.75
    idx:     (0,2,7)
-
 With weight: -24
 pt[1]:    location: -1.75 -0.75  1.25
    idx:     (0,2,6)
-
 With weight: 4
 pt[2]:    location: -1.75 -1.25  1.75
    idx:     (0,1,7)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.75  1.75
    idx:     (-1,2,7)
-
 With weight: 4
 pt[4]:    location: -1.25 -0.75  1.75
    idx:     (1,2,7)
-
 With weight: 4
 pt[5]:    location: -1.75 -0.25  1.75
    idx:     (0,3,7)
-
 With weight: 4
 pt[6]:    location: -1.75 -0.75  2.25
    idx:     (0,2,8)
-
 With weight: 4
 
 On point:    location: -1.25 -0.75  1.75
    idx:     (1,2,7)
-
 pt[0]:    location: -1.25 -0.75  1.75
    idx:     (1,2,7)
-
 With weight: -24
 pt[1]:    location: -1.25 -0.75  1.25
    idx:     (1,2,6)
-
 With weight: 4
 pt[2]:    location: -1.25 -1.25  1.75
    idx:     (1,1,7)
-
 With weight: 4
 pt[3]:    location: -1.75 -0.75  1.75
    idx:     (0,2,7)
-
 With weight: 4
 pt[4]:    location: -0.75 -0.75  1.75
    idx:     (2,2,7)
-
 With weight: 4
 pt[5]:    location: -1.25 -0.25  1.75
    idx:     (1,3,7)
-
 With weight: 4
 pt[6]:    location: -1.25 -0.75  2.25
    idx:     (1,2,8)
-
 With weight: 4
 
 On point:    location: -0.75 -0.75  1.75
    idx:     (2,2,7)
-
 pt[0]:    location: -0.75 -0.75  1.75
    idx:     (2,2,7)
-
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.25  1.75
    idx:     (2,1,7)
-
 With weight: 4
 pt[2]:    location: -1.25 -0.75  1.75
    idx:     (1,2,7)
-
 With weight: 4
 pt[3]:    location: -0.25 -0.75  1.75
    idx:     (3,2,7)
-
 With weight: 4
 pt[4]:    location: -0.75 -0.25  1.75
    idx:     (2,3,7)
-
 With weight: 4
 pt[5]:    location: -0.75 -0.75  2.25
    idx:     (2,2,8)
-
 With weight: 2.66667
 pt[6]:    location: -0.25 -1.25  1.75
    idx:     (3,1,7)
-
 With weight: 1.65992e-15
 
 On point:    location: -0.25 -0.75  1.75
    idx:     (3,2,7)
-
 pt[0]:    location: -0.25 -0.75  1.75
    idx:     (3,2,7)
-
 With weight: -19.2941
 pt[1]:    location: -0.25 -1.25  1.75
    idx:     (3,1,7)
-
 With weight: 2.11765
 pt[2]:    location: -0.75 -0.75  1.75
    idx:     (2,2,7)
-
 With weight: 4
 pt[3]:    location:  0.25 -0.75  1.75
    idx:     (4,2,7)
-
 With weight: 4
 pt[4]:    location: -0.25 -0.25  1.75
    idx:     (3,3,7)
-
 With weight: 4
 pt[5]:    location: -0.25 -0.75  2.25
    idx:     (3,2,8)
-
 With weight: 3.29412
 pt[6]:    location: -0.25 -1.25  1.25
    idx:     (3,1,6)
-
 With weight: 1.88235
 
 On point:    location:  0.25 -0.75  1.75
    idx:     (4,2,7)
-
 pt[0]:    location:  0.25 -0.75  1.75
    idx:     (4,2,7)
-
 With weight: -19.2941
 pt[1]:    location:  0.25 -1.25  1.75
    idx:     (4,1,7)
-
 With weight: 2.11765
 pt[2]:    location: -0.25 -0.75  1.75
    idx:     (3,2,7)
-
 With weight: 4
 pt[3]:    location:  0.75 -0.75  1.75
    idx:     (5,2,7)
-
 With weight: 4
 pt[4]:    location:  0.25 -0.25  1.75
    idx:     (4,3,7)
-
 With weight: 4
 pt[5]:    location:  0.25 -0.75  2.25
    idx:     (4,2,8)
-
 With weight: 3.29412
 pt[6]:    location:  0.25 -1.25  1.25
    idx:     (4,1,6)
-
 With weight: 1.88235
 
 On point:    location:  0.75 -0.75  1.75
    idx:     (5,2,7)
-
 pt[0]:    location:  0.75 -0.75  1.75
    idx:     (5,2,7)
-
 With weight: -19.2941
 pt[1]:    location:  0.75 -1.25  1.75
    idx:     (5,1,7)
-
 With weight: 2.11765
 pt[2]:    location:  0.25 -0.75  1.75
    idx:     (4,2,7)
-
 With weight: 4
 pt[3]:    location:  1.25 -0.75  1.75
    idx:     (6,2,7)
-
 With weight: 4
 pt[4]:    location:  0.75 -0.25  1.75
    idx:     (5,3,7)
-
 With weight: 4
 pt[5]:    location:  0.75 -0.75  2.25
    idx:     (5,2,8)
-
 With weight: 3.29412
 pt[6]:    location:  0.75 -1.25  1.25
    idx:     (5,1,6)
-
 With weight: 1.88235
 
 On point:    location:  1.25 -0.75  1.75
    idx:     (6,2,7)
-
 pt[0]:    location:  1.25 -0.75  1.75
    idx:     (6,2,7)
-
 With weight: -24
 pt[1]:    location:  1.25 -0.75  1.25
    idx:     (6,2,6)
-
 With weight: 4
 pt[2]:    location:  1.25 -1.25  1.75
    idx:     (6,1,7)
-
 With weight: 4
 pt[3]:    location:  0.75 -0.75  1.75
    idx:     (5,2,7)
-
 With weight: 4
 pt[4]:    location:  1.75 -0.75  1.75
    idx:     (7,2,7)
-
 With weight: 4
 pt[5]:    location:  1.25 -0.25  1.75
    idx:     (6,3,7)
-
 With weight: 4
 pt[6]:    location:  1.25 -0.75  2.25
    idx:     (6,2,8)
-
 With weight: 4
 
 On point:    location:  1.75 -0.75  1.75
    idx:     (7,2,7)
-
 pt[0]:    location:  1.75 -0.75  1.75
    idx:     (7,2,7)
-
 With weight: -24
 pt[1]:    location:  1.75 -0.75  1.25
    idx:     (7,2,6)
-
 With weight: 4
 pt[2]:    location:  1.75 -1.25  1.75
    idx:     (7,1,7)
-
 With weight: 4
 pt[3]:    location:  1.25 -0.75  1.75
    idx:     (6,2,7)
-
 With weight: 4
 pt[4]:    location:  2.25 -0.75  1.75
    idx:     (8,2,7)
-
 With weight: 4
 pt[5]:    location:  1.75 -0.25  1.75
    idx:     (7,3,7)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.75  2.25
    idx:     (7,2,8)
-
 With weight: 4
 
 On point:    location: -1.75 -0.25  1.75
    idx:     (0,3,7)
-
 pt[0]:    location: -1.75 -0.25  1.75
    idx:     (0,3,7)
-
 With weight: -24
 pt[1]:    location: -1.75 -0.25  1.25
    idx:     (0,3,6)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.75  1.75
    idx:     (0,2,7)
-
 With weight: 4
 pt[3]:    location: -2.25 -0.25  1.75
    idx:     (-1,3,7)
-
 With weight: 4
 pt[4]:    location: -1.25 -0.25  1.75
    idx:     (1,3,7)
-
 With weight: 4
 pt[5]:    location: -1.75  0.25  1.75
    idx:     (0,4,7)
-
 With weight: 4
 pt[6]:    location: -1.75 -0.25  2.25
    idx:     (0,3,8)
-
 With weight: 4
 
 On point:    location: -1.25 -0.25  1.75
    idx:     (1,3,7)
-
 pt[0]:    location: -1.25 -0.25  1.75
    idx:     (1,3,7)
-
 With weight: -24
 pt[1]:    location: -1.25 -0.25  1.25
    idx:     (1,3,6)
-
 With weight: 4
 pt[2]:    location: -1.25 -0.75  1.75
    idx:     (1,2,7)
-
 With weight: 4
 pt[3]:    location: -1.75 -0.25  1.75
    idx:     (0,3,7)
-
 With weight: 4
 pt[4]:    location: -0.75 -0.25  1.75
    idx:     (2,3,7)
-
 With weight: 4
 pt[5]:    location: -1.25  0.25  1.75
    idx:     (1,4,7)
-
 With weight: 4
 pt[6]:    location: -1.25 -0.25  2.25
    idx:     (1,3,8)
-
 With weight: 4
 
 On point:    location: -0.75 -0.25  1.75
    idx:     (2,3,7)
-
 pt[0]:    location: -0.75 -0.25  1.75
    idx:     (2,3,7)
-
 With weight: -19.2941
 pt[1]:    location: -0.75 -0.75  1.75
    idx:     (2,2,7)
-
 With weight: 4
 pt[2]:    location: -1.25 -0.25  1.75
    idx:     (1,3,7)
-
 With weight: 2.11765
 pt[3]:    location: -0.25 -0.25  1.75
    idx:     (3,3,7)
-
 With weight: 4
 pt[4]:    location: -0.75  0.25  1.75
    idx:     (2,4,7)
-
 With weight: 4
 pt[5]:    location: -0.75 -0.25  2.25
    idx:     (2,3,8)
-
 With weight: 3.29412
 pt[6]:    location: -1.25 -0.25  1.25
    idx:     (1,3,6)
-
 With weight: 1.88235
 
 On point:    location: -0.25 -0.25  1.75
    idx:     (3,3,7)
-
 pt[0]:    location: -0.25 -0.25  1.75
    idx:     (3,3,7)
-
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.75  1.75
    idx:     (3,2,7)
-
 With weight: 4
 pt[2]:    location: -0.75 -0.25  1.75
    idx:     (2,3,7)
-
 With weight: 4
 pt[3]:    location:  0.25 -0.25  1.75
    idx:     (4,3,7)
-
 With weight: 4
 pt[4]:    location: -0.25  0.25  1.75
    idx:     (3,4,7)
-
 With weight: 4
 pt[5]:    location: -0.25 -0.25  2.25
    idx:     (3,3,8)
-
 With weight: 2.66667
 pt[6]:    location: -0.75 -0.75  1.75
    idx:     (2,2,7)
-
 With weight: 1.70108e-15
 
 On point:    location:  0.25 -0.25  1.75
    idx:     (4,3,7)
-
 pt[0]:    location:  0.25 -0.25  1.75
    idx:     (4,3,7)
-
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.75  1.75
    idx:     (4,2,7)
-
 With weight: 4
 pt[2]:    location: -0.25 -0.25  1.75
    idx:     (3,3,7)
-
 With weight: 4
 pt[3]:    location:  0.75 -0.25  1.75
    idx:     (5,3,7)
-
 With weight: 4
 pt[4]:    location: 0.25 0.25 1.75
    idx:     (4,4,7)
-
 With weight: 4
 pt[5]:    location:  0.25 -0.25  2.25
    idx:     (4,3,8)
-
 With weight: 2.66667
 pt[6]:    location:  0.75 -0.75  1.75
    idx:     (5,2,7)
-
 With weight: 1.65992e-15
 
 On point:    location:  0.75 -0.25  1.75
    idx:     (5,3,7)
-
 pt[0]:    location:  0.75 -0.25  1.75
    idx:     (5,3,7)
-
 With weight: -19.2941
 pt[1]:    location:  0.75 -0.75  1.75
    idx:     (5,2,7)
-
 With weight: 4
 pt[2]:    location:  0.25 -0.25  1.75
    idx:     (4,3,7)
-
 With weight: 4
 pt[3]:    location:  1.25 -0.25  1.75
    idx:     (6,3,7)
-
 With weight: 2.11765
 pt[4]:    location: 0.75 0.25 1.75
    idx:     (5,4,7)
-
 With weight: 4
 pt[5]:    location:  0.75 -0.25  2.25
    idx:     (5,3,8)
-
 With weight: 3.29412
 pt[6]:    location:  1.25 -0.25  1.25
    idx:     (6,3,6)
-
 With weight: 1.88235
 
 On point:    location:  1.25 -0.25  1.75
    idx:     (6,3,7)
-
 pt[0]:    location:  1.25 -0.25  1.75
    idx:     (6,3,7)
-
 With weight: -24
 pt[1]:    location:  1.25 -0.25  1.25
    idx:     (6,3,6)
-
 With weight: 4
 pt[2]:    location:  1.25 -0.75  1.75
    idx:     (6,2,7)
-
 With weight: 4
 pt[3]:    location:  0.75 -0.25  1.75
    idx:     (5,3,7)
-
 With weight: 4
 pt[4]:    location:  1.75 -0.25  1.75
    idx:     (7,3,7)
-
 With weight: 4
 pt[5]:    location: 1.25 0.25 1.75
    idx:     (6,4,7)
-
 With weight: 4
 pt[6]:    location:  1.25 -0.25  2.25
    idx:     (6,3,8)
-
 With weight: 4
 
 On point:    location:  1.75 -0.25  1.75
    idx:     (7,3,7)
-
 pt[0]:    location:  1.75 -0.25  1.75
    idx:     (7,3,7)
-
 With weight: -24
 pt[1]:    location:  1.75 -0.25  1.25
    idx:     (7,3,6)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.75  1.75
    idx:     (7,2,7)
-
 With weight: 4
 pt[3]:    location:  1.25 -0.25  1.75
    idx:     (6,3,7)
-
 With weight: 4
 pt[4]:    location:  2.25 -0.25  1.75
    idx:     (8,3,7)
-
 With weight: 4
 pt[5]:    location: 1.75 0.25 1.75
    idx:     (7,4,7)
-
 With weight: 4
 pt[6]:    location:  1.75 -0.25  2.25
    idx:     (7,3,8)
-
 With weight: 4
 
 On point:    location: -1.75  0.25  1.75
    idx:     (0,4,7)
-
 pt[0]:    location: -1.75  0.25  1.75
    idx:     (0,4,7)
-
 With weight: -24
 pt[1]:    location: -1.75  0.25  1.25
    idx:     (0,4,6)
-
 With weight: 4
 pt[2]:    location: -1.75 -0.25  1.75
    idx:     (0,3,7)
-
 With weight: 4
 pt[3]:    location: -2.25  0.25  1.75
    idx:     (-1,4,7)
-
 With weight: 4
 pt[4]:    location: -1.25  0.25  1.75
    idx:     (1,4,7)
-
 With weight: 4
 pt[5]:    location: -1.75  0.75  1.75
    idx:     (0,5,7)
-
 With weight: 4
 pt[6]:    location: -1.75  0.25  2.25
    idx:     (0,4,8)
-
 With weight: 4
 
 On point:    location: -1.25  0.25  1.75
    idx:     (1,4,7)
-
 pt[0]:    location: -1.25  0.25  1.75
    idx:     (1,4,7)
-
 With weight: -24
 pt[1]:    location: -1.25  0.25  1.25
    idx:     (1,4,6)
-
 With weight: 4
 pt[2]:    location: -1.25 -0.25  1.75
    idx:     (1,3,7)
-
 With weight: 4
 pt[3]:    location: -1.75  0.25  1.75
    idx:     (0,4,7)
-
 With weight: 4
 pt[4]:    location: -0.75  0.25  1.75
    idx:     (2,4,7)
-
 With weight: 4
 pt[5]:    location: -1.25  0.75  1.75
    idx:     (1,5,7)
-
 With weight: 4
 pt[6]:    location: -1.25  0.25  2.25
    idx:     (1,4,8)
-
 With weight: 4
 
 On point:    location: -0.75  0.25  1.75
    idx:     (2,4,7)
-
 pt[0]:    location: -0.75  0.25  1.75
    idx:     (2,4,7)
-
 With weight: -19.2941
 pt[1]:    location: -0.75 -0.25  1.75
    idx:     (2,3,7)
-
 With weight: 4
 pt[2]:    location: -1.25  0.25  1.75
    idx:     (1,4,7)
-
 With weight: 2.11765
 pt[3]:    location: -0.25  0.25  1.75
    idx:     (3,4,7)
-
 With weight: 4
 pt[4]:    location: -0.75  0.75  1.75
    idx:     (2,5,7)
-
 With weight: 4
 pt[5]:    location: -0.75  0.25  2.25
    idx:     (2,4,8)
-
 With weight: 3.29412
 pt[6]:    location: -1.25  0.25  1.25
    idx:     (1,4,6)
-
 With weight: 1.88235
 
 On point:    location: -0.25  0.25  1.75
    idx:     (3,4,7)
-
 pt[0]:    location: -0.25  0.25  1.75
    idx:     (3,4,7)
-
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.25  1.75
    idx:     (3,3,7)
-
 With weight: 4
 pt[2]:    location: -0.75  0.25  1.75
    idx:     (2,4,7)
-
 With weight: 4
 pt[3]:    location: 0.25 0.25 1.75
    idx:     (4,4,7)
-
 With weight: 4
 pt[4]:    location: -0.25  0.75  1.75
    idx:     (3,5,7)
-
 With weight: 4
 pt[5]:    location: -0.25  0.25  2.25
    idx:     (3,4,8)
-
 With weight: 2.66667
 pt[6]:    location: -0.75  0.75  1.75
    idx:     (2,5,7)
-
 With weight: -5.76172e-16
 
 On point:    location: 0.25 0.25 1.75
    idx:     (4,4,7)
-
 pt[0]:    location: 0.25 0.25 1.75
    idx:     (4,4,7)
-
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.25  1.75
    idx:     (4,3,7)
-
 With weight: 4
 pt[2]:    location: -0.25  0.25  1.75
    idx:     (3,4,7)
-
 With weight: 4
 pt[3]:    location: 0.75 0.25 1.75
    idx:     (5,4,7)
-
 With weight: 4
 pt[4]:    location: 0.25 0.75 1.75
    idx:     (4,5,7)
-
 With weight: 4
 pt[5]:    location: 0.25 0.25 2.25
    idx:     (4,4,8)
-
 With weight: 2.66667
 pt[6]:    location: 0.75 0.75 1.75
    idx:     (5,5,7)
-
 With weight: -0
 
 On point:    location: 0.75 0.25 1.75
    idx:     (5,4,7)
-
 pt[0]:    location: 0.75 0.25 1.75
    idx:     (5,4,7)
-
 With weight: -19.2941
 pt[1]:    location:  0.75 -0.25  1.75
    idx:     (5,3,7)
-
 With weight: 4
 pt[2]:    location: 0.25 0.25 1.75
    idx:     (4,4,7)
-
 With weight: 4
 pt[3]:    location: 1.25 0.25 1.75
    idx:     (6,4,7)
-
 With weight: 2.11765
 pt[4]:    location: 0.75 0.75 1.75
    idx:     (5,5,7)
-
 With weight: 4
 pt[5]:    location: 0.75 0.25 2.25
    idx:     (5,4,8)
-
 With weight: 3.29412
 pt[6]:    location: 1.25 0.25 1.25
    idx:     (6,4,6)
-
 With weight: 1.88235
 
 On point:    location: 1.25 0.25 1.75
    idx:     (6,4,7)
-
 pt[0]:    location: 1.25 0.25 1.75
    idx:     (6,4,7)
-
 With weight: -24
 pt[1]:    location: 1.25 0.25 1.25
    idx:     (6,4,6)
-
 With weight: 4
 pt[2]:    location:  1.25 -0.25  1.75
    idx:     (6,3,7)
-
 With weight: 4
 pt[3]:    location: 0.75 0.25 1.75
    idx:     (5,4,7)
-
 With weight: 4
 pt[4]:    location: 1.75 0.25 1.75
    idx:     (7,4,7)
-
 With weight: 4
 pt[5]:    location: 1.25 0.75 1.75
    idx:     (6,5,7)
-
 With weight: 4
 pt[6]:    location: 1.25 0.25 2.25
    idx:     (6,4,8)
-
 With weight: 4
 
 On point:    location: 1.75 0.25 1.75
    idx:     (7,4,7)
-
 pt[0]:    location: 1.75 0.25 1.75
    idx:     (7,4,7)
-
 With weight: -24
 pt[1]:    location: 1.75 0.25 1.25
    idx:     (7,4,6)
-
 With weight: 4
 pt[2]:    location:  1.75 -0.25  1.75
    idx:     (7,3,7)
-
 With weight: 4
 pt[3]:    location: 1.25 0.25 1.75
    idx:     (6,4,7)
-
 With weight: 4
 pt[4]:    location: 2.25 0.25 1.75
    idx:     (8,4,7)
-
 With weight: 4
 pt[5]:    location: 1.75 0.75 1.75
    idx:     (7,5,7)
-
 With weight: 4
 pt[6]:    location: 1.75 0.25 2.25
    idx:     (7,4,8)
-
 With weight: 4
 
 On point:    location: -1.75  0.75  1.75
    idx:     (0,5,7)
-
 pt[0]:    location: -1.75  0.75  1.75
    idx:     (0,5,7)
-
 With weight: -24
 pt[1]:    location: -1.75  0.75  1.25
    idx:     (0,5,6)
-
 With weight: 4
 pt[2]:    location: -1.75  0.25  1.75
    idx:     (0,4,7)
-
 With weight: 4
 pt[3]:    location: -2.25  0.75  1.75
    idx:     (-1,5,7)
-
 With weight: 4
 pt[4]:    location: -1.25  0.75  1.75
    idx:     (1,5,7)
-
 With weight: 4
 pt[5]:    location: -1.75  1.25  1.75
    idx:     (0,6,7)
-
 With weight: 4
 pt[6]:    location: -1.75  0.75  2.25
    idx:     (0,5,8)
-
 With weight: 4
 
 On point:    location: -1.25  0.75  1.75
    idx:     (1,5,7)
-
 pt[0]:    location: -1.25  0.75  1.75
    idx:     (1,5,7)
-
 With weight: -24
 pt[1]:    location: -1.25  0.75  1.25
    idx:     (1,5,6)
-
 With weight: 4
 pt[2]:    location: -1.25  0.25  1.75
    idx:     (1,4,7)
-
 With weight: 4
 pt[3]:    location: -1.75  0.75  1.75
    idx:     (0,5,7)
-
 With weight: 4
 pt[4]:    location: -0.75  0.75  1.75
    idx:     (2,5,7)
-
 With weight: 4
 pt[5]:    location: -1.25  1.25  1.75
    idx:     (1,6,7)
-
 With weight: 4
 pt[6]:    location: -1.25  0.75  2.25
    idx:     (1,5,8)
-
 With weight: 4
 
 On point:    location: -0.75  0.75  1.75
    idx:     (2,5,7)
-
 pt[0]:    location: -0.75  0.75  1.75
    idx:     (2,5,7)
-
 With weight: -19.2941
 pt[1]:    location: -0.75  0.25  1.75
    idx:     (2,4,7)
-
 With weight: 4
 pt[2]:    location: -1.25  0.75  1.75
    idx:     (1,5,7)
-
 With weight: 4
 pt[3]:    location: -0.25  0.75  1.75
    idx:     (3,5,7)
-
 With weight: 4
 pt[4]:    location: -0.75  1.25  1.75
    idx:     (2,6,7)
-
 With weight: 2.11765
 pt[5]:    location: -0.75  0.75  2.25
    idx:     (2,5,8)
-
 With weight: 3.29412
 pt[6]:    location: -0.75  1.25  1.25
    idx:     (2,6,6)
-
 With weight: 1.88235
 
 On point:    location: -0.25  0.75  1.75
    idx:     (3,5,7)
-
 pt[0]:    location: -0.25  0.75  1.75
    idx:     (3,5,7)
-
 With weight: -19.2941
 pt[1]:    location: -0.25  0.25  1.75
    idx:     (3,4,7)
-
 With weight: 4
 pt[2]:    location: -0.75  0.75  1.75
    idx:     (2,5,7)
-
 With weight: 4
 pt[3]:    location: 0.25 0.75 1.75
    idx:     (4,5,7)
-
 With weight: 4
 pt[4]:    location: -0.25  1.25  1.75
    idx:     (3,6,7)
-
 With weight: 2.11765
 pt[5]:    location: -0.25  0.75  2.25
    idx:     (3,5,8)
-
 With weight: 3.29412
 pt[6]:    location: -0.25  1.25  1.25
    idx:     (3,6,6)
-
 With weight: 1.88235
 
 On point:    location: 0.25 0.75 1.75
    idx:     (4,5,7)
-
 pt[0]:    location: 0.25 0.75 1.75
    idx:     (4,5,7)
-
 With weight: -19.2941
 pt[1]:    location: 0.25 0.25 1.75
    idx:     (4,4,7)
-
 With weight: 4
 pt[2]:    location: -0.25  0.75  1.75
    idx:     (3,5,7)
-
 With weight: 4
 pt[3]:    location: 0.75 0.75 1.75
    idx:     (5,5,7)
-
 With weight: 4
 pt[4]:    location: 0.25 1.25 1.75
    idx:     (4,6,7)
-
 With weight: 2.11765
 pt[5]:    location: 0.25 0.75 2.25
    idx:     (4,5,8)
-
 With weight: 3.29412
 pt[6]:    location: 0.25 1.25 1.25
    idx:     (4,6,6)
-
 With weight: 1.88235
 
 On point:    location: 0.75 0.75 1.75
    idx:     (5,5,7)
-
 pt[0]:    location: 0.75 0.75 1.75
    idx:     (5,5,7)
-
 With weight: -19.2941
 pt[1]:    location: 0.75 0.25 1.75
    idx:     (5,4,7)
-
 With weight: 4
 pt[2]:    location: 0.25 0.75 1.75
    idx:     (4,5,7)
-
 With weight: 4
 pt[3]:    location: 1.25 0.75 1.75
    idx:     (6,5,7)
-
 With weight: 4
 pt[4]:    location: 0.75 1.25 1.75
    idx:     (5,6,7)
-
 With weight: 2.11765
 pt[5]:    location: 0.75 0.75 2.25
    idx:     (5,5,8)
-
 With weight: 3.29412
 pt[6]:    location: 0.75 1.25 1.25
    idx:     (5,6,6)
-
 With weight: 1.88235
 
 On point:    location: 1.25 0.75 1.75
    idx:     (6,5,7)
-
 pt[0]:    location: 1.25 0.75 1.75
    idx:     (6,5,7)
-
 With weight: -24
 pt[1]:    location: 1.25 0.75 1.25
    idx:     (6,5,6)
-
 With weight: 4
 pt[2]:    location: 1.25 0.25 1.75
    idx:     (6,4,7)
-
 With weight: 4
 pt[3]:    location: 0.75 0.75 1.75
    idx:     (5,5,7)
-
 With weight: 4
 pt[4]:    location: 1.75 0.75 1.75
    idx:     (7,5,7)
-
 With weight: 4
 pt[5]:    location: 1.25 1.25 1.75
    idx:     (6,6,7)
-
 With weight: 4
 pt[6]:    location: 1.25 0.75 2.25
    idx:     (6,5,8)
-
 With weight: 4
 
 On point:    location: 1.75 0.75 1.75
    idx:     (7,5,7)
-
 pt[0]:    location: 1.75 0.75 1.75
    idx:     (7,5,7)
-
 With weight: -24
 pt[1]:    location: 1.75 0.75 1.25
    idx:     (7,5,6)
-
 With weight: 4
 pt[2]:    location: 1.75 0.25 1.75
    idx:     (7,4,7)
-
 With weight: 4
 pt[3]:    location: 1.25 0.75 1.75
    idx:     (6,5,7)
-
 With weight: 4
 pt[4]:    location: 2.25 0.75 1.75
    idx:     (8,5,7)
-
 With weight: 4
 pt[5]:    location: 1.75 1.25 1.75
    idx:     (7,6,7)
-
 With weight: 4
 pt[6]:    location: 1.75 0.75 2.25
    idx:     (7,5,8)
-
 With weight: 4
 
 On point:    location: -1.75  1.25  1.75
    idx:     (0,6,7)
-
 pt[0]:    location: -1.75  1.25  1.75
    idx:     (0,6,7)
-
 With weight: -24
 pt[1]:    location: -1.75  1.25  1.25
    idx:     (0,6,6)
-
 With weight: 4
 pt[2]:    location: -1.75  0.75  1.75
    idx:     (0,5,7)
-
 With weight: 4
 pt[3]:    location: -2.25  1.25  1.75
    idx:     (-1,6,7)
-
 With weight: 4
 pt[4]:    location: -1.25  1.25  1.75
    idx:     (1,6,7)
-
 With weight: 4
 pt[5]:    location: -1.75  1.75  1.75
    idx:     (0,7,7)
-
 With weight: 4
 pt[6]:    location: -1.75  1.25  2.25
    idx:     (0,6,8)
-
 With weight: 4
 
 On point:    location: -1.25  1.25  1.75
    idx:     (1,6,7)
-
 pt[0]:    location: -1.25  1.25  1.75
    idx:     (1,6,7)
-
 With weight: -24
 pt[1]:    location: -1.25  1.25  1.25
    idx:     (1,6,6)
-
 With weight: 4
 pt[2]:    location: -1.25  0.75  1.75
    idx:     (1,5,7)
-
 With weight: 4
 pt[3]:    location: -1.75  1.25  1.75
    idx:     (0,6,7)
-
 With weight: 4
 pt[4]:    location: -0.75  1.25  1.75
    idx:     (2,6,7)
-
 With weight: 4
 pt[5]:    location: -1.25  1.75  1.75
    idx:     (1,7,7)
-
 With weight: 4
 pt[6]:    location: -1.25  1.25  2.25
    idx:     (1,6,8)
-
 With weight: 4
 
 On point:    location: -0.75  1.25  1.75
    idx:     (2,6,7)
-
 pt[0]:    location: -0.75  1.25  1.75
    idx:     (2,6,7)
-
 With weight: -24
 pt[1]:    location: -0.75  1.25  1.25
    idx:     (2,6,6)
-
 With weight: 4
 pt[2]:    location: -0.75  0.75  1.75
    idx:     (2,5,7)
-
 With weight: 4
 pt[3]:    location: -1.25  1.25  1.75
    idx:     (1,6,7)
-
 With weight: 4
 pt[4]:    location: -0.25  1.25  1.75
    idx:     (3,6,7)
-
 With weight: 4
 pt[5]:    location: -0.75  1.75  1.75
    idx:     (2,7,7)
-
 With weight: 4
 pt[6]:    location: -0.75  1.25  2.25
    idx:     (2,6,8)
-
 With weight: 4
 
 On point:    location: -0.25  1.25  1.75
    idx:     (3,6,7)
-
 pt[0]:    location: -0.25  1.25  1.75
    idx:     (3,6,7)
-
 With weight: -24
 pt[1]:    location: -0.25  1.25  1.25
    idx:     (3,6,6)
-
 With weight: 4
 pt[2]:    location: -0.25  0.75  1.75
    idx:     (3,5,7)
-
 With weight: 4
 pt[3]:    location: -0.75  1.25  1.75
    idx:     (2,6,7)
-
 With weight: 4
 pt[4]:    location: 0.25 1.25 1.75
    idx:     (4,6,7)
-
 With weight: 4
 pt[5]:    location: -0.25  1.75  1.75
    idx:     (3,7,7)
-
 With weight: 4
 pt[6]:    location: -0.25  1.25  2.25
    idx:     (3,6,8)
-
 With weight: 4
 
 On point:    location: 0.25 1.25 1.75
    idx:     (4,6,7)
-
 pt[0]:    location: 0.25 1.25 1.75
    idx:     (4,6,7)
-
 With weight: -24
 pt[1]:    location: 0.25 1.25 1.25
    idx:     (4,6,6)
-
 With weight: 4
 pt[2]:    location: 0.25 0.75 1.75
    idx:     (4,5,7)
-
 With weight: 4
 pt[3]:    location: -0.25  1.25  1.75
    idx:     (3,6,7)
-
 With weight: 4
 pt[4]:    location: 0.75 1.25 1.75
    idx:     (5,6,7)
-
 With weight: 4
 pt[5]:    location: 0.25 1.75 1.75
    idx:     (4,7,7)
-
 With weight: 4
 pt[6]:    location: 0.25 1.25 2.25
    idx:     (4,6,8)
-
 With weight: 4
 
 On point:    location: 0.75 1.25 1.75
    idx:     (5,6,7)
-
 pt[0]:    location: 0.75 1.25 1.75
    idx:     (5,6,7)
-
 With weight: -24
 pt[1]:    location: 0.75 1.25 1.25
    idx:     (5,6,6)
-
 With weight: 4
 pt[2]:    location: 0.75 0.75 1.75
    idx:     (5,5,7)
-
 With weight: 4
 pt[3]:    location: 0.25 1.25 1.75
    idx:     (4,6,7)
-
 With weight: 4
 pt[4]:    location: 1.25 1.25 1.75
    idx:     (6,6,7)
-
 With weight: 4
 pt[5]:    location: 0.75 1.75 1.75
    idx:     (5,7,7)
-
 With weight: 4
 pt[6]:    location: 0.75 1.25 2.25
    idx:     (5,6,8)
-
 With weight: 4
 
 On point:    location: 1.25 1.25 1.75
    idx:     (6,6,7)
-
 pt[0]:    location: 1.25 1.25 1.75
    idx:     (6,6,7)
-
 With weight: -24
 pt[1]:    location: 1.25 1.25 1.25
    idx:     (6,6,6)
-
 With weight: 4
 pt[2]:    location: 1.25 0.75 1.75
    idx:     (6,5,7)
-
 With weight: 4
 pt[3]:    location: 0.75 1.25 1.75
    idx:     (5,6,7)
-
 With weight: 4
 pt[4]:    location: 1.75 1.25 1.75
    idx:     (7,6,7)
-
 With weight: 4
 pt[5]:    location: 1.25 1.75 1.75
    idx:     (6,7,7)
-
 With weight: 4
 pt[6]:    location: 1.25 1.25 2.25
    idx:     (6,6,8)
-
 With weight: 4
 
 On point:    location: 1.75 1.25 1.75
    idx:     (7,6,7)
-
 pt[0]:    location: 1.75 1.25 1.75
    idx:     (7,6,7)
-
 With weight: -24
 pt[1]:    location: 1.75 1.25 1.25
    idx:     (7,6,6)
-
 With weight: 4
 pt[2]:    location: 1.75 0.75 1.75
    idx:     (7,5,7)
-
 With weight: 4
 pt[3]:    location: 1.25 1.25 1.75
    idx:     (6,6,7)
-
 With weight: 4
 pt[4]:    location: 2.25 1.25 1.75
    idx:     (8,6,7)
-
 With weight: 4
 pt[5]:    location: 1.75 1.75 1.75
    idx:     (7,7,7)
-
 With weight: 4
 pt[6]:    location: 1.75 1.25 2.25
    idx:     (7,6,8)
-
 With weight: 4
 
 On point:    location: -1.75  1.75  1.75
    idx:     (0,7,7)
-
 pt[0]:    location: -1.75  1.75  1.75
    idx:     (0,7,7)
-
 With weight: -24
 pt[1]:    location: -1.75  1.75  1.25
    idx:     (0,7,6)
-
 With weight: 4
 pt[2]:    location: -1.75  1.25  1.75
    idx:     (0,6,7)
-
 With weight: 4
 pt[3]:    location: -2.25  1.75  1.75
    idx:     (-1,7,7)
-
 With weight: 4
 pt[4]:    location: -1.25  1.75  1.75
    idx:     (1,7,7)
-
 With weight: 4
 pt[5]:    location: -1.75  2.25  1.75
    idx:     (0,8,7)
-
 With weight: 4
 pt[6]:    location: -1.75  1.75  2.25
    idx:     (0,7,8)
-
 With weight: 4
 
 On point:    location: -1.25  1.75  1.75
    idx:     (1,7,7)
-
 pt[0]:    location: -1.25  1.75  1.75
    idx:     (1,7,7)
-
 With weight: -24
 pt[1]:    location: -1.25  1.75  1.25
    idx:     (1,7,6)
-
 With weight: 4
 pt[2]:    location: -1.25  1.25  1.75
    idx:     (1,6,7)
-
 With weight: 4
 pt[3]:    location: -1.75  1.75  1.75
    idx:     (0,7,7)
-
 With weight: 4
 pt[4]:    location: -0.75  1.75  1.75
    idx:     (2,7,7)
-
 With weight: 4
 pt[5]:    location: -1.25  2.25  1.75
    idx:     (1,8,7)
-
 With weight: 4
 pt[6]:    location: -1.25  1.75  2.25
    idx:     (1,7,8)
-
 With weight: 4
 
 On point:    location: -0.75  1.75  1.75
    idx:     (2,7,7)
-
 pt[0]:    location: -0.75  1.75  1.75
    idx:     (2,7,7)
-
 With weight: -24
 pt[1]:    location: -0.75  1.75  1.25
    idx:     (2,7,6)
-
 With weight: 4
 pt[2]:    location: -0.75  1.25  1.75
    idx:     (2,6,7)
-
 With weight: 4
 pt[3]:    location: -1.25  1.75  1.75
    idx:     (1,7,7)
-
 With weight: 4
 pt[4]:    location: -0.25  1.75  1.75
    idx:     (3,7,7)
-
 With weight: 4
 pt[5]:    location: -0.75  2.25  1.75
    idx:     (2,8,7)
-
 With weight: 4
 pt[6]:    location: -0.75  1.75  2.25
    idx:     (2,7,8)
-
 With weight: 4
 
 On point:    location: -0.25  1.75  1.75
    idx:     (3,7,7)
-
 pt[0]:    location: -0.25  1.75  1.75
    idx:     (3,7,7)
-
 With weight: -24
 pt[1]:    location: -0.25  1.75  1.25
    idx:     (3,7,6)
-
 With weight: 4
 pt[2]:    location: -0.25  1.25  1.75
    idx:     (3,6,7)
-
 With weight: 4
 pt[3]:    location: -0.75  1.75  1.75
    idx:     (2,7,7)
-
 With weight: 4
 pt[4]:    location: 0.25 1.75 1.75
    idx:     (4,7,7)
-
 With weight: 4
 pt[5]:    location: -0.25  2.25  1.75
    idx:     (3,8,7)
-
 With weight: 4
 pt[6]:    location: -0.25  1.75  2.25
    idx:     (3,7,8)
-
 With weight: 4
 
 On point:    location: 0.25 1.75 1.75
    idx:     (4,7,7)
-
 pt[0]:    location: 0.25 1.75 1.75
    idx:     (4,7,7)
-
 With weight: -24
 pt[1]:    location: 0.25 1.75 1.25
    idx:     (4,7,6)
-
 With weight: 4
 pt[2]:    location: 0.25 1.25 1.75
    idx:     (4,6,7)
-
 With weight: 4
 pt[3]:    location: -0.25  1.75  1.75
    idx:     (3,7,7)
-
 With weight: 4
 pt[4]:    location: 0.75 1.75 1.75
    idx:     (5,7,7)
-
 With weight: 4
 pt[5]:    location: 0.25 2.25 1.75
    idx:     (4,8,7)
-
 With weight: 4
 pt[6]:    location: 0.25 1.75 2.25
    idx:     (4,7,8)
-
 With weight: 4
 
 On point:    location: 0.75 1.75 1.75
    idx:     (5,7,7)
-
 pt[0]:    location: 0.75 1.75 1.75
    idx:     (5,7,7)
-
 With weight: -24
 pt[1]:    location: 0.75 1.75 1.25
    idx:     (5,7,6)
-
 With weight: 4
 pt[2]:    location: 0.75 1.25 1.75
    idx:     (5,6,7)
-
 With weight: 4
 pt[3]:    location: 0.25 1.75 1.75
    idx:     (4,7,7)
-
 With weight: 4
 pt[4]:    location: 1.25 1.75 1.75
    idx:     (6,7,7)
-
 With weight: 4
 pt[5]:    location: 0.75 2.25 1.75
    idx:     (5,8,7)
-
 With weight: 4
 pt[6]:    location: 0.75 1.75 2.25
    idx:     (5,7,8)
-
 With weight: 4
 
 On point:    location: 1.25 1.75 1.75
    idx:     (6,7,7)
-
 pt[0]:    location: 1.25 1.75 1.75
    idx:     (6,7,7)
-
 With weight: -24
 pt[1]:    location: 1.25 1.75 1.25
    idx:     (6,7,6)
-
 With weight: 4
 pt[2]:    location: 1.25 1.25 1.75
    idx:     (6,6,7)
-
 With weight: 4
 pt[3]:    location: 0.75 1.75 1.75
    idx:     (5,7,7)
-
 With weight: 4
 pt[4]:    location: 1.75 1.75 1.75
    idx:     (7,7,7)
-
 With weight: 4
 pt[5]:    location: 1.25 2.25 1.75
    idx:     (6,8,7)
-
 With weight: 4
 pt[6]:    location: 1.25 1.75 2.25
    idx:     (6,7,8)
-
 With weight: 4
 
 On point:    location: 1.75 1.75 1.75
    idx:     (7,7,7)
-
 pt[0]:    location: 1.75 1.75 1.75
    idx:     (7,7,7)
-
 With weight: -24
 pt[1]:    location: 1.75 1.75 1.25
    idx:     (7,7,6)
-
 With weight: 4
 pt[2]:    location: 1.75 1.25 1.75
    idx:     (7,6,7)
-
 With weight: 4
 pt[3]:    location: 1.25 1.75 1.75
    idx:     (6,7,7)
-
 With weight: 4
 pt[4]:    location: 2.25 1.75 1.75
    idx:     (8,7,7)
-
 With weight: 4
 pt[5]:    location: 1.75 2.25 1.75
    idx:     (7,8,7)
-
 With weight: 4
 pt[6]:    location: 1.75 1.75 2.25
    idx:     (7,7,8)
-
 With weight: 4
 

--- a/tests/operators/rbf_fd_weights_3d.output
+++ b/tests/operators/rbf_fd_weights_3d.output
@@ -1,11264 +1,11264 @@
 On point:    location: -1.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (0,0,0)
+
 pt[0]:    location: -1.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (0,0,0)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -2.25
-   is located on boundary: 0
    idx:     (0,0,-1)
+
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -1.75
-   is located on boundary: 0
    idx:     (0,-1,0)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (-1,0,0)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (1,0,0)
+
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (0,1,0)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (0,0,1)
+
 With weight: 4
 
 On point:    location: -1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (1,0,0)
+
 pt[0]:    location: -1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (1,0,0)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -2.25
-   is located on boundary: 0
    idx:     (1,0,-1)
+
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -1.75
-   is located on boundary: 0
    idx:     (1,-1,0)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (0,0,0)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (2,0,0)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (1,1,0)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (1,0,1)
+
 With weight: 4
 
 On point:    location: -0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (2,0,0)
+
 pt[0]:    location: -0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (2,0,0)
+
 With weight: -24
 pt[1]:    location: -0.75 -1.75 -2.25
-   is located on boundary: 0
    idx:     (2,0,-1)
+
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -1.75
-   is located on boundary: 0
    idx:     (2,-1,0)
+
 With weight: 4
 pt[3]:    location: -1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (1,0,0)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (3,0,0)
+
 With weight: 4
 pt[5]:    location: -0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (2,1,0)
+
 With weight: 4
 pt[6]:    location: -0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (2,0,1)
+
 With weight: 4
 
 On point:    location: -0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (3,0,0)
+
 pt[0]:    location: -0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (3,0,0)
+
 With weight: -24
 pt[1]:    location: -0.25 -1.75 -2.25
-   is located on boundary: 0
    idx:     (3,0,-1)
+
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -1.75
-   is located on boundary: 0
    idx:     (3,-1,0)
+
 With weight: 4
 pt[3]:    location: -0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (2,0,0)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (4,0,0)
+
 With weight: 4
 pt[5]:    location: -0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (3,1,0)
+
 With weight: 4
 pt[6]:    location: -0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (3,0,1)
+
 With weight: 4
 
 On point:    location:  0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (4,0,0)
+
 pt[0]:    location:  0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (4,0,0)
+
 With weight: -24
 pt[1]:    location:  0.25 -1.75 -2.25
-   is located on boundary: 0
    idx:     (4,0,-1)
+
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -1.75
-   is located on boundary: 0
    idx:     (4,-1,0)
+
 With weight: 4
 pt[3]:    location: -0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (3,0,0)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (5,0,0)
+
 With weight: 4
 pt[5]:    location:  0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (4,1,0)
+
 With weight: 4
 pt[6]:    location:  0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (4,0,1)
+
 With weight: 4
 
 On point:    location:  0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (5,0,0)
+
 pt[0]:    location:  0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (5,0,0)
+
 With weight: -24
 pt[1]:    location:  0.75 -1.75 -2.25
-   is located on boundary: 0
    idx:     (5,0,-1)
+
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -1.75
-   is located on boundary: 0
    idx:     (5,-1,0)
+
 With weight: 4
 pt[3]:    location:  0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (4,0,0)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (6,0,0)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (5,1,0)
+
 With weight: 4
 pt[6]:    location:  0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (5,0,1)
+
 With weight: 4
 
 On point:    location:  1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (6,0,0)
+
 pt[0]:    location:  1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (6,0,0)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -2.25
-   is located on boundary: 0
    idx:     (6,0,-1)
+
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -1.75
-   is located on boundary: 0
    idx:     (6,-1,0)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (5,0,0)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (7,0,0)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (6,1,0)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (6,0,1)
+
 With weight: 4
 
 On point:    location:  1.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (7,0,0)
+
 pt[0]:    location:  1.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (7,0,0)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -2.25
-   is located on boundary: 0
    idx:     (7,0,-1)
+
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -1.75
-   is located on boundary: 0
    idx:     (7,-1,0)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (6,0,0)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (8,0,0)
+
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (7,1,0)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (7,0,1)
+
 With weight: 4
 
 On point:    location: -1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (0,1,0)
+
 pt[0]:    location: -1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (0,1,0)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -2.25
-   is located on boundary: 0
    idx:     (0,1,-1)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (0,0,0)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (-1,1,0)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (1,1,0)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (0,2,0)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (0,1,1)
+
 With weight: 4
 
 On point:    location: -1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (1,1,0)
+
 pt[0]:    location: -1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (1,1,0)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.25 -2.25
-   is located on boundary: 0
    idx:     (1,1,-1)
+
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (1,0,0)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (0,1,0)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (2,1,0)
+
 With weight: 4
 pt[5]:    location: -1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (1,2,0)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (1,1,1)
+
 With weight: 4
 
 On point:    location: -0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (2,1,0)
+
 pt[0]:    location: -0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (2,1,0)
+
 With weight: -24
 pt[1]:    location: -0.75 -1.25 -2.25
-   is located on boundary: 0
    idx:     (2,1,-1)
+
 With weight: 4
 pt[2]:    location: -0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (2,0,0)
+
 With weight: 4
 pt[3]:    location: -1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (1,1,0)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (3,1,0)
+
 With weight: 4
 pt[5]:    location: -0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (2,2,0)
+
 With weight: 4
 pt[6]:    location: -0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (2,1,1)
+
 With weight: 4
 
 On point:    location: -0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (3,1,0)
+
 pt[0]:    location: -0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (3,1,0)
+
 With weight: -24
 pt[1]:    location: -0.25 -1.25 -2.25
-   is located on boundary: 0
    idx:     (3,1,-1)
+
 With weight: 4
 pt[2]:    location: -0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (3,0,0)
+
 With weight: 4
 pt[3]:    location: -0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (2,1,0)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (4,1,0)
+
 With weight: 4
 pt[5]:    location: -0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (3,2,0)
+
 With weight: 4
 pt[6]:    location: -0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (3,1,1)
+
 With weight: 4
 
 On point:    location:  0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (4,1,0)
+
 pt[0]:    location:  0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (4,1,0)
+
 With weight: -24
 pt[1]:    location:  0.25 -1.25 -2.25
-   is located on boundary: 0
    idx:     (4,1,-1)
+
 With weight: 4
 pt[2]:    location:  0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (4,0,0)
+
 With weight: 4
 pt[3]:    location: -0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (3,1,0)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (5,1,0)
+
 With weight: 4
 pt[5]:    location:  0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (4,2,0)
+
 With weight: 4
 pt[6]:    location:  0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (4,1,1)
+
 With weight: 4
 
 On point:    location:  0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (5,1,0)
+
 pt[0]:    location:  0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (5,1,0)
+
 With weight: -24
 pt[1]:    location:  0.75 -1.25 -2.25
-   is located on boundary: 0
    idx:     (5,1,-1)
+
 With weight: 4
 pt[2]:    location:  0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (5,0,0)
+
 With weight: 4
 pt[3]:    location:  0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (4,1,0)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (6,1,0)
+
 With weight: 4
 pt[5]:    location:  0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (5,2,0)
+
 With weight: 4
 pt[6]:    location:  0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (5,1,1)
+
 With weight: 4
 
 On point:    location:  1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (6,1,0)
+
 pt[0]:    location:  1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (6,1,0)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.25 -2.25
-   is located on boundary: 0
    idx:     (6,1,-1)
+
 With weight: 4
 pt[2]:    location:  1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (6,0,0)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (5,1,0)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (7,1,0)
+
 With weight: 4
 pt[5]:    location:  1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (6,2,0)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (6,1,1)
+
 With weight: 4
 
 On point:    location:  1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (7,1,0)
+
 pt[0]:    location:  1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (7,1,0)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -2.25
-   is located on boundary: 0
    idx:     (7,1,-1)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (7,0,0)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (6,1,0)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (8,1,0)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (7,2,0)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (7,1,1)
+
 With weight: 4
 
 On point:    location: -1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (0,2,0)
+
 pt[0]:    location: -1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (0,2,0)
+
 With weight: -24
 pt[1]:    location: -1.75 -0.75 -2.25
-   is located on boundary: 0
    idx:     (0,2,-1)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (0,1,0)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (-1,2,0)
+
 With weight: 4
 pt[4]:    location: -1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (1,2,0)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (0,3,0)
+
 With weight: 4
 pt[6]:    location: -1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (0,2,1)
+
 With weight: 4
 
 On point:    location: -1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (1,2,0)
+
 pt[0]:    location: -1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (1,2,0)
+
 With weight: -24
 pt[1]:    location: -1.25 -0.75 -2.25
-   is located on boundary: 0
    idx:     (1,2,-1)
+
 With weight: 4
 pt[2]:    location: -1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (1,1,0)
+
 With weight: 4
 pt[3]:    location: -1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (0,2,0)
+
 With weight: 4
 pt[4]:    location: -0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (2,2,0)
+
 With weight: 4
 pt[5]:    location: -1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (1,3,0)
+
 With weight: 4
 pt[6]:    location: -1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (1,2,1)
+
 With weight: 4
 
 On point:    location: -0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (2,2,0)
+
 pt[0]:    location: -0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (2,2,0)
+
 With weight: -18.6667
 pt[1]:    location: -0.75 -0.75 -2.25
-   is located on boundary: 0
    idx:     (2,2,-1)
+
 With weight: 2.66667
 pt[2]:    location: -0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (2,1,0)
+
 With weight: 4
 pt[3]:    location: -1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (1,2,0)
+
 With weight: 4
 pt[4]:    location: -0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (3,2,0)
+
 With weight: 4
 pt[5]:    location: -0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (2,3,0)
+
 With weight: 4
 pt[6]:    location: -0.75 -1.25 -2.25
-   is located on boundary: 0
    idx:     (2,1,-1)
+
 With weight: -5.7285e-16
 
 On point:    location: -0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (3,2,0)
+
 pt[0]:    location: -0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (3,2,0)
+
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.75 -2.25
-   is located on boundary: 0
    idx:     (3,2,-1)
+
 With weight: 2.66667
 pt[2]:    location: -0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (3,1,0)
+
 With weight: 4
 pt[3]:    location: -0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (2,2,0)
+
 With weight: 4
 pt[4]:    location:  0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (4,2,0)
+
 With weight: 4
 pt[5]:    location: -0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (3,3,0)
+
 With weight: 4
 pt[6]:    location: -0.25 -1.25 -2.25
-   is located on boundary: 0
    idx:     (3,1,-1)
+
 With weight: -5.7285e-16
 
 On point:    location:  0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (4,2,0)
+
 pt[0]:    location:  0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (4,2,0)
+
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.75 -2.25
-   is located on boundary: 0
    idx:     (4,2,-1)
+
 With weight: 2.66667
 pt[2]:    location:  0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (4,1,0)
+
 With weight: 4
 pt[3]:    location: -0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (3,2,0)
+
 With weight: 4
 pt[4]:    location:  0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (5,2,0)
+
 With weight: 4
 pt[5]:    location:  0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (4,3,0)
+
 With weight: 4
 pt[6]:    location:  0.25 -1.25 -2.25
-   is located on boundary: 0
    idx:     (4,1,-1)
+
 With weight: -5.7285e-16
 
 On point:    location:  0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (5,2,0)
+
 pt[0]:    location:  0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (5,2,0)
+
 With weight: -18.6667
 pt[1]:    location:  0.75 -0.75 -2.25
-   is located on boundary: 0
    idx:     (5,2,-1)
+
 With weight: 2.66667
 pt[2]:    location:  0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (5,1,0)
+
 With weight: 4
 pt[3]:    location:  0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (4,2,0)
+
 With weight: 4
 pt[4]:    location:  1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (6,2,0)
+
 With weight: 4
 pt[5]:    location:  0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (5,3,0)
+
 With weight: 4
 pt[6]:    location:  0.75 -1.25 -2.25
-   is located on boundary: 0
    idx:     (5,1,-1)
+
 With weight: -5.7285e-16
 
 On point:    location:  1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (6,2,0)
+
 pt[0]:    location:  1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (6,2,0)
+
 With weight: -24
 pt[1]:    location:  1.25 -0.75 -2.25
-   is located on boundary: 0
    idx:     (6,2,-1)
+
 With weight: 4
 pt[2]:    location:  1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (6,1,0)
+
 With weight: 4
 pt[3]:    location:  0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (5,2,0)
+
 With weight: 4
 pt[4]:    location:  1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (7,2,0)
+
 With weight: 4
 pt[5]:    location:  1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (6,3,0)
+
 With weight: 4
 pt[6]:    location:  1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (6,2,1)
+
 With weight: 4
 
 On point:    location:  1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (7,2,0)
+
 pt[0]:    location:  1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (7,2,0)
+
 With weight: -24
 pt[1]:    location:  1.75 -0.75 -2.25
-   is located on boundary: 0
    idx:     (7,2,-1)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (7,1,0)
+
 With weight: 4
 pt[3]:    location:  1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (6,2,0)
+
 With weight: 4
 pt[4]:    location:  2.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (8,2,0)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (7,3,0)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (7,2,1)
+
 With weight: 4
 
 On point:    location: -1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (0,3,0)
+
 pt[0]:    location: -1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (0,3,0)
+
 With weight: -24
 pt[1]:    location: -1.75 -0.25 -2.25
-   is located on boundary: 0
    idx:     (0,3,-1)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (0,2,0)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (-1,3,0)
+
 With weight: 4
 pt[4]:    location: -1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (1,3,0)
+
 With weight: 4
 pt[5]:    location: -1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (0,4,0)
+
 With weight: 4
 pt[6]:    location: -1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (0,3,1)
+
 With weight: 4
 
 On point:    location: -1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (1,3,0)
+
 pt[0]:    location: -1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (1,3,0)
+
 With weight: -24
 pt[1]:    location: -1.25 -0.25 -2.25
-   is located on boundary: 0
    idx:     (1,3,-1)
+
 With weight: 4
 pt[2]:    location: -1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (1,2,0)
+
 With weight: 4
 pt[3]:    location: -1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (0,3,0)
+
 With weight: 4
 pt[4]:    location: -0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (2,3,0)
+
 With weight: 4
 pt[5]:    location: -1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (1,4,0)
+
 With weight: 4
 pt[6]:    location: -1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (1,3,1)
+
 With weight: 4
 
 On point:    location: -0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (2,3,0)
+
 pt[0]:    location: -0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (2,3,0)
+
 With weight: -18.6667
 pt[1]:    location: -0.75 -0.25 -2.25
-   is located on boundary: 0
    idx:     (2,3,-1)
+
 With weight: 2.66667
 pt[2]:    location: -0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (2,2,0)
+
 With weight: 4
 pt[3]:    location: -1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (1,3,0)
+
 With weight: 4
 pt[4]:    location: -0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (3,3,0)
+
 With weight: 4
 pt[5]:    location: -0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (2,4,0)
+
 With weight: 4
 pt[6]:    location: -0.75 -0.75 -2.25
-   is located on boundary: 0
    idx:     (2,2,-1)
+
 With weight: -5.7285e-16
 
 On point:    location: -0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (3,3,0)
+
 pt[0]:    location: -0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (3,3,0)
+
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.25 -2.25
-   is located on boundary: 0
    idx:     (3,3,-1)
+
 With weight: 2.66667
 pt[2]:    location: -0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (3,2,0)
+
 With weight: 4
 pt[3]:    location: -0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (2,3,0)
+
 With weight: 4
 pt[4]:    location:  0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (4,3,0)
+
 With weight: 4
 pt[5]:    location: -0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (3,4,0)
+
 With weight: 4
 pt[6]:    location: -0.25 -0.75 -2.25
-   is located on boundary: 0
    idx:     (3,2,-1)
+
 With weight: -5.7285e-16
 
 On point:    location:  0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (4,3,0)
+
 pt[0]:    location:  0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (4,3,0)
+
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.25 -2.25
-   is located on boundary: 0
    idx:     (4,3,-1)
+
 With weight: 2.66667
 pt[2]:    location:  0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (4,2,0)
+
 With weight: 4
 pt[3]:    location: -0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (3,3,0)
+
 With weight: 4
 pt[4]:    location:  0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (5,3,0)
+
 With weight: 4
 pt[5]:    location:  0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (4,4,0)
+
 With weight: 4
 pt[6]:    location:  0.25 -0.75 -2.25
-   is located on boundary: 0
    idx:     (4,2,-1)
+
 With weight: -5.7285e-16
 
 On point:    location:  0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (5,3,0)
+
 pt[0]:    location:  0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (5,3,0)
+
 With weight: -18.6667
 pt[1]:    location:  0.75 -0.25 -2.25
-   is located on boundary: 0
    idx:     (5,3,-1)
+
 With weight: 2.66667
 pt[2]:    location:  0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (5,2,0)
+
 With weight: 4
 pt[3]:    location:  0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (4,3,0)
+
 With weight: 4
 pt[4]:    location:  1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (6,3,0)
+
 With weight: 4
 pt[5]:    location:  0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (5,4,0)
+
 With weight: 4
 pt[6]:    location:  0.75 -0.75 -2.25
-   is located on boundary: 0
    idx:     (5,2,-1)
+
 With weight: -5.7285e-16
 
 On point:    location:  1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (6,3,0)
+
 pt[0]:    location:  1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (6,3,0)
+
 With weight: -24
 pt[1]:    location:  1.25 -0.25 -2.25
-   is located on boundary: 0
    idx:     (6,3,-1)
+
 With weight: 4
 pt[2]:    location:  1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (6,2,0)
+
 With weight: 4
 pt[3]:    location:  0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (5,3,0)
+
 With weight: 4
 pt[4]:    location:  1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (7,3,0)
+
 With weight: 4
 pt[5]:    location:  1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (6,4,0)
+
 With weight: 4
 pt[6]:    location:  1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (6,3,1)
+
 With weight: 4
 
 On point:    location:  1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (7,3,0)
+
 pt[0]:    location:  1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (7,3,0)
+
 With weight: -24
 pt[1]:    location:  1.75 -0.25 -2.25
-   is located on boundary: 0
    idx:     (7,3,-1)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (7,2,0)
+
 With weight: 4
 pt[3]:    location:  1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (6,3,0)
+
 With weight: 4
 pt[4]:    location:  2.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (8,3,0)
+
 With weight: 4
 pt[5]:    location:  1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (7,4,0)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (7,3,1)
+
 With weight: 4
 
 On point:    location: -1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (0,4,0)
+
 pt[0]:    location: -1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (0,4,0)
+
 With weight: -24
 pt[1]:    location: -1.75  0.25 -2.25
-   is located on boundary: 0
    idx:     (0,4,-1)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (0,3,0)
+
 With weight: 4
 pt[3]:    location: -2.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (-1,4,0)
+
 With weight: 4
 pt[4]:    location: -1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (1,4,0)
+
 With weight: 4
 pt[5]:    location: -1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (0,5,0)
+
 With weight: 4
 pt[6]:    location: -1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (0,4,1)
+
 With weight: 4
 
 On point:    location: -1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (1,4,0)
+
 pt[0]:    location: -1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (1,4,0)
+
 With weight: -24
 pt[1]:    location: -1.25  0.25 -2.25
-   is located on boundary: 0
    idx:     (1,4,-1)
+
 With weight: 4
 pt[2]:    location: -1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (1,3,0)
+
 With weight: 4
 pt[3]:    location: -1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (0,4,0)
+
 With weight: 4
 pt[4]:    location: -0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (2,4,0)
+
 With weight: 4
 pt[5]:    location: -1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (1,5,0)
+
 With weight: 4
 pt[6]:    location: -1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (1,4,1)
+
 With weight: 4
 
 On point:    location: -0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (2,4,0)
+
 pt[0]:    location: -0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (2,4,0)
+
 With weight: -18.6667
 pt[1]:    location: -0.75  0.25 -2.25
-   is located on boundary: 0
    idx:     (2,4,-1)
+
 With weight: 2.66667
 pt[2]:    location: -0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (2,3,0)
+
 With weight: 4
 pt[3]:    location: -1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (1,4,0)
+
 With weight: 4
 pt[4]:    location: -0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (3,4,0)
+
 With weight: 4
 pt[5]:    location: -0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (2,5,0)
+
 With weight: 4
 pt[6]:    location: -1.25  0.25 -2.25
-   is located on boundary: 0
    idx:     (1,4,-1)
+
 With weight: 1.82407e-15
 
 On point:    location: -0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (3,4,0)
+
 pt[0]:    location: -0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (3,4,0)
+
 With weight: -18.6667
 pt[1]:    location: -0.25  0.25 -2.25
-   is located on boundary: 0
    idx:     (3,4,-1)
+
 With weight: 2.66667
 pt[2]:    location: -0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (3,3,0)
+
 With weight: 4
 pt[3]:    location: -0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (2,4,0)
+
 With weight: 4
 pt[4]:    location:  0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (4,4,0)
+
 With weight: 4
 pt[5]:    location: -0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (3,5,0)
+
 With weight: 4
 pt[6]:    location: -0.75  0.25 -2.25
-   is located on boundary: 0
    idx:     (2,4,-1)
+
 With weight: 1.82407e-15
 
 On point:    location:  0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (4,4,0)
+
 pt[0]:    location:  0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (4,4,0)
+
 With weight: -18.6667
 pt[1]:    location:  0.25  0.25 -2.25
-   is located on boundary: 0
    idx:     (4,4,-1)
+
 With weight: 2.66667
 pt[2]:    location:  0.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (4,3,0)
+
 With weight: 4
 pt[3]:    location: -0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (3,4,0)
+
 With weight: 4
 pt[4]:    location:  0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (5,4,0)
+
 With weight: 4
 pt[5]:    location:  0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (4,5,0)
+
 With weight: 4
 pt[6]:    location:  0.75  0.25 -2.25
-   is located on boundary: 0
    idx:     (5,4,-1)
+
 With weight: -2.7135e-16
 
 On point:    location:  0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (5,4,0)
+
 pt[0]:    location:  0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (5,4,0)
+
 With weight: -18.6667
 pt[1]:    location:  0.75  0.25 -2.25
-   is located on boundary: 0
    idx:     (5,4,-1)
+
 With weight: 2.66667
 pt[2]:    location:  0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (5,3,0)
+
 With weight: 4
 pt[3]:    location:  0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (4,4,0)
+
 With weight: 4
 pt[4]:    location:  1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (6,4,0)
+
 With weight: 4
 pt[5]:    location:  0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (5,5,0)
+
 With weight: 4
 pt[6]:    location:  0.25  0.25 -2.25
-   is located on boundary: 0
    idx:     (4,4,-1)
+
 With weight: 1.82407e-15
 
 On point:    location:  1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (6,4,0)
+
 pt[0]:    location:  1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (6,4,0)
+
 With weight: -24
 pt[1]:    location:  1.25  0.25 -2.25
-   is located on boundary: 0
    idx:     (6,4,-1)
+
 With weight: 4
 pt[2]:    location:  1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (6,3,0)
+
 With weight: 4
 pt[3]:    location:  0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (5,4,0)
+
 With weight: 4
 pt[4]:    location:  1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (7,4,0)
+
 With weight: 4
 pt[5]:    location:  1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (6,5,0)
+
 With weight: 4
 pt[6]:    location:  1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (6,4,1)
+
 With weight: 4
 
 On point:    location:  1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (7,4,0)
+
 pt[0]:    location:  1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (7,4,0)
+
 With weight: -24
 pt[1]:    location:  1.75  0.25 -2.25
-   is located on boundary: 0
    idx:     (7,4,-1)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (7,3,0)
+
 With weight: 4
 pt[3]:    location:  1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (6,4,0)
+
 With weight: 4
 pt[4]:    location:  2.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (8,4,0)
+
 With weight: 4
 pt[5]:    location:  1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (7,5,0)
+
 With weight: 4
 pt[6]:    location:  1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (7,4,1)
+
 With weight: 4
 
 On point:    location: -1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (0,5,0)
+
 pt[0]:    location: -1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (0,5,0)
+
 With weight: -24
 pt[1]:    location: -1.75  0.75 -2.25
-   is located on boundary: 0
    idx:     (0,5,-1)
+
 With weight: 4
 pt[2]:    location: -1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (0,4,0)
+
 With weight: 4
 pt[3]:    location: -2.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (-1,5,0)
+
 With weight: 4
 pt[4]:    location: -1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (1,5,0)
+
 With weight: 4
 pt[5]:    location: -1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (0,6,0)
+
 With weight: 4
 pt[6]:    location: -1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (0,5,1)
+
 With weight: 4
 
 On point:    location: -1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (1,5,0)
+
 pt[0]:    location: -1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (1,5,0)
+
 With weight: -24
 pt[1]:    location: -1.25  0.75 -2.25
-   is located on boundary: 0
    idx:     (1,5,-1)
+
 With weight: 4
 pt[2]:    location: -1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (1,4,0)
+
 With weight: 4
 pt[3]:    location: -1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (0,5,0)
+
 With weight: 4
 pt[4]:    location: -0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (2,5,0)
+
 With weight: 4
 pt[5]:    location: -1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (1,6,0)
+
 With weight: 4
 pt[6]:    location: -1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (1,5,1)
+
 With weight: 4
 
 On point:    location: -0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (2,5,0)
+
 pt[0]:    location: -0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (2,5,0)
+
 With weight: -18.6667
 pt[1]:    location: -0.75  0.75 -2.25
-   is located on boundary: 0
    idx:     (2,5,-1)
+
 With weight: 2.66667
 pt[2]:    location: -0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (2,4,0)
+
 With weight: 4
 pt[3]:    location: -1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (1,5,0)
+
 With weight: 4
 pt[4]:    location: -0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (3,5,0)
+
 With weight: 4
 pt[5]:    location: -0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (2,6,0)
+
 With weight: 4
 pt[6]:    location: -0.75  0.25 -2.25
-   is located on boundary: 0
    idx:     (2,4,-1)
+
 With weight: -5.7285e-16
 
 On point:    location: -0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (3,5,0)
+
 pt[0]:    location: -0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (3,5,0)
+
 With weight: -18.6667
 pt[1]:    location: -0.25  0.75 -2.25
-   is located on boundary: 0
    idx:     (3,5,-1)
+
 With weight: 2.66667
 pt[2]:    location: -0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (3,4,0)
+
 With weight: 4
 pt[3]:    location: -0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (2,5,0)
+
 With weight: 4
 pt[4]:    location:  0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (4,5,0)
+
 With weight: 4
 pt[5]:    location: -0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (3,6,0)
+
 With weight: 4
 pt[6]:    location: -0.25  0.25 -2.25
-   is located on boundary: 0
    idx:     (3,4,-1)
+
 With weight: -5.7285e-16
 
 On point:    location:  0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (4,5,0)
+
 pt[0]:    location:  0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (4,5,0)
+
 With weight: -18.6667
 pt[1]:    location:  0.25  0.75 -2.25
-   is located on boundary: 0
    idx:     (4,5,-1)
+
 With weight: 2.66667
 pt[2]:    location:  0.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (4,4,0)
+
 With weight: 4
 pt[3]:    location: -0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (3,5,0)
+
 With weight: 4
 pt[4]:    location:  0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (5,5,0)
+
 With weight: 4
 pt[5]:    location:  0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (4,6,0)
+
 With weight: 4
 pt[6]:    location:  0.25  0.25 -2.25
-   is located on boundary: 0
    idx:     (4,4,-1)
+
 With weight: -5.7285e-16
 
 On point:    location:  0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (5,5,0)
+
 pt[0]:    location:  0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (5,5,0)
+
 With weight: -18.6667
 pt[1]:    location:  0.75  0.75 -2.25
-   is located on boundary: 0
    idx:     (5,5,-1)
+
 With weight: 2.66667
 pt[2]:    location:  0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (5,4,0)
+
 With weight: 4
 pt[3]:    location:  0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (4,5,0)
+
 With weight: 4
 pt[4]:    location:  1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (6,5,0)
+
 With weight: 4
 pt[5]:    location:  0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (5,6,0)
+
 With weight: 4
 pt[6]:    location:  0.75  0.25 -2.25
-   is located on boundary: 0
    idx:     (5,4,-1)
+
 With weight: -5.7285e-16
 
 On point:    location:  1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (6,5,0)
+
 pt[0]:    location:  1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (6,5,0)
+
 With weight: -24
 pt[1]:    location:  1.25  0.75 -2.25
-   is located on boundary: 0
    idx:     (6,5,-1)
+
 With weight: 4
 pt[2]:    location:  1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (6,4,0)
+
 With weight: 4
 pt[3]:    location:  0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (5,5,0)
+
 With weight: 4
 pt[4]:    location:  1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (7,5,0)
+
 With weight: 4
 pt[5]:    location:  1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (6,6,0)
+
 With weight: 4
 pt[6]:    location:  1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (6,5,1)
+
 With weight: 4
 
 On point:    location:  1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (7,5,0)
+
 pt[0]:    location:  1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (7,5,0)
+
 With weight: -24
 pt[1]:    location:  1.75  0.75 -2.25
-   is located on boundary: 0
    idx:     (7,5,-1)
+
 With weight: 4
 pt[2]:    location:  1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (7,4,0)
+
 With weight: 4
 pt[3]:    location:  1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (6,5,0)
+
 With weight: 4
 pt[4]:    location:  2.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (8,5,0)
+
 With weight: 4
 pt[5]:    location:  1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (7,6,0)
+
 With weight: 4
 pt[6]:    location:  1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (7,5,1)
+
 With weight: 4
 
 On point:    location: -1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (0,6,0)
+
 pt[0]:    location: -1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (0,6,0)
+
 With weight: -24
 pt[1]:    location: -1.75  1.25 -2.25
-   is located on boundary: 0
    idx:     (0,6,-1)
+
 With weight: 4
 pt[2]:    location: -1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (0,5,0)
+
 With weight: 4
 pt[3]:    location: -2.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (-1,6,0)
+
 With weight: 4
 pt[4]:    location: -1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (1,6,0)
+
 With weight: 4
 pt[5]:    location: -1.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (0,7,0)
+
 With weight: 4
 pt[6]:    location: -1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (0,6,1)
+
 With weight: 4
 
 On point:    location: -1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (1,6,0)
+
 pt[0]:    location: -1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (1,6,0)
+
 With weight: -24
 pt[1]:    location: -1.25  1.25 -2.25
-   is located on boundary: 0
    idx:     (1,6,-1)
+
 With weight: 4
 pt[2]:    location: -1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (1,5,0)
+
 With weight: 4
 pt[3]:    location: -1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (0,6,0)
+
 With weight: 4
 pt[4]:    location: -0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (2,6,0)
+
 With weight: 4
 pt[5]:    location: -1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (1,7,0)
+
 With weight: 4
 pt[6]:    location: -1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (1,6,1)
+
 With weight: 4
 
 On point:    location: -0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (2,6,0)
+
 pt[0]:    location: -0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (2,6,0)
+
 With weight: -24
 pt[1]:    location: -0.75  1.25 -2.25
-   is located on boundary: 0
    idx:     (2,6,-1)
+
 With weight: 4
 pt[2]:    location: -0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (2,5,0)
+
 With weight: 4
 pt[3]:    location: -1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (1,6,0)
+
 With weight: 4
 pt[4]:    location: -0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (3,6,0)
+
 With weight: 4
 pt[5]:    location: -0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (2,7,0)
+
 With weight: 4
 pt[6]:    location: -0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (2,6,1)
+
 With weight: 4
 
 On point:    location: -0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (3,6,0)
+
 pt[0]:    location: -0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (3,6,0)
+
 With weight: -24
 pt[1]:    location: -0.25  1.25 -2.25
-   is located on boundary: 0
    idx:     (3,6,-1)
+
 With weight: 4
 pt[2]:    location: -0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (3,5,0)
+
 With weight: 4
 pt[3]:    location: -0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (2,6,0)
+
 With weight: 4
 pt[4]:    location:  0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (4,6,0)
+
 With weight: 4
 pt[5]:    location: -0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (3,7,0)
+
 With weight: 4
 pt[6]:    location: -0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (3,6,1)
+
 With weight: 4
 
 On point:    location:  0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (4,6,0)
+
 pt[0]:    location:  0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (4,6,0)
+
 With weight: -24
 pt[1]:    location:  0.25  1.25 -2.25
-   is located on boundary: 0
    idx:     (4,6,-1)
+
 With weight: 4
 pt[2]:    location:  0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (4,5,0)
+
 With weight: 4
 pt[3]:    location: -0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (3,6,0)
+
 With weight: 4
 pt[4]:    location:  0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (5,6,0)
+
 With weight: 4
 pt[5]:    location:  0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (4,7,0)
+
 With weight: 4
 pt[6]:    location:  0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (4,6,1)
+
 With weight: 4
 
 On point:    location:  0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (5,6,0)
+
 pt[0]:    location:  0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (5,6,0)
+
 With weight: -24
 pt[1]:    location:  0.75  1.25 -2.25
-   is located on boundary: 0
    idx:     (5,6,-1)
+
 With weight: 4
 pt[2]:    location:  0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (5,5,0)
+
 With weight: 4
 pt[3]:    location:  0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (4,6,0)
+
 With weight: 4
 pt[4]:    location:  1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (6,6,0)
+
 With weight: 4
 pt[5]:    location:  0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (5,7,0)
+
 With weight: 4
 pt[6]:    location:  0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (5,6,1)
+
 With weight: 4
 
 On point:    location:  1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (6,6,0)
+
 pt[0]:    location:  1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (6,6,0)
+
 With weight: -24
 pt[1]:    location:  1.25  1.25 -2.25
-   is located on boundary: 0
    idx:     (6,6,-1)
+
 With weight: 4
 pt[2]:    location:  1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (6,5,0)
+
 With weight: 4
 pt[3]:    location:  0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (5,6,0)
+
 With weight: 4
 pt[4]:    location:  1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (7,6,0)
+
 With weight: 4
 pt[5]:    location:  1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (6,7,0)
+
 With weight: 4
 pt[6]:    location:  1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (6,6,1)
+
 With weight: 4
 
 On point:    location:  1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (7,6,0)
+
 pt[0]:    location:  1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (7,6,0)
+
 With weight: -24
 pt[1]:    location:  1.75  1.25 -2.25
-   is located on boundary: 0
    idx:     (7,6,-1)
+
 With weight: 4
 pt[2]:    location:  1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (7,5,0)
+
 With weight: 4
 pt[3]:    location:  1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (6,6,0)
+
 With weight: 4
 pt[4]:    location:  2.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (8,6,0)
+
 With weight: 4
 pt[5]:    location:  1.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (7,7,0)
+
 With weight: 4
 pt[6]:    location:  1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (7,6,1)
+
 With weight: 4
 
 On point:    location: -1.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (0,7,0)
+
 pt[0]:    location: -1.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (0,7,0)
+
 With weight: -24
 pt[1]:    location: -1.75  1.75 -2.25
-   is located on boundary: 0
    idx:     (0,7,-1)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (0,6,0)
+
 With weight: 4
 pt[3]:    location: -2.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (-1,7,0)
+
 With weight: 4
 pt[4]:    location: -1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (1,7,0)
+
 With weight: 4
 pt[5]:    location: -1.75  2.25 -1.75
-   is located on boundary: 0
    idx:     (0,8,0)
+
 With weight: 4
 pt[6]:    location: -1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (0,7,1)
+
 With weight: 4
 
 On point:    location: -1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (1,7,0)
+
 pt[0]:    location: -1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (1,7,0)
+
 With weight: -24
 pt[1]:    location: -1.25  1.75 -2.25
-   is located on boundary: 0
    idx:     (1,7,-1)
+
 With weight: 4
 pt[2]:    location: -1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (1,6,0)
+
 With weight: 4
 pt[3]:    location: -1.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (0,7,0)
+
 With weight: 4
 pt[4]:    location: -0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (2,7,0)
+
 With weight: 4
 pt[5]:    location: -1.25  2.25 -1.75
-   is located on boundary: 0
    idx:     (1,8,0)
+
 With weight: 4
 pt[6]:    location: -1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (1,7,1)
+
 With weight: 4
 
 On point:    location: -0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (2,7,0)
+
 pt[0]:    location: -0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (2,7,0)
+
 With weight: -24
 pt[1]:    location: -0.75  1.75 -2.25
-   is located on boundary: 0
    idx:     (2,7,-1)
+
 With weight: 4
 pt[2]:    location: -0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (2,6,0)
+
 With weight: 4
 pt[3]:    location: -1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (1,7,0)
+
 With weight: 4
 pt[4]:    location: -0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (3,7,0)
+
 With weight: 4
 pt[5]:    location: -0.75  2.25 -1.75
-   is located on boundary: 0
    idx:     (2,8,0)
+
 With weight: 4
 pt[6]:    location: -0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (2,7,1)
+
 With weight: 4
 
 On point:    location: -0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (3,7,0)
+
 pt[0]:    location: -0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (3,7,0)
+
 With weight: -24
 pt[1]:    location: -0.25  1.75 -2.25
-   is located on boundary: 0
    idx:     (3,7,-1)
+
 With weight: 4
 pt[2]:    location: -0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (3,6,0)
+
 With weight: 4
 pt[3]:    location: -0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (2,7,0)
+
 With weight: 4
 pt[4]:    location:  0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (4,7,0)
+
 With weight: 4
 pt[5]:    location: -0.25  2.25 -1.75
-   is located on boundary: 0
    idx:     (3,8,0)
+
 With weight: 4
 pt[6]:    location: -0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (3,7,1)
+
 With weight: 4
 
 On point:    location:  0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (4,7,0)
+
 pt[0]:    location:  0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (4,7,0)
+
 With weight: -24
 pt[1]:    location:  0.25  1.75 -2.25
-   is located on boundary: 0
    idx:     (4,7,-1)
+
 With weight: 4
 pt[2]:    location:  0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (4,6,0)
+
 With weight: 4
 pt[3]:    location: -0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (3,7,0)
+
 With weight: 4
 pt[4]:    location:  0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (5,7,0)
+
 With weight: 4
 pt[5]:    location:  0.25  2.25 -1.75
-   is located on boundary: 0
    idx:     (4,8,0)
+
 With weight: 4
 pt[6]:    location:  0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (4,7,1)
+
 With weight: 4
 
 On point:    location:  0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (5,7,0)
+
 pt[0]:    location:  0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (5,7,0)
+
 With weight: -24
 pt[1]:    location:  0.75  1.75 -2.25
-   is located on boundary: 0
    idx:     (5,7,-1)
+
 With weight: 4
 pt[2]:    location:  0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (5,6,0)
+
 With weight: 4
 pt[3]:    location:  0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (4,7,0)
+
 With weight: 4
 pt[4]:    location:  1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (6,7,0)
+
 With weight: 4
 pt[5]:    location:  0.75  2.25 -1.75
-   is located on boundary: 0
    idx:     (5,8,0)
+
 With weight: 4
 pt[6]:    location:  0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (5,7,1)
+
 With weight: 4
 
 On point:    location:  1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (6,7,0)
+
 pt[0]:    location:  1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (6,7,0)
+
 With weight: -24
 pt[1]:    location:  1.25  1.75 -2.25
-   is located on boundary: 0
    idx:     (6,7,-1)
+
 With weight: 4
 pt[2]:    location:  1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (6,6,0)
+
 With weight: 4
 pt[3]:    location:  0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (5,7,0)
+
 With weight: 4
 pt[4]:    location:  1.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (7,7,0)
+
 With weight: 4
 pt[5]:    location:  1.25  2.25 -1.75
-   is located on boundary: 0
    idx:     (6,8,0)
+
 With weight: 4
 pt[6]:    location:  1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (6,7,1)
+
 With weight: 4
 
 On point:    location:  1.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (7,7,0)
+
 pt[0]:    location:  1.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (7,7,0)
+
 With weight: -24
 pt[1]:    location:  1.75  1.75 -2.25
-   is located on boundary: 0
    idx:     (7,7,-1)
+
 With weight: 4
 pt[2]:    location:  1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (7,6,0)
+
 With weight: 4
 pt[3]:    location:  1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (6,7,0)
+
 With weight: 4
 pt[4]:    location:  2.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (8,7,0)
+
 With weight: 4
 pt[5]:    location:  1.75  2.25 -1.75
-   is located on boundary: 0
    idx:     (7,8,0)
+
 With weight: 4
 pt[6]:    location:  1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (7,7,1)
+
 With weight: 4
 
 On point:    location: -1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (0,0,1)
+
 pt[0]:    location: -1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (0,0,1)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (0,0,0)
+
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -1.25
-   is located on boundary: 0
    idx:     (0,-1,1)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (-1,0,1)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (1,0,1)
+
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (0,1,1)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (0,0,2)
+
 With weight: 4
 
 On point:    location: -1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (1,0,1)
+
 pt[0]:    location: -1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (1,0,1)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (1,0,0)
+
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -1.25
-   is located on boundary: 0
    idx:     (1,-1,1)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (0,0,1)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (2,0,1)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (1,1,1)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (1,0,2)
+
 With weight: 4
 
 On point:    location: -0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (2,0,1)
+
 pt[0]:    location: -0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (2,0,1)
+
 With weight: -24
 pt[1]:    location: -0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (2,0,0)
+
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -1.25
-   is located on boundary: 0
    idx:     (2,-1,1)
+
 With weight: 4
 pt[3]:    location: -1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (1,0,1)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (3,0,1)
+
 With weight: 4
 pt[5]:    location: -0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (2,1,1)
+
 With weight: 4
 pt[6]:    location: -0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (2,0,2)
+
 With weight: 4
 
 On point:    location: -0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (3,0,1)
+
 pt[0]:    location: -0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (3,0,1)
+
 With weight: -24
 pt[1]:    location: -0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (3,0,0)
+
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -1.25
-   is located on boundary: 0
    idx:     (3,-1,1)
+
 With weight: 4
 pt[3]:    location: -0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (2,0,1)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (4,0,1)
+
 With weight: 4
 pt[5]:    location: -0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (3,1,1)
+
 With weight: 4
 pt[6]:    location: -0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (3,0,2)
+
 With weight: 4
 
 On point:    location:  0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (4,0,1)
+
 pt[0]:    location:  0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (4,0,1)
+
 With weight: -24
 pt[1]:    location:  0.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (4,0,0)
+
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -1.25
-   is located on boundary: 0
    idx:     (4,-1,1)
+
 With weight: 4
 pt[3]:    location: -0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (3,0,1)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (5,0,1)
+
 With weight: 4
 pt[5]:    location:  0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (4,1,1)
+
 With weight: 4
 pt[6]:    location:  0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (4,0,2)
+
 With weight: 4
 
 On point:    location:  0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (5,0,1)
+
 pt[0]:    location:  0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (5,0,1)
+
 With weight: -24
 pt[1]:    location:  0.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (5,0,0)
+
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -1.25
-   is located on boundary: 0
    idx:     (5,-1,1)
+
 With weight: 4
 pt[3]:    location:  0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (4,0,1)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (6,0,1)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (5,1,1)
+
 With weight: 4
 pt[6]:    location:  0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (5,0,2)
+
 With weight: 4
 
 On point:    location:  1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (6,0,1)
+
 pt[0]:    location:  1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (6,0,1)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -1.75
-   is located on boundary: 0
    idx:     (6,0,0)
+
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -1.25
-   is located on boundary: 0
    idx:     (6,-1,1)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (5,0,1)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (7,0,1)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (6,1,1)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (6,0,2)
+
 With weight: 4
 
 On point:    location:  1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (7,0,1)
+
 pt[0]:    location:  1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (7,0,1)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -1.75
-   is located on boundary: 0
    idx:     (7,0,0)
+
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -1.25
-   is located on boundary: 0
    idx:     (7,-1,1)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (6,0,1)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (8,0,1)
+
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (7,1,1)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (7,0,2)
+
 With weight: 4
 
 On point:    location: -1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (0,1,1)
+
 pt[0]:    location: -1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (0,1,1)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (0,1,0)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (0,0,1)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (-1,1,1)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (1,1,1)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (0,2,1)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (0,1,2)
+
 With weight: 4
 
 On point:    location: -1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (1,1,1)
+
 pt[0]:    location: -1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (1,1,1)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (1,1,0)
+
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (1,0,1)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (0,1,1)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (2,1,1)
+
 With weight: 4
 pt[5]:    location: -1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (1,2,1)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (1,1,2)
+
 With weight: 4
 
 On point:    location: -0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (2,1,1)
+
 pt[0]:    location: -0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (2,1,1)
+
 With weight: -13.9608
 pt[1]:    location: -0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (2,1,0)
+
 With weight: 0.784314
 pt[2]:    location: -0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (2,0,1)
+
 With weight: 3.29412
 pt[3]:    location: -1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (1,1,1)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (3,1,1)
+
 With weight: 4
 pt[5]:    location: -0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (3,1,0)
+
 With weight: -1.78054e-15
 pt[6]:    location: -0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (2,2,0)
+
 With weight: 1.88235
 
 On point:    location: -0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (3,1,1)
+
 pt[0]:    location: -0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (3,1,1)
+
 With weight: -13.9608
 pt[1]:    location: -0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (3,1,0)
+
 With weight: 0.784314
 pt[2]:    location: -0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (3,0,1)
+
 With weight: 3.29412
 pt[3]:    location: -0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (2,1,1)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (4,1,1)
+
 With weight: 4
 pt[5]:    location: -0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (2,1,0)
+
 With weight: -8.73475e-16
 pt[6]:    location: -0.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (3,2,0)
+
 With weight: 1.88235
 
 On point:    location:  0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (4,1,1)
+
 pt[0]:    location:  0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (4,1,1)
+
 With weight: -13.3333
 pt[1]:    location:  0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (4,1,0)
+
 With weight: 2.66667
 pt[2]:    location:  0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (4,0,1)
+
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (3,1,1)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (5,1,1)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (5,1,0)
+
 With weight: 5.16489e-16
 pt[6]:    location:  0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (5,0,1)
+
 With weight: 5.20671e-16
 
 On point:    location:  0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (5,1,1)
+
 pt[0]:    location:  0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (5,1,1)
+
 With weight: -13.3333
 pt[1]:    location:  0.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (5,1,0)
+
 With weight: 2.66667
 pt[2]:    location:  0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (5,0,1)
+
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (4,1,1)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (6,1,1)
+
 With weight: 4
 pt[5]:    location:  0.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (4,1,0)
+
 With weight: 5.38239e-16
 pt[6]:    location:  1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (6,1,0)
+
 With weight: 1.1751e-15
 
 On point:    location:  1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (6,1,1)
+
 pt[0]:    location:  1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (6,1,1)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (6,1,0)
+
 With weight: 4
 pt[2]:    location:  1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (6,0,1)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (5,1,1)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (7,1,1)
+
 With weight: 4
 pt[5]:    location:  1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (6,2,1)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (6,1,2)
+
 With weight: 4
 
 On point:    location:  1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (7,1,1)
+
 pt[0]:    location:  1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (7,1,1)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -1.75
-   is located on boundary: 0
    idx:     (7,1,0)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (7,0,1)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (6,1,1)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (8,1,1)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (7,2,1)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (7,1,2)
+
 With weight: 4
 
 On point:    location: -1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (0,2,1)
+
 pt[0]:    location: -1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (0,2,1)
+
 With weight: -24
 pt[1]:    location: -1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (0,2,0)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (0,1,1)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (-1,2,1)
+
 With weight: 4
 pt[4]:    location: -1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (1,2,1)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (0,3,1)
+
 With weight: 4
 pt[6]:    location: -1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (0,2,2)
+
 With weight: 4
 
 On point:    location: -1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (1,2,1)
+
 pt[0]:    location: -1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (1,2,1)
+
 With weight: -13.3333
 pt[1]:    location: -1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (1,2,0)
+
 With weight: 2.66667
 pt[2]:    location: -1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (1,1,1)
+
 With weight: 4
 pt[3]:    location: -1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (0,2,1)
+
 With weight: 2.66667
 pt[4]:    location: -1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (1,3,1)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (1,1,0)
+
 With weight: -4.09907e-16
 pt[6]:    location: -1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (0,2,0)
+
 With weight: 1.05205e-15
 
 On point:    location:  1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (6,2,1)
+
 pt[0]:    location:  1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (6,2,1)
+
 With weight: -13.9608
 pt[1]:    location:  1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (6,2,0)
+
 With weight: 0.784314
 pt[2]:    location:  1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (6,1,1)
+
 With weight: 4
 pt[3]:    location:  1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (7,2,1)
+
 With weight: 3.29412
 pt[4]:    location:  1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (6,3,1)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -1.75
-   is located on boundary: 0
    idx:     (6,1,0)
+
 With weight: 3.35952e-17
 pt[6]:    location:  0.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (5,2,0)
+
 With weight: 1.88235
 
 On point:    location:  1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (7,2,1)
+
 pt[0]:    location:  1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (7,2,1)
+
 With weight: -24
 pt[1]:    location:  1.75 -0.75 -1.75
-   is located on boundary: 0
    idx:     (7,2,0)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (7,1,1)
+
 With weight: 4
 pt[3]:    location:  1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (6,2,1)
+
 With weight: 4
 pt[4]:    location:  2.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (8,2,1)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (7,3,1)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (7,2,2)
+
 With weight: 4
 
 On point:    location: -1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (0,3,1)
+
 pt[0]:    location: -1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (0,3,1)
+
 With weight: -24
 pt[1]:    location: -1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (0,3,0)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (0,2,1)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (-1,3,1)
+
 With weight: 4
 pt[4]:    location: -1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (1,3,1)
+
 With weight: 4
 pt[5]:    location: -1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (0,4,1)
+
 With weight: 4
 pt[6]:    location: -1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (0,3,2)
+
 With weight: 4
 
 On point:    location: -1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (1,3,1)
+
 pt[0]:    location: -1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (1,3,1)
+
 With weight: -13.3333
 pt[1]:    location: -1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (1,3,0)
+
 With weight: 2.66667
 pt[2]:    location: -1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (1,2,1)
+
 With weight: 4
 pt[3]:    location: -1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (0,3,1)
+
 With weight: 2.66667
 pt[4]:    location: -1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (1,4,1)
+
 With weight: 4
 pt[5]:    location: -1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (1,2,0)
+
 With weight: -4.09907e-16
 pt[6]:    location: -1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (0,3,0)
+
 With weight: 1.05205e-15
 
 On point:    location:  1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (6,3,1)
+
 pt[0]:    location:  1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (6,3,1)
+
 With weight: -13.9608
 pt[1]:    location:  1.25 -0.25 -1.75
-   is located on boundary: 0
    idx:     (6,3,0)
+
 With weight: 0.784314
 pt[2]:    location:  1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (6,2,1)
+
 With weight: 4
 pt[3]:    location:  1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (7,3,1)
+
 With weight: 3.29412
 pt[4]:    location:  1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (6,4,1)
+
 With weight: 4
 pt[5]:    location:  1.25 -0.75 -1.75
-   is located on boundary: 0
    idx:     (6,2,0)
+
 With weight: 3.35952e-17
 pt[6]:    location:  0.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (5,3,0)
+
 With weight: 1.88235
 
 On point:    location:  1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (7,3,1)
+
 pt[0]:    location:  1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (7,3,1)
+
 With weight: -24
 pt[1]:    location:  1.75 -0.25 -1.75
-   is located on boundary: 0
    idx:     (7,3,0)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (7,2,1)
+
 With weight: 4
 pt[3]:    location:  1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (6,3,1)
+
 With weight: 4
 pt[4]:    location:  2.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (8,3,1)
+
 With weight: 4
 pt[5]:    location:  1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (7,4,1)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (7,3,2)
+
 With weight: 4
 
 On point:    location: -1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (0,4,1)
+
 pt[0]:    location: -1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (0,4,1)
+
 With weight: -24
 pt[1]:    location: -1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (0,4,0)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (0,3,1)
+
 With weight: 4
 pt[3]:    location: -2.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (-1,4,1)
+
 With weight: 4
 pt[4]:    location: -1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (1,4,1)
+
 With weight: 4
 pt[5]:    location: -1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (0,5,1)
+
 With weight: 4
 pt[6]:    location: -1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (0,4,2)
+
 With weight: 4
 
 On point:    location: -1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (1,4,1)
+
 pt[0]:    location: -1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (1,4,1)
+
 With weight: -13.3333
 pt[1]:    location: -1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (1,4,0)
+
 With weight: 2.66667
 pt[2]:    location: -1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (1,3,1)
+
 With weight: 4
 pt[3]:    location: -1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (0,4,1)
+
 With weight: 2.66667
 pt[4]:    location: -1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (1,5,1)
+
 With weight: 4
 pt[5]:    location: -1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (0,4,0)
+
 With weight: -1.50293e-16
 pt[6]:    location: -1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (1,5,0)
+
 With weight: -7.34622e-16
 
 On point:    location:  1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (6,4,1)
+
 pt[0]:    location:  1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (6,4,1)
+
 With weight: -13.3333
 pt[1]:    location:  1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (6,4,0)
+
 With weight: -1.30741e-15
 pt[2]:    location:  1.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (6,3,1)
+
 With weight: 4
 pt[3]:    location:  1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (7,4,1)
+
 With weight: 2.66667
 pt[4]:    location:  1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (6,5,1)
+
 With weight: 4
 pt[5]:    location:  0.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (5,4,0)
+
 With weight: 2
 pt[6]:    location:  1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (7,4,0)
+
 With weight: 0.666667
 
 On point:    location:  1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (7,4,1)
+
 pt[0]:    location:  1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (7,4,1)
+
 With weight: -24
 pt[1]:    location:  1.75  0.25 -1.75
-   is located on boundary: 0
    idx:     (7,4,0)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (7,3,1)
+
 With weight: 4
 pt[3]:    location:  1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (6,4,1)
+
 With weight: 4
 pt[4]:    location:  2.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (8,4,1)
+
 With weight: 4
 pt[5]:    location:  1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (7,5,1)
+
 With weight: 4
 pt[6]:    location:  1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (7,4,2)
+
 With weight: 4
 
 On point:    location: -1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (0,5,1)
+
 pt[0]:    location: -1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (0,5,1)
+
 With weight: -24
 pt[1]:    location: -1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (0,5,0)
+
 With weight: 4
 pt[2]:    location: -1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (0,4,1)
+
 With weight: 4
 pt[3]:    location: -2.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (-1,5,1)
+
 With weight: 4
 pt[4]:    location: -1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (1,5,1)
+
 With weight: 4
 pt[5]:    location: -1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (0,6,1)
+
 With weight: 4
 pt[6]:    location: -1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (0,5,2)
+
 With weight: 4
 
 On point:    location: -1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (1,5,1)
+
 pt[0]:    location: -1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (1,5,1)
+
 With weight: -13.3333
 pt[1]:    location: -1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (1,5,0)
+
 With weight: 2.66667
 pt[2]:    location: -1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (1,4,1)
+
 With weight: 4
 pt[3]:    location: -1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (0,5,1)
+
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (1,6,1)
+
 With weight: 4
 pt[5]:    location: -1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (0,5,0)
+
 With weight: 1.50293e-16
 pt[6]:    location: -1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (0,4,1)
+
 With weight: -1.24779e-15
 
 On point:    location:  1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (6,5,1)
+
 pt[0]:    location:  1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (6,5,1)
+
 With weight: -13.9608
 pt[1]:    location:  1.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (6,5,0)
+
 With weight: 0.784314
 pt[2]:    location:  1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (6,4,1)
+
 With weight: 4
 pt[3]:    location:  1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (7,5,1)
+
 With weight: 3.29412
 pt[4]:    location:  1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (6,6,1)
+
 With weight: 4
 pt[5]:    location:  1.25  0.25 -1.75
-   is located on boundary: 0
    idx:     (6,4,0)
+
 With weight: 3.35952e-17
 pt[6]:    location:  0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (5,5,0)
+
 With weight: 1.88235
 
 On point:    location:  1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (7,5,1)
+
 pt[0]:    location:  1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (7,5,1)
+
 With weight: -24
 pt[1]:    location:  1.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (7,5,0)
+
 With weight: 4
 pt[2]:    location:  1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (7,4,1)
+
 With weight: 4
 pt[3]:    location:  1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (6,5,1)
+
 With weight: 4
 pt[4]:    location:  2.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (8,5,1)
+
 With weight: 4
 pt[5]:    location:  1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (7,6,1)
+
 With weight: 4
 pt[6]:    location:  1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (7,5,2)
+
 With weight: 4
 
 On point:    location: -1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (0,6,1)
+
 pt[0]:    location: -1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (0,6,1)
+
 With weight: -24
 pt[1]:    location: -1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (0,6,0)
+
 With weight: 4
 pt[2]:    location: -1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (0,5,1)
+
 With weight: 4
 pt[3]:    location: -2.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (-1,6,1)
+
 With weight: 4
 pt[4]:    location: -1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (1,6,1)
+
 With weight: 4
 pt[5]:    location: -1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (0,7,1)
+
 With weight: 4
 pt[6]:    location: -1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (0,6,2)
+
 With weight: 4
 
 On point:    location: -1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (1,6,1)
+
 pt[0]:    location: -1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (1,6,1)
+
 With weight: -24
 pt[1]:    location: -1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (1,6,0)
+
 With weight: 4
 pt[2]:    location: -1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (1,5,1)
+
 With weight: 4
 pt[3]:    location: -1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (0,6,1)
+
 With weight: 4
 pt[4]:    location: -0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (2,6,1)
+
 With weight: 4
 pt[5]:    location: -1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (1,7,1)
+
 With weight: 4
 pt[6]:    location: -1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (1,6,2)
+
 With weight: 4
 
 On point:    location: -0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (2,6,1)
+
 pt[0]:    location: -0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (2,6,1)
+
 With weight: -13.9608
 pt[1]:    location: -0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (2,6,0)
+
 With weight: 0.784314
 pt[2]:    location: -1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (1,6,1)
+
 With weight: 4
 pt[3]:    location: -0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (3,6,1)
+
 With weight: 4
 pt[4]:    location: -0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (2,7,1)
+
 With weight: 3.29412
 pt[5]:    location: -0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (2,5,0)
+
 With weight: 1.88235
 pt[6]:    location: -0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (3,6,0)
+
 With weight: 2.01571e-16
 
 On point:    location: -0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (3,6,1)
+
 pt[0]:    location: -0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (3,6,1)
+
 With weight: -13.9608
 pt[1]:    location: -0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (3,6,0)
+
 With weight: 0.784314
 pt[2]:    location: -0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (2,6,1)
+
 With weight: 4
 pt[3]:    location:  0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (4,6,1)
+
 With weight: 4
 pt[4]:    location: -0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (3,7,1)
+
 With weight: 3.29412
 pt[5]:    location: -0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (3,5,0)
+
 With weight: 1.88235
 pt[6]:    location: -0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (2,6,0)
+
 With weight: -1.94852e-15
 
 On point:    location:  0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (4,6,1)
+
 pt[0]:    location:  0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (4,6,1)
+
 With weight: -13.9608
 pt[1]:    location:  0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (4,6,0)
+
 With weight: 0.784314
 pt[2]:    location: -0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (3,6,1)
+
 With weight: 4
 pt[3]:    location:  0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (5,6,1)
+
 With weight: 4
 pt[4]:    location:  0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (4,7,1)
+
 With weight: 3.29412
 pt[5]:    location:  0.25  0.75 -1.75
-   is located on boundary: 0
    idx:     (4,5,0)
+
 With weight: 1.88235
 pt[6]:    location:  0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (5,6,0)
+
 With weight: 2.01571e-16
 
 On point:    location:  0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (5,6,1)
+
 pt[0]:    location:  0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (5,6,1)
+
 With weight: -13.9608
 pt[1]:    location:  0.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (5,6,0)
+
 With weight: 0.784314
 pt[2]:    location:  0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (4,6,1)
+
 With weight: 4
 pt[3]:    location:  1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (6,6,1)
+
 With weight: 4
 pt[4]:    location:  0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (5,7,1)
+
 With weight: 3.29412
 pt[5]:    location:  0.75  0.75 -1.75
-   is located on boundary: 0
    idx:     (5,5,0)
+
 With weight: 1.88235
 pt[6]:    location:  0.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (4,6,0)
+
 With weight: -1.94852e-15
 
 On point:    location:  1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (6,6,1)
+
 pt[0]:    location:  1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (6,6,1)
+
 With weight: -24
 pt[1]:    location:  1.25  1.25 -1.75
-   is located on boundary: 0
    idx:     (6,6,0)
+
 With weight: 4
 pt[2]:    location:  1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (6,5,1)
+
 With weight: 4
 pt[3]:    location:  0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (5,6,1)
+
 With weight: 4
 pt[4]:    location:  1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (7,6,1)
+
 With weight: 4
 pt[5]:    location:  1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (6,7,1)
+
 With weight: 4
 pt[6]:    location:  1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (6,6,2)
+
 With weight: 4
 
 On point:    location:  1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (7,6,1)
+
 pt[0]:    location:  1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (7,6,1)
+
 With weight: -24
 pt[1]:    location:  1.75  1.25 -1.75
-   is located on boundary: 0
    idx:     (7,6,0)
+
 With weight: 4
 pt[2]:    location:  1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (7,5,1)
+
 With weight: 4
 pt[3]:    location:  1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (6,6,1)
+
 With weight: 4
 pt[4]:    location:  2.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (8,6,1)
+
 With weight: 4
 pt[5]:    location:  1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (7,7,1)
+
 With weight: 4
 pt[6]:    location:  1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (7,6,2)
+
 With weight: 4
 
 On point:    location: -1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (0,7,1)
+
 pt[0]:    location: -1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (0,7,1)
+
 With weight: -24
 pt[1]:    location: -1.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (0,7,0)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (0,6,1)
+
 With weight: 4
 pt[3]:    location: -2.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (-1,7,1)
+
 With weight: 4
 pt[4]:    location: -1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (1,7,1)
+
 With weight: 4
 pt[5]:    location: -1.75  2.25 -1.25
-   is located on boundary: 0
    idx:     (0,8,1)
+
 With weight: 4
 pt[6]:    location: -1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (0,7,2)
+
 With weight: 4
 
 On point:    location: -1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (1,7,1)
+
 pt[0]:    location: -1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (1,7,1)
+
 With weight: -24
 pt[1]:    location: -1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (1,7,0)
+
 With weight: 4
 pt[2]:    location: -1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (1,6,1)
+
 With weight: 4
 pt[3]:    location: -1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (0,7,1)
+
 With weight: 4
 pt[4]:    location: -0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (2,7,1)
+
 With weight: 4
 pt[5]:    location: -1.25  2.25 -1.25
-   is located on boundary: 0
    idx:     (1,8,1)
+
 With weight: 4
 pt[6]:    location: -1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (1,7,2)
+
 With weight: 4
 
 On point:    location: -0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (2,7,1)
+
 pt[0]:    location: -0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (2,7,1)
+
 With weight: -24
 pt[1]:    location: -0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (2,7,0)
+
 With weight: 4
 pt[2]:    location: -0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (2,6,1)
+
 With weight: 4
 pt[3]:    location: -1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (1,7,1)
+
 With weight: 4
 pt[4]:    location: -0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (3,7,1)
+
 With weight: 4
 pt[5]:    location: -0.75  2.25 -1.25
-   is located on boundary: 0
    idx:     (2,8,1)
+
 With weight: 4
 pt[6]:    location: -0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (2,7,2)
+
 With weight: 4
 
 On point:    location: -0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (3,7,1)
+
 pt[0]:    location: -0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (3,7,1)
+
 With weight: -24
 pt[1]:    location: -0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (3,7,0)
+
 With weight: 4
 pt[2]:    location: -0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (3,6,1)
+
 With weight: 4
 pt[3]:    location: -0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (2,7,1)
+
 With weight: 4
 pt[4]:    location:  0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (4,7,1)
+
 With weight: 4
 pt[5]:    location: -0.25  2.25 -1.25
-   is located on boundary: 0
    idx:     (3,8,1)
+
 With weight: 4
 pt[6]:    location: -0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (3,7,2)
+
 With weight: 4
 
 On point:    location:  0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (4,7,1)
+
 pt[0]:    location:  0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (4,7,1)
+
 With weight: -24
 pt[1]:    location:  0.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (4,7,0)
+
 With weight: 4
 pt[2]:    location:  0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (4,6,1)
+
 With weight: 4
 pt[3]:    location: -0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (3,7,1)
+
 With weight: 4
 pt[4]:    location:  0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (5,7,1)
+
 With weight: 4
 pt[5]:    location:  0.25  2.25 -1.25
-   is located on boundary: 0
    idx:     (4,8,1)
+
 With weight: 4
 pt[6]:    location:  0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (4,7,2)
+
 With weight: 4
 
 On point:    location:  0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (5,7,1)
+
 pt[0]:    location:  0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (5,7,1)
+
 With weight: -24
 pt[1]:    location:  0.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (5,7,0)
+
 With weight: 4
 pt[2]:    location:  0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (5,6,1)
+
 With weight: 4
 pt[3]:    location:  0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (4,7,1)
+
 With weight: 4
 pt[4]:    location:  1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (6,7,1)
+
 With weight: 4
 pt[5]:    location:  0.75  2.25 -1.25
-   is located on boundary: 0
    idx:     (5,8,1)
+
 With weight: 4
 pt[6]:    location:  0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (5,7,2)
+
 With weight: 4
 
 On point:    location:  1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (6,7,1)
+
 pt[0]:    location:  1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (6,7,1)
+
 With weight: -24
 pt[1]:    location:  1.25  1.75 -1.75
-   is located on boundary: 0
    idx:     (6,7,0)
+
 With weight: 4
 pt[2]:    location:  1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (6,6,1)
+
 With weight: 4
 pt[3]:    location:  0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (5,7,1)
+
 With weight: 4
 pt[4]:    location:  1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (7,7,1)
+
 With weight: 4
 pt[5]:    location:  1.25  2.25 -1.25
-   is located on boundary: 0
    idx:     (6,8,1)
+
 With weight: 4
 pt[6]:    location:  1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (6,7,2)
+
 With weight: 4
 
 On point:    location:  1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (7,7,1)
+
 pt[0]:    location:  1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (7,7,1)
+
 With weight: -24
 pt[1]:    location:  1.75  1.75 -1.75
-   is located on boundary: 0
    idx:     (7,7,0)
+
 With weight: 4
 pt[2]:    location:  1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (7,6,1)
+
 With weight: 4
 pt[3]:    location:  1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (6,7,1)
+
 With weight: 4
 pt[4]:    location:  2.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (8,7,1)
+
 With weight: 4
 pt[5]:    location:  1.75  2.25 -1.25
-   is located on boundary: 0
    idx:     (7,8,1)
+
 With weight: 4
 pt[6]:    location:  1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (7,7,2)
+
 With weight: 4
 
 On point:    location: -1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (0,0,2)
+
 pt[0]:    location: -1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (0,0,2)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (0,0,1)
+
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -0.75
-   is located on boundary: 0
    idx:     (0,-1,2)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (-1,0,2)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (1,0,2)
+
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (0,1,2)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (0,0,3)
+
 With weight: 4
 
 On point:    location: -1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (1,0,2)
+
 pt[0]:    location: -1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (1,0,2)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (1,0,1)
+
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -0.75
-   is located on boundary: 0
    idx:     (1,-1,2)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (0,0,2)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (2,0,2)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (1,1,2)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (1,0,3)
+
 With weight: 4
 
 On point:    location: -0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (2,0,2)
+
 pt[0]:    location: -0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (2,0,2)
+
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (2,0,1)
+
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -0.75
-   is located on boundary: 0
    idx:     (2,-1,2)
+
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (1,0,2)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (3,0,2)
+
 With weight: 4
 pt[5]:    location: -0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (2,0,3)
+
 With weight: 4
 pt[6]:    location: -0.75 -2.25 -1.25
-   is located on boundary: 0
    idx:     (2,-1,1)
+
 With weight: 1.05525e-15
 
 On point:    location: -0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (3,0,2)
+
 pt[0]:    location: -0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (3,0,2)
+
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (3,0,1)
+
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -0.75
-   is located on boundary: 0
    idx:     (3,-1,2)
+
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (2,0,2)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (4,0,2)
+
 With weight: 4
 pt[5]:    location: -0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (3,0,3)
+
 With weight: 4
 pt[6]:    location: -0.25 -2.25 -1.25
-   is located on boundary: 0
    idx:     (3,-1,1)
+
 With weight: 1.05525e-15
 
 On point:    location:  0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (4,0,2)
+
 pt[0]:    location:  0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (4,0,2)
+
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (4,0,1)
+
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -0.75
-   is located on boundary: 0
    idx:     (4,-1,2)
+
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (3,0,2)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (5,0,2)
+
 With weight: 4
 pt[5]:    location:  0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (4,0,3)
+
 With weight: 4
 pt[6]:    location:  0.25 -2.25 -1.25
-   is located on boundary: 0
    idx:     (4,-1,1)
+
 With weight: 1.05525e-15
 
 On point:    location:  0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (5,0,2)
+
 pt[0]:    location:  0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (5,0,2)
+
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (5,0,1)
+
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -0.75
-   is located on boundary: 0
    idx:     (5,-1,2)
+
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (4,0,2)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (6,0,2)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (5,0,3)
+
 With weight: 4
 pt[6]:    location:  0.75 -2.25 -1.25
-   is located on boundary: 0
    idx:     (5,-1,1)
+
 With weight: 1.05525e-15
 
 On point:    location:  1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (6,0,2)
+
 pt[0]:    location:  1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (6,0,2)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (6,0,1)
+
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -0.75
-   is located on boundary: 0
    idx:     (6,-1,2)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (5,0,2)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (7,0,2)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (6,1,2)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (6,0,3)
+
 With weight: 4
 
 On point:    location:  1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (7,0,2)
+
 pt[0]:    location:  1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (7,0,2)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -1.25
-   is located on boundary: 0
    idx:     (7,0,1)
+
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -0.75
-   is located on boundary: 0
    idx:     (7,-1,2)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (6,0,2)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (8,0,2)
+
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (7,1,2)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (7,0,3)
+
 With weight: 4
 
 On point:    location: -1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (0,1,2)
+
 pt[0]:    location: -1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (0,1,2)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (0,1,1)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (0,0,2)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (-1,1,2)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (1,1,2)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (0,2,2)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (0,1,3)
+
 With weight: 4
 
 On point:    location: -1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (1,1,2)
+
 pt[0]:    location: -1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (1,1,2)
+
 With weight: -13.3333
 pt[1]:    location: -1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (1,1,1)
+
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (1,0,2)
+
 With weight: 2.66667
 pt[3]:    location: -1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (0,1,2)
+
 With weight: 2.66667
 pt[4]:    location: -1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (1,1,3)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.75 -1.25
-   is located on boundary: 0
    idx:     (1,0,1)
+
 With weight: -9.11452e-17
 pt[6]:    location: -1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (0,1,1)
+
 With weight: -7.36121e-16
 
 On point:    location:  1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (6,1,2)
+
 pt[0]:    location:  1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (6,1,2)
+
 With weight: -14.1867
 pt[1]:    location:  1.25 -1.25 -1.25
-   is located on boundary: 0
    idx:     (6,1,1)
+
 With weight: 2.72
 pt[2]:    location:  1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (6,0,2)
+
 With weight: 1.38667
 pt[3]:    location:  1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (7,1,2)
+
 With weight: 3.52
 pt[4]:    location:  1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (6,1,3)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (5,1,1)
+
 With weight: 1.28
 pt[6]:    location:  0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (5,0,2)
+
 With weight: 1.28
 
 On point:    location:  1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (7,1,2)
+
 pt[0]:    location:  1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (7,1,2)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -1.25
-   is located on boundary: 0
    idx:     (7,1,1)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (7,0,2)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (6,1,2)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (8,1,2)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (7,2,2)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (7,1,3)
+
 With weight: 4
 
 On point:    location: -1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (0,2,2)
+
 pt[0]:    location: -1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (0,2,2)
+
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (0,2,1)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (0,1,2)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -0.75
-   is located on boundary: 0
    idx:     (-1,2,2)
+
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (0,3,2)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (0,2,3)
+
 With weight: 4
 pt[6]:    location: -2.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (-1,2,1)
+
 With weight: 1.13062e-15
 
 On point:    location:  1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (7,2,2)
+
 pt[0]:    location:  1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (7,2,2)
+
 With weight: -19.2941
 pt[1]:    location:  1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (7,2,1)
+
 With weight: 2.11765
 pt[2]:    location:  1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (7,1,2)
+
 With weight: 4
 pt[3]:    location:  2.25 -0.75 -0.75
-   is located on boundary: 0
    idx:     (8,2,2)
+
 With weight: 3.29412
 pt[4]:    location:  1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (7,3,2)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (7,2,3)
+
 With weight: 4
 pt[6]:    location:  1.25 -0.75 -1.25
-   is located on boundary: 0
    idx:     (6,2,1)
+
 With weight: 1.88235
 
 On point:    location: -1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (0,3,2)
+
 pt[0]:    location: -1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (0,3,2)
+
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (0,3,1)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (0,2,2)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -0.75
-   is located on boundary: 0
    idx:     (-1,3,2)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (0,4,2)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (0,3,3)
+
 With weight: 4
 pt[6]:    location: -2.25 -0.25 -1.25
-   is located on boundary: 0
    idx:     (-1,3,1)
+
 With weight: 1.13062e-15
 
 On point:    location:  1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (7,3,2)
+
 pt[0]:    location:  1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (7,3,2)
+
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25 -1.25
-   is located on boundary: 0
    idx:     (7,3,1)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (7,2,2)
+
 With weight: 4
 pt[3]:    location:  2.25 -0.25 -0.75
-   is located on boundary: 0
    idx:     (8,3,2)
+
 With weight: 2.66667
 pt[4]:    location:  1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (7,4,2)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (7,3,3)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -1.25
-   is located on boundary: 0
    idx:     (7,2,1)
+
 With weight: -7.27074e-16
 
 On point:    location: -1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (0,4,2)
+
 pt[0]:    location: -1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (0,4,2)
+
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (0,4,1)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (0,3,2)
+
 With weight: 4
 pt[3]:    location: -2.25  0.25 -0.75
-   is located on boundary: 0
    idx:     (-1,4,2)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (0,5,2)
+
 With weight: 4
 pt[5]:    location: -1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (0,4,3)
+
 With weight: 4
 pt[6]:    location: -2.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (-1,4,1)
+
 With weight: 1.13062e-15
 
 On point:    location:  1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (7,4,2)
+
 pt[0]:    location:  1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (7,4,2)
+
 With weight: -19.2941
 pt[1]:    location:  1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (7,4,1)
+
 With weight: 2.11765
 pt[2]:    location:  1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (7,3,2)
+
 With weight: 4
 pt[3]:    location:  2.25  0.25 -0.75
-   is located on boundary: 0
    idx:     (8,4,2)
+
 With weight: 3.29412
 pt[4]:    location:  1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (7,5,2)
+
 With weight: 4
 pt[5]:    location:  1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (7,4,3)
+
 With weight: 4
 pt[6]:    location:  1.25  0.25 -1.25
-   is located on boundary: 0
    idx:     (6,4,1)
+
 With weight: 1.88235
 
 On point:    location: -1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (0,5,2)
+
 pt[0]:    location: -1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (0,5,2)
+
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (0,5,1)
+
 With weight: 4
 pt[2]:    location: -1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (0,4,2)
+
 With weight: 4
 pt[3]:    location: -2.25  0.75 -0.75
-   is located on boundary: 0
    idx:     (-1,5,2)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (0,6,2)
+
 With weight: 4
 pt[5]:    location: -1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (0,5,3)
+
 With weight: 4
 pt[6]:    location: -2.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (-1,5,1)
+
 With weight: 1.13062e-15
 
 On point:    location:  1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (7,5,2)
+
 pt[0]:    location:  1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (7,5,2)
+
 With weight: -18.6667
 pt[1]:    location:  1.75  0.75 -1.25
-   is located on boundary: 0
    idx:     (7,5,1)
+
 With weight: 4
 pt[2]:    location:  1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (7,4,2)
+
 With weight: 4
 pt[3]:    location:  2.25  0.75 -0.75
-   is located on boundary: 0
    idx:     (8,5,2)
+
 With weight: 2.66667
 pt[4]:    location:  1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (7,6,2)
+
 With weight: 4
 pt[5]:    location:  1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (7,5,3)
+
 With weight: 4
 pt[6]:    location:  1.75  0.25 -1.25
-   is located on boundary: 0
    idx:     (7,4,1)
+
 With weight: -7.27074e-16
 
 On point:    location: -1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (0,6,2)
+
 pt[0]:    location: -1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (0,6,2)
+
 With weight: -24
 pt[1]:    location: -1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (0,6,1)
+
 With weight: 4
 pt[2]:    location: -1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (0,5,2)
+
 With weight: 4
 pt[3]:    location: -2.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (-1,6,2)
+
 With weight: 4
 pt[4]:    location: -1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (1,6,2)
+
 With weight: 4
 pt[5]:    location: -1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (0,7,2)
+
 With weight: 4
 pt[6]:    location: -1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (0,6,3)
+
 With weight: 4
 
 On point:    location: -1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (1,6,2)
+
 pt[0]:    location: -1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (1,6,2)
+
 With weight: -13.3333
 pt[1]:    location: -1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (1,6,1)
+
 With weight: 1.33333
 pt[2]:    location: -1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (0,6,2)
+
 With weight: 2.66667
 pt[3]:    location: -1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (1,7,2)
+
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (1,6,3)
+
 With weight: 4
 pt[5]:    location: -1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (1,5,1)
+
 With weight: 2
 pt[6]:    location: -1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (1,7,1)
+
 With weight: 0.666667
 
 On point:    location:  1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (6,6,2)
+
 pt[0]:    location:  1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (6,6,2)
+
 With weight: -14.5882
 pt[1]:    location:  1.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (6,6,1)
+
 With weight: 0.235294
 pt[2]:    location:  1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (7,6,2)
+
 With weight: 3.29412
 pt[3]:    location:  1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (6,7,2)
+
 With weight: 3.29412
 pt[4]:    location:  1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (6,6,3)
+
 With weight: 4
 pt[5]:    location:  1.25  0.75 -1.25
-   is located on boundary: 0
    idx:     (6,5,1)
+
 With weight: 1.88235
 pt[6]:    location:  0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (5,6,1)
+
 With weight: 1.88235
 
 On point:    location:  1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (7,6,2)
+
 pt[0]:    location:  1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (7,6,2)
+
 With weight: -24
 pt[1]:    location:  1.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (7,6,1)
+
 With weight: 4
 pt[2]:    location:  1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (7,5,2)
+
 With weight: 4
 pt[3]:    location:  1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (6,6,2)
+
 With weight: 4
 pt[4]:    location:  2.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (8,6,2)
+
 With weight: 4
 pt[5]:    location:  1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (7,7,2)
+
 With weight: 4
 pt[6]:    location:  1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (7,6,3)
+
 With weight: 4
 
 On point:    location: -1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (0,7,2)
+
 pt[0]:    location: -1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (0,7,2)
+
 With weight: -24
 pt[1]:    location: -1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (0,7,1)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (0,6,2)
+
 With weight: 4
 pt[3]:    location: -2.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (-1,7,2)
+
 With weight: 4
 pt[4]:    location: -1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (1,7,2)
+
 With weight: 4
 pt[5]:    location: -1.75  2.25 -0.75
-   is located on boundary: 0
    idx:     (0,8,2)
+
 With weight: 4
 pt[6]:    location: -1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (0,7,3)
+
 With weight: 4
 
 On point:    location: -1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (1,7,2)
+
 pt[0]:    location: -1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (1,7,2)
+
 With weight: -24
 pt[1]:    location: -1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (1,7,1)
+
 With weight: 4
 pt[2]:    location: -1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (1,6,2)
+
 With weight: 4
 pt[3]:    location: -1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (0,7,2)
+
 With weight: 4
 pt[4]:    location: -0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (2,7,2)
+
 With weight: 4
 pt[5]:    location: -1.25  2.25 -0.75
-   is located on boundary: 0
    idx:     (1,8,2)
+
 With weight: 4
 pt[6]:    location: -1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (1,7,3)
+
 With weight: 4
 
 On point:    location: -0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (2,7,2)
+
 pt[0]:    location: -0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (2,7,2)
+
 With weight: -18.6667
 pt[1]:    location: -0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (2,7,1)
+
 With weight: 4
 pt[2]:    location: -1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (1,7,2)
+
 With weight: 4
 pt[3]:    location: -0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (3,7,2)
+
 With weight: 4
 pt[4]:    location: -0.75  2.25 -0.75
-   is located on boundary: 0
    idx:     (2,8,2)
+
 With weight: 2.66667
 pt[5]:    location: -0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (2,7,3)
+
 With weight: 4
 pt[6]:    location: -0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (3,7,1)
+
 With weight: 1.09747e-15
 
 On point:    location: -0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (3,7,2)
+
 pt[0]:    location: -0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (3,7,2)
+
 With weight: -19.2941
 pt[1]:    location: -0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (3,7,1)
+
 With weight: 2.11765
 pt[2]:    location: -0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (2,7,2)
+
 With weight: 4
 pt[3]:    location:  0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (4,7,2)
+
 With weight: 4
 pt[4]:    location: -0.25  2.25 -0.75
-   is located on boundary: 0
    idx:     (3,8,2)
+
 With weight: 3.29412
 pt[5]:    location: -0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (3,7,3)
+
 With weight: 4
 pt[6]:    location: -0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (3,6,1)
+
 With weight: 1.88235
 
 On point:    location:  0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (4,7,2)
+
 pt[0]:    location:  0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (4,7,2)
+
 With weight: -19.2941
 pt[1]:    location:  0.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (4,7,1)
+
 With weight: 2.11765
 pt[2]:    location: -0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (3,7,2)
+
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (5,7,2)
+
 With weight: 4
 pt[4]:    location:  0.25  2.25 -0.75
-   is located on boundary: 0
    idx:     (4,8,2)
+
 With weight: 3.29412
 pt[5]:    location:  0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (4,7,3)
+
 With weight: 4
 pt[6]:    location:  0.25  1.25 -1.25
-   is located on boundary: 0
    idx:     (4,6,1)
+
 With weight: 1.88235
 
 On point:    location:  0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (5,7,2)
+
 pt[0]:    location:  0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (5,7,2)
+
 With weight: -19.2941
 pt[1]:    location:  0.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (5,7,1)
+
 With weight: 2.11765
 pt[2]:    location:  0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (4,7,2)
+
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (6,7,2)
+
 With weight: 4
 pt[4]:    location:  0.75  2.25 -0.75
-   is located on boundary: 0
    idx:     (5,8,2)
+
 With weight: 3.29412
 pt[5]:    location:  0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (5,7,3)
+
 With weight: 4
 pt[6]:    location:  0.75  1.25 -1.25
-   is located on boundary: 0
    idx:     (5,6,1)
+
 With weight: 1.88235
 
 On point:    location:  1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (6,7,2)
+
 pt[0]:    location:  1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (6,7,2)
+
 With weight: -24
 pt[1]:    location:  1.25  1.75 -1.25
-   is located on boundary: 0
    idx:     (6,7,1)
+
 With weight: 4
 pt[2]:    location:  1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (6,6,2)
+
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (5,7,2)
+
 With weight: 4
 pt[4]:    location:  1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (7,7,2)
+
 With weight: 4
 pt[5]:    location:  1.25  2.25 -0.75
-   is located on boundary: 0
    idx:     (6,8,2)
+
 With weight: 4
 pt[6]:    location:  1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (6,7,3)
+
 With weight: 4
 
 On point:    location:  1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (7,7,2)
+
 pt[0]:    location:  1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (7,7,2)
+
 With weight: -24
 pt[1]:    location:  1.75  1.75 -1.25
-   is located on boundary: 0
    idx:     (7,7,1)
+
 With weight: 4
 pt[2]:    location:  1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (7,6,2)
+
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (6,7,2)
+
 With weight: 4
 pt[4]:    location:  2.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (8,7,2)
+
 With weight: 4
 pt[5]:    location:  1.75  2.25 -0.75
-   is located on boundary: 0
    idx:     (7,8,2)
+
 With weight: 4
 pt[6]:    location:  1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (7,7,3)
+
 With weight: 4
 
 On point:    location: -1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (0,0,3)
+
 pt[0]:    location: -1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (0,0,3)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (0,0,2)
+
 With weight: 4
 pt[2]:    location: -1.75 -2.25 -0.25
-   is located on boundary: 0
    idx:     (0,-1,3)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (-1,0,3)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (1,0,3)
+
 With weight: 4
 pt[5]:    location: -1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (0,1,3)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (0,0,4)
+
 With weight: 4
 
 On point:    location: -1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (1,0,3)
+
 pt[0]:    location: -1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (1,0,3)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (1,0,2)
+
 With weight: 4
 pt[2]:    location: -1.25 -2.25 -0.25
-   is located on boundary: 0
    idx:     (1,-1,3)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (0,0,3)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (2,0,3)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (1,1,3)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (1,0,4)
+
 With weight: 4
 
 On point:    location: -0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (2,0,3)
+
 pt[0]:    location: -0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (2,0,3)
+
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (2,0,2)
+
 With weight: 4
 pt[2]:    location: -0.75 -2.25 -0.25
-   is located on boundary: 0
    idx:     (2,-1,3)
+
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (1,0,3)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (3,0,3)
+
 With weight: 4
 pt[5]:    location: -0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (2,0,4)
+
 With weight: 4
 pt[6]:    location: -0.75 -2.25 -0.75
-   is located on boundary: 0
    idx:     (2,-1,2)
+
 With weight: 1.05525e-15
 
 On point:    location: -0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (3,0,3)
+
 pt[0]:    location: -0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (3,0,3)
+
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (3,0,2)
+
 With weight: 4
 pt[2]:    location: -0.25 -2.25 -0.25
-   is located on boundary: 0
    idx:     (3,-1,3)
+
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (2,0,3)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (4,0,3)
+
 With weight: 4
 pt[5]:    location: -0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (3,0,4)
+
 With weight: 4
 pt[6]:    location: -0.25 -2.25 -0.75
-   is located on boundary: 0
    idx:     (3,-1,2)
+
 With weight: 1.05525e-15
 
 On point:    location:  0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (4,0,3)
+
 pt[0]:    location:  0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (4,0,3)
+
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (4,0,2)
+
 With weight: 4
 pt[2]:    location:  0.25 -2.25 -0.25
-   is located on boundary: 0
    idx:     (4,-1,3)
+
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (3,0,3)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (5,0,3)
+
 With weight: 4
 pt[5]:    location:  0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (4,0,4)
+
 With weight: 4
 pt[6]:    location:  0.25 -2.25 -0.75
-   is located on boundary: 0
    idx:     (4,-1,2)
+
 With weight: 1.05525e-15
 
 On point:    location:  0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (5,0,3)
+
 pt[0]:    location:  0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (5,0,3)
+
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (5,0,2)
+
 With weight: 4
 pt[2]:    location:  0.75 -2.25 -0.25
-   is located on boundary: 0
    idx:     (5,-1,3)
+
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (4,0,3)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (6,0,3)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (5,0,4)
+
 With weight: 4
 pt[6]:    location:  0.75 -2.25 -0.75
-   is located on boundary: 0
    idx:     (5,-1,2)
+
 With weight: 1.05525e-15
 
 On point:    location:  1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (6,0,3)
+
 pt[0]:    location:  1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (6,0,3)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (6,0,2)
+
 With weight: 4
 pt[2]:    location:  1.25 -2.25 -0.25
-   is located on boundary: 0
    idx:     (6,-1,3)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (5,0,3)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (7,0,3)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (6,1,3)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (6,0,4)
+
 With weight: 4
 
 On point:    location:  1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (7,0,3)
+
 pt[0]:    location:  1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (7,0,3)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -0.75
-   is located on boundary: 0
    idx:     (7,0,2)
+
 With weight: 4
 pt[2]:    location:  1.75 -2.25 -0.25
-   is located on boundary: 0
    idx:     (7,-1,3)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (6,0,3)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (8,0,3)
+
 With weight: 4
 pt[5]:    location:  1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (7,1,3)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (7,0,4)
+
 With weight: 4
 
 On point:    location: -1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (0,1,3)
+
 pt[0]:    location: -1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (0,1,3)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (0,1,2)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (0,0,3)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (-1,1,3)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (1,1,3)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (0,2,3)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (0,1,4)
+
 With weight: 4
 
 On point:    location: -1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (1,1,3)
+
 pt[0]:    location: -1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (1,1,3)
+
 With weight: -13.3333
 pt[1]:    location: -1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (1,1,2)
+
 With weight: 4
 pt[2]:    location: -1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (1,0,3)
+
 With weight: 2.66667
 pt[3]:    location: -1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (0,1,3)
+
 With weight: 2.66667
 pt[4]:    location: -1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (1,1,4)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (1,0,2)
+
 With weight: -9.11452e-17
 pt[6]:    location: -1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (0,1,2)
+
 With weight: -7.36121e-16
 
 On point:    location:  1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (6,1,3)
+
 pt[0]:    location:  1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (6,1,3)
+
 With weight: -13.3333
 pt[1]:    location:  1.25 -1.25 -0.75
-   is located on boundary: 0
    idx:     (6,1,2)
+
 With weight: 4
 pt[2]:    location:  1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (6,0,3)
+
 With weight: 2.66667
 pt[3]:    location:  1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (7,1,3)
+
 With weight: 2.66667
 pt[4]:    location:  1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (6,1,4)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.75 -0.75
-   is located on boundary: 0
    idx:     (6,0,2)
+
 With weight: -9.11452e-17
 pt[6]:    location:  1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (7,1,2)
+
 With weight: -7.36121e-16
 
 On point:    location:  1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (7,1,3)
+
 pt[0]:    location:  1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (7,1,3)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (7,1,2)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (7,0,3)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (6,1,3)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (8,1,3)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (7,2,3)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (7,1,4)
+
 With weight: 4
 
 On point:    location: -1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (0,2,3)
+
 pt[0]:    location: -1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (0,2,3)
+
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (0,2,2)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (0,1,3)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.75 -0.25
-   is located on boundary: 0
    idx:     (-1,2,3)
+
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (0,3,3)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (0,2,4)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (0,1,2)
+
 With weight: -7.27074e-16
 
 On point:    location:  1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (7,2,3)
+
 pt[0]:    location:  1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (7,2,3)
+
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (7,2,2)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (7,1,3)
+
 With weight: 4
 pt[3]:    location:  2.25 -0.75 -0.25
-   is located on boundary: 0
    idx:     (8,2,3)
+
 With weight: 2.66667
 pt[4]:    location:  1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (7,3,3)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (7,2,4)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.25 -0.75
-   is located on boundary: 0
    idx:     (7,1,2)
+
 With weight: -7.27074e-16
 
 On point:    location: -1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (0,3,3)
+
 pt[0]:    location: -1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (0,3,3)
+
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (0,3,2)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (0,2,3)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.25 -0.25
-   is located on boundary: 0
    idx:     (-1,3,3)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (0,4,3)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (0,3,4)
+
 With weight: 4
 pt[6]:    location: -1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (0,2,2)
+
 With weight: -7.27074e-16
 
 On point:    location:  1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (7,3,3)
+
 pt[0]:    location:  1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (7,3,3)
+
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25 -0.75
-   is located on boundary: 0
    idx:     (7,3,2)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (7,2,3)
+
 With weight: 4
 pt[3]:    location:  2.25 -0.25 -0.25
-   is located on boundary: 0
    idx:     (8,3,3)
+
 With weight: 2.66667
 pt[4]:    location:  1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (7,4,3)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (7,3,4)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.75 -0.75
-   is located on boundary: 0
    idx:     (7,2,2)
+
 With weight: -7.27074e-16
 
 On point:    location: -1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (0,4,3)
+
 pt[0]:    location: -1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (0,4,3)
+
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (0,4,2)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (0,3,3)
+
 With weight: 4
 pt[3]:    location: -2.25  0.25 -0.25
-   is located on boundary: 0
    idx:     (-1,4,3)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (0,5,3)
+
 With weight: 4
 pt[5]:    location: -1.75  0.25  0.25
-   is located on boundary: 0
    idx:     (0,4,4)
+
 With weight: 4
 pt[6]:    location: -2.25  0.25 -0.75
-   is located on boundary: 0
    idx:     (-1,4,2)
+
 With weight: 1.13062e-15
 
 On point:    location:  1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (7,4,3)
+
 pt[0]:    location:  1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (7,4,3)
+
 With weight: -18.6667
 pt[1]:    location:  1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (7,4,2)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (7,3,3)
+
 With weight: 4
 pt[3]:    location:  2.25  0.25 -0.25
-   is located on boundary: 0
    idx:     (8,4,3)
+
 With weight: 2.66667
 pt[4]:    location:  1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (7,5,3)
+
 With weight: 4
 pt[5]:    location: 1.75 0.25 0.25
-   is located on boundary: 0
    idx:     (7,4,4)
+
 With weight: 4
 pt[6]:    location:  2.25  0.25 -0.75
-   is located on boundary: 0
    idx:     (8,4,2)
+
 With weight: 1.13062e-15
 
 On point:    location: -1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (0,5,3)
+
 pt[0]:    location: -1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (0,5,3)
+
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (0,5,2)
+
 With weight: 4
 pt[2]:    location: -1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (0,4,3)
+
 With weight: 4
 pt[3]:    location: -2.25  0.75 -0.25
-   is located on boundary: 0
    idx:     (-1,5,3)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (0,6,3)
+
 With weight: 4
 pt[5]:    location: -1.75  0.75  0.25
-   is located on boundary: 0
    idx:     (0,5,4)
+
 With weight: 4
 pt[6]:    location: -1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (0,4,2)
+
 With weight: -7.27074e-16
 
 On point:    location:  1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (7,5,3)
+
 pt[0]:    location:  1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (7,5,3)
+
 With weight: -18.6667
 pt[1]:    location:  1.75  0.75 -0.75
-   is located on boundary: 0
    idx:     (7,5,2)
+
 With weight: 4
 pt[2]:    location:  1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (7,4,3)
+
 With weight: 4
 pt[3]:    location:  2.25  0.75 -0.25
-   is located on boundary: 0
    idx:     (8,5,3)
+
 With weight: 2.66667
 pt[4]:    location:  1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (7,6,3)
+
 With weight: 4
 pt[5]:    location: 1.75 0.75 0.25
-   is located on boundary: 0
    idx:     (7,5,4)
+
 With weight: 4
 pt[6]:    location:  1.75  0.25 -0.75
-   is located on boundary: 0
    idx:     (7,4,2)
+
 With weight: -7.27074e-16
 
 On point:    location: -1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (0,6,3)
+
 pt[0]:    location: -1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (0,6,3)
+
 With weight: -24
 pt[1]:    location: -1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (0,6,2)
+
 With weight: 4
 pt[2]:    location: -1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (0,5,3)
+
 With weight: 4
 pt[3]:    location: -2.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (-1,6,3)
+
 With weight: 4
 pt[4]:    location: -1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (1,6,3)
+
 With weight: 4
 pt[5]:    location: -1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (0,7,3)
+
 With weight: 4
 pt[6]:    location: -1.75  1.25  0.25
-   is located on boundary: 0
    idx:     (0,6,4)
+
 With weight: 4
 
 On point:    location: -1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (1,6,3)
+
 pt[0]:    location: -1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (1,6,3)
+
 With weight: -13.9608
 pt[1]:    location: -1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (1,6,2)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (0,6,3)
+
 With weight: 0.784314
 pt[3]:    location: -1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (1,7,3)
+
 With weight: 3.29412
 pt[4]:    location: -1.25  1.25  0.25
-   is located on boundary: 0
    idx:     (1,6,4)
+
 With weight: 4
 pt[5]:    location: -1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (0,6,2)
+
 With weight: -7.39094e-16
 pt[6]:    location: -1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (0,5,3)
+
 With weight: 1.88235
 
 On point:    location:  1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (6,6,3)
+
 pt[0]:    location:  1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (6,6,3)
+
 With weight: -13.3333
 pt[1]:    location:  1.25  1.25 -0.75
-   is located on boundary: 0
    idx:     (6,6,2)
+
 With weight: 4
 pt[2]:    location:  1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (7,6,3)
+
 With weight: 2.66667
 pt[3]:    location:  1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (6,7,3)
+
 With weight: 2.66667
 pt[4]:    location: 1.25 1.25 0.25
-   is located on boundary: 0
    idx:     (6,6,4)
+
 With weight: 4
 pt[5]:    location:  1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (7,6,2)
+
 With weight: 3.03817e-17
 pt[6]:    location:  1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (6,7,2)
+
 With weight: -3.14198e-16
 
 On point:    location:  1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (7,6,3)
+
 pt[0]:    location:  1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (7,6,3)
+
 With weight: -24
 pt[1]:    location:  1.75  1.25 -0.75
-   is located on boundary: 0
    idx:     (7,6,2)
+
 With weight: 4
 pt[2]:    location:  1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (7,5,3)
+
 With weight: 4
 pt[3]:    location:  1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (6,6,3)
+
 With weight: 4
 pt[4]:    location:  2.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (8,6,3)
+
 With weight: 4
 pt[5]:    location:  1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (7,7,3)
+
 With weight: 4
 pt[6]:    location: 1.75 1.25 0.25
-   is located on boundary: 0
    idx:     (7,6,4)
+
 With weight: 4
 
 On point:    location: -1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (0,7,3)
+
 pt[0]:    location: -1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (0,7,3)
+
 With weight: -24
 pt[1]:    location: -1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (0,7,2)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (0,6,3)
+
 With weight: 4
 pt[3]:    location: -2.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (-1,7,3)
+
 With weight: 4
 pt[4]:    location: -1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (1,7,3)
+
 With weight: 4
 pt[5]:    location: -1.75  2.25 -0.25
-   is located on boundary: 0
    idx:     (0,8,3)
+
 With weight: 4
 pt[6]:    location: -1.75  1.75  0.25
-   is located on boundary: 0
    idx:     (0,7,4)
+
 With weight: 4
 
 On point:    location: -1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (1,7,3)
+
 pt[0]:    location: -1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (1,7,3)
+
 With weight: -24
 pt[1]:    location: -1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (1,7,2)
+
 With weight: 4
 pt[2]:    location: -1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (1,6,3)
+
 With weight: 4
 pt[3]:    location: -1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (0,7,3)
+
 With weight: 4
 pt[4]:    location: -0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (2,7,3)
+
 With weight: 4
 pt[5]:    location: -1.25  2.25 -0.25
-   is located on boundary: 0
    idx:     (1,8,3)
+
 With weight: 4
 pt[6]:    location: -1.25  1.75  0.25
-   is located on boundary: 0
    idx:     (1,7,4)
+
 With weight: 4
 
 On point:    location: -0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (2,7,3)
+
 pt[0]:    location: -0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (2,7,3)
+
 With weight: -18.6667
 pt[1]:    location: -0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (2,7,2)
+
 With weight: 4
 pt[2]:    location: -1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (1,7,3)
+
 With weight: 4
 pt[3]:    location: -0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (3,7,3)
+
 With weight: 4
 pt[4]:    location: -0.75  2.25 -0.25
-   is located on boundary: 0
    idx:     (2,8,3)
+
 With weight: 2.66667
 pt[5]:    location: -0.75  1.75  0.25
-   is located on boundary: 0
    idx:     (2,7,4)
+
 With weight: 4
 pt[6]:    location: -1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (1,7,2)
+
 With weight: 8.23102e-16
 
 On point:    location: -0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (3,7,3)
+
 pt[0]:    location: -0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (3,7,3)
+
 With weight: -18.6667
 pt[1]:    location: -0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (3,7,2)
+
 With weight: 4
 pt[2]:    location: -0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (2,7,3)
+
 With weight: 4
 pt[3]:    location:  0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (4,7,3)
+
 With weight: 4
 pt[4]:    location: -0.25  2.25 -0.25
-   is located on boundary: 0
    idx:     (3,8,3)
+
 With weight: 2.66667
 pt[5]:    location: -0.25  1.75  0.25
-   is located on boundary: 0
    idx:     (3,7,4)
+
 With weight: 4
 pt[6]:    location: -0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (2,7,2)
+
 With weight: 8.23102e-16
 
 On point:    location:  0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (4,7,3)
+
 pt[0]:    location:  0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (4,7,3)
+
 With weight: -18.6667
 pt[1]:    location:  0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (4,7,2)
+
 With weight: 4
 pt[2]:    location: -0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (3,7,3)
+
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (5,7,3)
+
 With weight: 4
 pt[4]:    location:  0.25  2.25 -0.25
-   is located on boundary: 0
    idx:     (4,8,3)
+
 With weight: 2.66667
 pt[5]:    location: 0.25 1.75 0.25
-   is located on boundary: 0
    idx:     (4,7,4)
+
 With weight: 4
 pt[6]:    location:  0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (5,7,2)
+
 With weight: 1.09747e-15
 
 On point:    location:  0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (5,7,3)
+
 pt[0]:    location:  0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (5,7,3)
+
 With weight: -18.6667
 pt[1]:    location:  0.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (5,7,2)
+
 With weight: 4
 pt[2]:    location:  0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (4,7,3)
+
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (6,7,3)
+
 With weight: 4
 pt[4]:    location:  0.75  2.25 -0.25
-   is located on boundary: 0
    idx:     (5,8,3)
+
 With weight: 2.66667
 pt[5]:    location: 0.75 1.75 0.25
-   is located on boundary: 0
    idx:     (5,7,4)
+
 With weight: 4
 pt[6]:    location:  0.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (4,7,2)
+
 With weight: 8.23102e-16
 
 On point:    location:  1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (6,7,3)
+
 pt[0]:    location:  1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (6,7,3)
+
 With weight: -24
 pt[1]:    location:  1.25  1.75 -0.75
-   is located on boundary: 0
    idx:     (6,7,2)
+
 With weight: 4
 pt[2]:    location:  1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (6,6,3)
+
 With weight: 4
 pt[3]:    location:  0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (5,7,3)
+
 With weight: 4
 pt[4]:    location:  1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (7,7,3)
+
 With weight: 4
 pt[5]:    location:  1.25  2.25 -0.25
-   is located on boundary: 0
    idx:     (6,8,3)
+
 With weight: 4
 pt[6]:    location: 1.25 1.75 0.25
-   is located on boundary: 0
    idx:     (6,7,4)
+
 With weight: 4
 
 On point:    location:  1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (7,7,3)
+
 pt[0]:    location:  1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (7,7,3)
+
 With weight: -24
 pt[1]:    location:  1.75  1.75 -0.75
-   is located on boundary: 0
    idx:     (7,7,2)
+
 With weight: 4
 pt[2]:    location:  1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (7,6,3)
+
 With weight: 4
 pt[3]:    location:  1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (6,7,3)
+
 With weight: 4
 pt[4]:    location:  2.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (8,7,3)
+
 With weight: 4
 pt[5]:    location:  1.75  2.25 -0.25
-   is located on boundary: 0
    idx:     (7,8,3)
+
 With weight: 4
 pt[6]:    location: 1.75 1.75 0.25
-   is located on boundary: 0
    idx:     (7,7,4)
+
 With weight: 4
 
 On point:    location: -1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (0,0,4)
+
 pt[0]:    location: -1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (0,0,4)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (0,0,3)
+
 With weight: 4
 pt[2]:    location: -1.75 -2.25  0.25
-   is located on boundary: 0
    idx:     (0,-1,4)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (-1,0,4)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (1,0,4)
+
 With weight: 4
 pt[5]:    location: -1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (0,1,4)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (0,0,5)
+
 With weight: 4
 
 On point:    location: -1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (1,0,4)
+
 pt[0]:    location: -1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (1,0,4)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (1,0,3)
+
 With weight: 4
 pt[2]:    location: -1.25 -2.25  0.25
-   is located on boundary: 0
    idx:     (1,-1,4)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (0,0,4)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (2,0,4)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (1,1,4)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (1,0,5)
+
 With weight: 4
 
 On point:    location: -0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (2,0,4)
+
 pt[0]:    location: -0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (2,0,4)
+
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (2,0,3)
+
 With weight: 4
 pt[2]:    location: -0.75 -2.25  0.25
-   is located on boundary: 0
    idx:     (2,-1,4)
+
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (1,0,4)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (3,0,4)
+
 With weight: 4
 pt[5]:    location: -0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (2,0,5)
+
 With weight: 4
 pt[6]:    location: -1.25 -2.25  0.25
-   is located on boundary: 0
    idx:     (1,-1,4)
+
 With weight: 6.03e-16
 
 On point:    location: -0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (3,0,4)
+
 pt[0]:    location: -0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (3,0,4)
+
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (3,0,3)
+
 With weight: 4
 pt[2]:    location: -0.25 -2.25  0.25
-   is located on boundary: 0
    idx:     (3,-1,4)
+
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (2,0,4)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (4,0,4)
+
 With weight: 4
 pt[5]:    location: -0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (3,0,5)
+
 With weight: 4
 pt[6]:    location: -0.75 -2.25  0.25
-   is located on boundary: 0
    idx:     (2,-1,4)
+
 With weight: 6.03e-16
 
 On point:    location:  0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (4,0,4)
+
 pt[0]:    location:  0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (4,0,4)
+
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (4,0,3)
+
 With weight: 4
 pt[2]:    location:  0.25 -2.25  0.25
-   is located on boundary: 0
    idx:     (4,-1,4)
+
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (3,0,4)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (5,0,4)
+
 With weight: 4
 pt[5]:    location:  0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (4,0,5)
+
 With weight: 4
 pt[6]:    location:  0.75 -2.25  0.25
-   is located on boundary: 0
    idx:     (5,-1,4)
+
 With weight: -6.85912e-16
 
 On point:    location:  0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (5,0,4)
+
 pt[0]:    location:  0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (5,0,4)
+
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (5,0,3)
+
 With weight: 4
 pt[2]:    location:  0.75 -2.25  0.25
-   is located on boundary: 0
    idx:     (5,-1,4)
+
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (4,0,4)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (6,0,4)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (5,0,5)
+
 With weight: 4
 pt[6]:    location:  0.25 -2.25  0.25
-   is located on boundary: 0
    idx:     (4,-1,4)
+
 With weight: 6.03e-16
 
 On point:    location:  1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (6,0,4)
+
 pt[0]:    location:  1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (6,0,4)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.75 -0.25
-   is located on boundary: 0
    idx:     (6,0,3)
+
 With weight: 4
 pt[2]:    location:  1.25 -2.25  0.25
-   is located on boundary: 0
    idx:     (6,-1,4)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (5,0,4)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (7,0,4)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (6,1,4)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (6,0,5)
+
 With weight: 4
 
 On point:    location:  1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (7,0,4)
+
 pt[0]:    location:  1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (7,0,4)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.75 -0.25
-   is located on boundary: 0
    idx:     (7,0,3)
+
 With weight: 4
 pt[2]:    location:  1.75 -2.25  0.25
-   is located on boundary: 0
    idx:     (7,-1,4)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (6,0,4)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (8,0,4)
+
 With weight: 4
 pt[5]:    location:  1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (7,1,4)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (7,0,5)
+
 With weight: 4
 
 On point:    location: -1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (0,1,4)
+
 pt[0]:    location: -1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (0,1,4)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (0,1,3)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (0,0,4)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (-1,1,4)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (1,1,4)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (0,2,4)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (0,1,5)
+
 With weight: 4
 
 On point:    location: -1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (1,1,4)
+
 pt[0]:    location: -1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (1,1,4)
+
 With weight: -13.9608
 pt[1]:    location: -1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (1,1,3)
+
 With weight: 4
 pt[2]:    location: -1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (1,0,4)
+
 With weight: 3.29412
 pt[3]:    location: -1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (0,1,4)
+
 With weight: 0.784314
 pt[4]:    location: -1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (1,1,5)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (0,2,4)
+
 With weight: 1.88235
 pt[6]:    location: -1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (1,0,5)
+
 With weight: -1.55529e-15
 
 On point:    location:  1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (6,1,4)
+
 pt[0]:    location:  1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (6,1,4)
+
 With weight: -13.3333
 pt[1]:    location:  1.25 -1.25 -0.25
-   is located on boundary: 0
    idx:     (6,1,3)
+
 With weight: 4
 pt[2]:    location:  1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (6,0,4)
+
 With weight: 6.03419e-16
 pt[3]:    location:  1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (7,1,4)
+
 With weight: 2.66667
 pt[4]:    location:  1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (6,1,5)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (5,0,4)
+
 With weight: 2
 pt[6]:    location:  1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (7,0,4)
+
 With weight: 0.666667
 
 On point:    location:  1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (7,1,4)
+
 pt[0]:    location:  1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (7,1,4)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.25 -0.25
-   is located on boundary: 0
    idx:     (7,1,3)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (7,0,4)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (6,1,4)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (8,1,4)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (7,2,4)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (7,1,5)
+
 With weight: 4
 
 On point:    location: -1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (0,2,4)
+
 pt[0]:    location: -1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (0,2,4)
+
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (0,2,3)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (0,1,4)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.75  0.25
-   is located on boundary: 0
    idx:     (-1,2,4)
+
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (0,3,4)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (0,2,5)
+
 With weight: 4
 pt[6]:    location: -2.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (-1,1,4)
+
 With weight: 1.3869e-15
 
 On point:    location:  1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (7,2,4)
+
 pt[0]:    location:  1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (7,2,4)
+
 With weight: -19.2941
 pt[1]:    location:  1.75 -0.75 -0.25
-   is located on boundary: 0
    idx:     (7,2,3)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (7,1,4)
+
 With weight: 2.11765
 pt[3]:    location:  2.25 -0.75  0.25
-   is located on boundary: 0
    idx:     (8,2,4)
+
 With weight: 3.29412
 pt[4]:    location:  1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (7,3,4)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (7,2,5)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (6,1,4)
+
 With weight: 1.88235
 
 On point:    location: -1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (0,3,4)
+
 pt[0]:    location: -1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (0,3,4)
+
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (0,3,3)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (0,2,4)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.25  0.25
-   is located on boundary: 0
    idx:     (-1,3,4)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25  0.25
-   is located on boundary: 0
    idx:     (0,4,4)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (0,3,5)
+
 With weight: 4
 pt[6]:    location: -2.25 -0.75  0.25
-   is located on boundary: 0
    idx:     (-1,2,4)
+
 With weight: 1.3869e-15
 
 On point:    location:  1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (7,3,4)
+
 pt[0]:    location:  1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (7,3,4)
+
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25 -0.25
-   is located on boundary: 0
    idx:     (7,3,3)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (7,2,4)
+
 With weight: 4
 pt[3]:    location:  2.25 -0.25  0.25
-   is located on boundary: 0
    idx:     (8,3,4)
+
 With weight: 2.66667
 pt[4]:    location: 1.75 0.25 0.25
-   is located on boundary: 0
    idx:     (7,4,4)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (7,3,5)
+
 With weight: 4
 pt[6]:    location:  2.25 -0.75  0.25
-   is located on boundary: 0
    idx:     (8,2,4)
+
 With weight: 1.3869e-15
 
 On point:    location: -1.75  0.25  0.25
-   is located on boundary: 0
    idx:     (0,4,4)
+
 pt[0]:    location: -1.75  0.25  0.25
-   is located on boundary: 0
    idx:     (0,4,4)
+
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (0,4,3)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (0,3,4)
+
 With weight: 4
 pt[3]:    location: -2.25  0.25  0.25
-   is located on boundary: 0
    idx:     (-1,4,4)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75  0.25
-   is located on boundary: 0
    idx:     (0,5,4)
+
 With weight: 4
 pt[5]:    location: -1.75  0.25  0.75
-   is located on boundary: 0
    idx:     (0,4,5)
+
 With weight: 4
 pt[6]:    location: -2.25  0.75  0.25
-   is located on boundary: 0
    idx:     (-1,5,4)
+
 With weight: -1.47735e-15
 
 On point:    location: 1.75 0.25 0.25
-   is located on boundary: 0
    idx:     (7,4,4)
+
 pt[0]:    location: 1.75 0.25 0.25
-   is located on boundary: 0
    idx:     (7,4,4)
+
 With weight: -18.6667
 pt[1]:    location:  1.75  0.25 -0.25
-   is located on boundary: 0
    idx:     (7,4,3)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (7,3,4)
+
 With weight: 4
 pt[3]:    location: 2.25 0.25 0.25
-   is located on boundary: 0
    idx:     (8,4,4)
+
 With weight: 2.66667
 pt[4]:    location: 1.75 0.75 0.25
-   is located on boundary: 0
    idx:     (7,5,4)
+
 With weight: 4
 pt[5]:    location: 1.75 0.25 0.75
-   is located on boundary: 0
    idx:     (7,4,5)
+
 With weight: 4
 pt[6]:    location: 2.25 0.75 0.25
-   is located on boundary: 0
    idx:     (8,5,4)
+
 With weight: -1.47735e-15
 
 On point:    location: -1.75  0.75  0.25
-   is located on boundary: 0
    idx:     (0,5,4)
+
 pt[0]:    location: -1.75  0.75  0.25
-   is located on boundary: 0
    idx:     (0,5,4)
+
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (0,5,3)
+
 With weight: 4
 pt[2]:    location: -1.75  0.25  0.25
-   is located on boundary: 0
    idx:     (0,4,4)
+
 With weight: 4
 pt[3]:    location: -2.25  0.75  0.25
-   is located on boundary: 0
    idx:     (-1,5,4)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25  0.25
-   is located on boundary: 0
    idx:     (0,6,4)
+
 With weight: 4
 pt[5]:    location: -1.75  0.75  0.75
-   is located on boundary: 0
    idx:     (0,5,5)
+
 With weight: 4
 pt[6]:    location: -2.25  0.25  0.25
-   is located on boundary: 0
    idx:     (-1,4,4)
+
 With weight: 1.3869e-15
 
 On point:    location: 1.75 0.75 0.25
-   is located on boundary: 0
    idx:     (7,5,4)
+
 pt[0]:    location: 1.75 0.75 0.25
-   is located on boundary: 0
    idx:     (7,5,4)
+
 With weight: -19.2941
 pt[1]:    location:  1.75  0.75 -0.25
-   is located on boundary: 0
    idx:     (7,5,3)
+
 With weight: 4
 pt[2]:    location: 1.75 0.25 0.25
-   is located on boundary: 0
    idx:     (7,4,4)
+
 With weight: 4
 pt[3]:    location: 2.25 0.75 0.25
-   is located on boundary: 0
    idx:     (8,5,4)
+
 With weight: 3.29412
 pt[4]:    location: 1.75 1.25 0.25
-   is located on boundary: 0
    idx:     (7,6,4)
+
 With weight: 2.11765
 pt[5]:    location: 1.75 0.75 0.75
-   is located on boundary: 0
    idx:     (7,5,5)
+
 With weight: 4
 pt[6]:    location: 1.25 1.25 0.25
-   is located on boundary: 0
    idx:     (6,6,4)
+
 With weight: 1.88235
 
 On point:    location: -1.75  1.25  0.25
-   is located on boundary: 0
    idx:     (0,6,4)
+
 pt[0]:    location: -1.75  1.25  0.25
-   is located on boundary: 0
    idx:     (0,6,4)
+
 With weight: -24
 pt[1]:    location: -1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (0,6,3)
+
 With weight: 4
 pt[2]:    location: -1.75  0.75  0.25
-   is located on boundary: 0
    idx:     (0,5,4)
+
 With weight: 4
 pt[3]:    location: -2.25  1.25  0.25
-   is located on boundary: 0
    idx:     (-1,6,4)
+
 With weight: 4
 pt[4]:    location: -1.25  1.25  0.25
-   is located on boundary: 0
    idx:     (1,6,4)
+
 With weight: 4
 pt[5]:    location: -1.75  1.75  0.25
-   is located on boundary: 0
    idx:     (0,7,4)
+
 With weight: 4
 pt[6]:    location: -1.75  1.25  0.75
-   is located on boundary: 0
    idx:     (0,6,5)
+
 With weight: 4
 
 On point:    location: -1.25  1.25  0.25
-   is located on boundary: 0
    idx:     (1,6,4)
+
 pt[0]:    location: -1.25  1.25  0.25
-   is located on boundary: 0
    idx:     (1,6,4)
+
 With weight: -13.3333
 pt[1]:    location: -1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (1,6,3)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.25
-   is located on boundary: 0
    idx:     (0,6,4)
+
 With weight: 2.66667
 pt[3]:    location: -1.25  1.75  0.25
-   is located on boundary: 0
    idx:     (1,7,4)
+
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25  0.75
-   is located on boundary: 0
    idx:     (1,6,5)
+
 With weight: 4
 pt[5]:    location: -1.75  1.75  0.25
-   is located on boundary: 0
    idx:     (0,7,4)
+
 With weight: 4.50879e-16
 pt[6]:    location: -1.75  1.25  0.75
-   is located on boundary: 0
    idx:     (0,6,5)
+
 With weight: 1.30313e-16
 
 On point:    location: 1.25 1.25 0.25
-   is located on boundary: 0
    idx:     (6,6,4)
+
 pt[0]:    location: 1.25 1.25 0.25
-   is located on boundary: 0
    idx:     (6,6,4)
+
 With weight: -13.3333
 pt[1]:    location:  1.25  1.25 -0.25
-   is located on boundary: 0
    idx:     (6,6,3)
+
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.25
-   is located on boundary: 0
    idx:     (7,6,4)
+
 With weight: 2.66667
 pt[3]:    location: 1.25 1.75 0.25
-   is located on boundary: 0
    idx:     (6,7,4)
+
 With weight: -2.16225e-15
 pt[4]:    location: 1.25 1.25 0.75
-   is located on boundary: 0
    idx:     (6,6,5)
+
 With weight: 4
 pt[5]:    location: 0.75 1.75 0.25
-   is located on boundary: 0
    idx:     (5,7,4)
+
 With weight: 2
 pt[6]:    location: 1.75 1.75 0.25
-   is located on boundary: 0
    idx:     (7,7,4)
+
 With weight: 0.666667
 
 On point:    location: 1.75 1.25 0.25
-   is located on boundary: 0
    idx:     (7,6,4)
+
 pt[0]:    location: 1.75 1.25 0.25
-   is located on boundary: 0
    idx:     (7,6,4)
+
 With weight: -24
 pt[1]:    location:  1.75  1.25 -0.25
-   is located on boundary: 0
    idx:     (7,6,3)
+
 With weight: 4
 pt[2]:    location: 1.75 0.75 0.25
-   is located on boundary: 0
    idx:     (7,5,4)
+
 With weight: 4
 pt[3]:    location: 1.25 1.25 0.25
-   is located on boundary: 0
    idx:     (6,6,4)
+
 With weight: 4
 pt[4]:    location: 2.25 1.25 0.25
-   is located on boundary: 0
    idx:     (8,6,4)
+
 With weight: 4
 pt[5]:    location: 1.75 1.75 0.25
-   is located on boundary: 0
    idx:     (7,7,4)
+
 With weight: 4
 pt[6]:    location: 1.75 1.25 0.75
-   is located on boundary: 0
    idx:     (7,6,5)
+
 With weight: 4
 
 On point:    location: -1.75  1.75  0.25
-   is located on boundary: 0
    idx:     (0,7,4)
+
 pt[0]:    location: -1.75  1.75  0.25
-   is located on boundary: 0
    idx:     (0,7,4)
+
 With weight: -24
 pt[1]:    location: -1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (0,7,3)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.25
-   is located on boundary: 0
    idx:     (0,6,4)
+
 With weight: 4
 pt[3]:    location: -2.25  1.75  0.25
-   is located on boundary: 0
    idx:     (-1,7,4)
+
 With weight: 4
 pt[4]:    location: -1.25  1.75  0.25
-   is located on boundary: 0
    idx:     (1,7,4)
+
 With weight: 4
 pt[5]:    location: -1.75  2.25  0.25
-   is located on boundary: 0
    idx:     (0,8,4)
+
 With weight: 4
 pt[6]:    location: -1.75  1.75  0.75
-   is located on boundary: 0
    idx:     (0,7,5)
+
 With weight: 4
 
 On point:    location: -1.25  1.75  0.25
-   is located on boundary: 0
    idx:     (1,7,4)
+
 pt[0]:    location: -1.25  1.75  0.25
-   is located on boundary: 0
    idx:     (1,7,4)
+
 With weight: -24
 pt[1]:    location: -1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (1,7,3)
+
 With weight: 4
 pt[2]:    location: -1.25  1.25  0.25
-   is located on boundary: 0
    idx:     (1,6,4)
+
 With weight: 4
 pt[3]:    location: -1.75  1.75  0.25
-   is located on boundary: 0
    idx:     (0,7,4)
+
 With weight: 4
 pt[4]:    location: -0.75  1.75  0.25
-   is located on boundary: 0
    idx:     (2,7,4)
+
 With weight: 4
 pt[5]:    location: -1.25  2.25  0.25
-   is located on boundary: 0
    idx:     (1,8,4)
+
 With weight: 4
 pt[6]:    location: -1.25  1.75  0.75
-   is located on boundary: 0
    idx:     (1,7,5)
+
 With weight: 4
 
 On point:    location: -0.75  1.75  0.25
-   is located on boundary: 0
    idx:     (2,7,4)
+
 pt[0]:    location: -0.75  1.75  0.25
-   is located on boundary: 0
    idx:     (2,7,4)
+
 With weight: -19.2941
 pt[1]:    location: -0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (2,7,3)
+
 With weight: 4
 pt[2]:    location: -1.25  1.75  0.25
-   is located on boundary: 0
    idx:     (1,7,4)
+
 With weight: 2.11765
 pt[3]:    location: -0.25  1.75  0.25
-   is located on boundary: 0
    idx:     (3,7,4)
+
 With weight: 4
 pt[4]:    location: -0.75  2.25  0.25
-   is located on boundary: 0
    idx:     (2,8,4)
+
 With weight: 3.29412
 pt[5]:    location: -0.75  1.75  0.75
-   is located on boundary: 0
    idx:     (2,7,5)
+
 With weight: 4
 pt[6]:    location: -1.25  1.25  0.25
-   is located on boundary: 0
    idx:     (1,6,4)
+
 With weight: 1.88235
 
 On point:    location: -0.25  1.75  0.25
-   is located on boundary: 0
    idx:     (3,7,4)
+
 pt[0]:    location: -0.25  1.75  0.25
-   is located on boundary: 0
    idx:     (3,7,4)
+
 With weight: -18.6667
 pt[1]:    location: -0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (3,7,3)
+
 With weight: 4
 pt[2]:    location: -0.75  1.75  0.25
-   is located on boundary: 0
    idx:     (2,7,4)
+
 With weight: 4
 pt[3]:    location: 0.25 1.75 0.25
-   is located on boundary: 0
    idx:     (4,7,4)
+
 With weight: 4
 pt[4]:    location: -0.25  2.25  0.25
-   is located on boundary: 0
    idx:     (3,8,4)
+
 With weight: 2.66667
 pt[5]:    location: -0.25  1.75  0.75
-   is located on boundary: 0
    idx:     (3,7,5)
+
 With weight: 4
 pt[6]:    location: -0.75  2.25  0.25
-   is located on boundary: 0
    idx:     (2,8,4)
+
 With weight: -5.87925e-16
 
 On point:    location: 0.25 1.75 0.25
-   is located on boundary: 0
    idx:     (4,7,4)
+
 pt[0]:    location: 0.25 1.75 0.25
-   is located on boundary: 0
    idx:     (4,7,4)
+
 With weight: -18.6667
 pt[1]:    location:  0.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (4,7,3)
+
 With weight: 4
 pt[2]:    location: -0.25  1.75  0.25
-   is located on boundary: 0
    idx:     (3,7,4)
+
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.25
-   is located on boundary: 0
    idx:     (5,7,4)
+
 With weight: 4
 pt[4]:    location: 0.25 2.25 0.25
-   is located on boundary: 0
    idx:     (4,8,4)
+
 With weight: 2.66667
 pt[5]:    location: 0.25 1.75 0.75
-   is located on boundary: 0
    idx:     (4,7,5)
+
 With weight: 4
 pt[6]:    location: 0.75 2.25 0.25
-   is located on boundary: 0
    idx:     (5,8,4)
+
 With weight: -7.31137e-16
 
 On point:    location: 0.75 1.75 0.25
-   is located on boundary: 0
    idx:     (5,7,4)
+
 pt[0]:    location: 0.75 1.75 0.25
-   is located on boundary: 0
    idx:     (5,7,4)
+
 With weight: -19.2941
 pt[1]:    location:  0.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (5,7,3)
+
 With weight: 4
 pt[2]:    location: 0.25 1.75 0.25
-   is located on boundary: 0
    idx:     (4,7,4)
+
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.25
-   is located on boundary: 0
    idx:     (6,7,4)
+
 With weight: 2.11765
 pt[4]:    location: 0.75 2.25 0.25
-   is located on boundary: 0
    idx:     (5,8,4)
+
 With weight: 3.29412
 pt[5]:    location: 0.75 1.75 0.75
-   is located on boundary: 0
    idx:     (5,7,5)
+
 With weight: 4
 pt[6]:    location: 1.25 1.25 0.25
-   is located on boundary: 0
    idx:     (6,6,4)
+
 With weight: 1.88235
 
 On point:    location: 1.25 1.75 0.25
-   is located on boundary: 0
    idx:     (6,7,4)
+
 pt[0]:    location: 1.25 1.75 0.25
-   is located on boundary: 0
    idx:     (6,7,4)
+
 With weight: -24
 pt[1]:    location:  1.25  1.75 -0.25
-   is located on boundary: 0
    idx:     (6,7,3)
+
 With weight: 4
 pt[2]:    location: 1.25 1.25 0.25
-   is located on boundary: 0
    idx:     (6,6,4)
+
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.25
-   is located on boundary: 0
    idx:     (5,7,4)
+
 With weight: 4
 pt[4]:    location: 1.75 1.75 0.25
-   is located on boundary: 0
    idx:     (7,7,4)
+
 With weight: 4
 pt[5]:    location: 1.25 2.25 0.25
-   is located on boundary: 0
    idx:     (6,8,4)
+
 With weight: 4
 pt[6]:    location: 1.25 1.75 0.75
-   is located on boundary: 0
    idx:     (6,7,5)
+
 With weight: 4
 
 On point:    location: 1.75 1.75 0.25
-   is located on boundary: 0
    idx:     (7,7,4)
+
 pt[0]:    location: 1.75 1.75 0.25
-   is located on boundary: 0
    idx:     (7,7,4)
+
 With weight: -24
 pt[1]:    location:  1.75  1.75 -0.25
-   is located on boundary: 0
    idx:     (7,7,3)
+
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.25
-   is located on boundary: 0
    idx:     (7,6,4)
+
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.25
-   is located on boundary: 0
    idx:     (6,7,4)
+
 With weight: 4
 pt[4]:    location: 2.25 1.75 0.25
-   is located on boundary: 0
    idx:     (8,7,4)
+
 With weight: 4
 pt[5]:    location: 1.75 2.25 0.25
-   is located on boundary: 0
    idx:     (7,8,4)
+
 With weight: 4
 pt[6]:    location: 1.75 1.75 0.75
-   is located on boundary: 0
    idx:     (7,7,5)
+
 With weight: 4
 
 On point:    location: -1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (0,0,5)
+
 pt[0]:    location: -1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (0,0,5)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (0,0,4)
+
 With weight: 4
 pt[2]:    location: -1.75 -2.25  0.75
-   is located on boundary: 0
    idx:     (0,-1,5)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (-1,0,5)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (1,0,5)
+
 With weight: 4
 pt[5]:    location: -1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (0,1,5)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (0,0,6)
+
 With weight: 4
 
 On point:    location: -1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (1,0,5)
+
 pt[0]:    location: -1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (1,0,5)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (1,0,4)
+
 With weight: 4
 pt[2]:    location: -1.25 -2.25  0.75
-   is located on boundary: 0
    idx:     (1,-1,5)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (0,0,5)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (2,0,5)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (1,1,5)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (1,0,6)
+
 With weight: 4
 
 On point:    location: -0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (2,0,5)
+
 pt[0]:    location: -0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (2,0,5)
+
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (2,0,4)
+
 With weight: 4
 pt[2]:    location: -0.75 -2.25  0.75
-   is located on boundary: 0
    idx:     (2,-1,5)
+
 With weight: 2.66667
 pt[3]:    location: -1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (1,0,5)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (3,0,5)
+
 With weight: 4
 pt[5]:    location: -0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (2,0,6)
+
 With weight: 4
 pt[6]:    location: -0.75 -2.25  0.25
-   is located on boundary: 0
    idx:     (2,-1,4)
+
 With weight: 1.05525e-15
 
 On point:    location: -0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (3,0,5)
+
 pt[0]:    location: -0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (3,0,5)
+
 With weight: -18.6667
 pt[1]:    location: -0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (3,0,4)
+
 With weight: 4
 pt[2]:    location: -0.25 -2.25  0.75
-   is located on boundary: 0
    idx:     (3,-1,5)
+
 With weight: 2.66667
 pt[3]:    location: -0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (2,0,5)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (4,0,5)
+
 With weight: 4
 pt[5]:    location: -0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (3,0,6)
+
 With weight: 4
 pt[6]:    location: -0.25 -2.25  0.25
-   is located on boundary: 0
    idx:     (3,-1,4)
+
 With weight: 1.05525e-15
 
 On point:    location:  0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (4,0,5)
+
 pt[0]:    location:  0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (4,0,5)
+
 With weight: -18.6667
 pt[1]:    location:  0.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (4,0,4)
+
 With weight: 4
 pt[2]:    location:  0.25 -2.25  0.75
-   is located on boundary: 0
    idx:     (4,-1,5)
+
 With weight: 2.66667
 pt[3]:    location: -0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (3,0,5)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (5,0,5)
+
 With weight: 4
 pt[5]:    location:  0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (4,0,6)
+
 With weight: 4
 pt[6]:    location:  0.25 -2.25  0.25
-   is located on boundary: 0
    idx:     (4,-1,4)
+
 With weight: 1.05525e-15
 
 On point:    location:  0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (5,0,5)
+
 pt[0]:    location:  0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (5,0,5)
+
 With weight: -18.6667
 pt[1]:    location:  0.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (5,0,4)
+
 With weight: 4
 pt[2]:    location:  0.75 -2.25  0.75
-   is located on boundary: 0
    idx:     (5,-1,5)
+
 With weight: 2.66667
 pt[3]:    location:  0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (4,0,5)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (6,0,5)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (5,0,6)
+
 With weight: 4
 pt[6]:    location:  0.75 -2.25  0.25
-   is located on boundary: 0
    idx:     (5,-1,4)
+
 With weight: 1.05525e-15
 
 On point:    location:  1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (6,0,5)
+
 pt[0]:    location:  1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (6,0,5)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (6,0,4)
+
 With weight: 4
 pt[2]:    location:  1.25 -2.25  0.75
-   is located on boundary: 0
    idx:     (6,-1,5)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (5,0,5)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (7,0,5)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (6,1,5)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (6,0,6)
+
 With weight: 4
 
 On point:    location:  1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (7,0,5)
+
 pt[0]:    location:  1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (7,0,5)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.75  0.25
-   is located on boundary: 0
    idx:     (7,0,4)
+
 With weight: 4
 pt[2]:    location:  1.75 -2.25  0.75
-   is located on boundary: 0
    idx:     (7,-1,5)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (6,0,5)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (8,0,5)
+
 With weight: 4
 pt[5]:    location:  1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (7,1,5)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (7,0,6)
+
 With weight: 4
 
 On point:    location: -1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (0,1,5)
+
 pt[0]:    location: -1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (0,1,5)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (0,1,4)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (0,0,5)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (-1,1,5)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (1,1,5)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (0,2,5)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (0,1,6)
+
 With weight: 4
 
 On point:    location: -1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (1,1,5)
+
 pt[0]:    location: -1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (1,1,5)
+
 With weight: -13.3333
 pt[1]:    location: -1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (1,1,4)
+
 With weight: 4
 pt[2]:    location: -1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (1,0,5)
+
 With weight: 2.66667
 pt[3]:    location: -1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (0,1,5)
+
 With weight: 2.66667
 pt[4]:    location: -1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (1,1,6)
+
 With weight: 4
 pt[5]:    location: -1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (0,1,4)
+
 With weight: -1.19224e-15
 pt[6]:    location: -1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (0,0,5)
+
 With weight: 1.05205e-15
 
 On point:    location:  1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (6,1,5)
+
 pt[0]:    location:  1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (6,1,5)
+
 With weight: -13.9608
 pt[1]:    location:  1.25 -1.25  0.25
-   is located on boundary: 0
    idx:     (6,1,4)
+
 With weight: 4
 pt[2]:    location:  1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (6,0,5)
+
 With weight: 0.784314
 pt[3]:    location:  1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (7,1,5)
+
 With weight: 3.29412
 pt[4]:    location:  1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (6,1,6)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.75  0.25
-   is located on boundary: 0
    idx:     (6,0,4)
+
 With weight: -6.71904e-17
 pt[6]:    location:  0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (5,0,5)
+
 With weight: 1.88235
 
 On point:    location:  1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (7,1,5)
+
 pt[0]:    location:  1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (7,1,5)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.25  0.25
-   is located on boundary: 0
    idx:     (7,1,4)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (7,0,5)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (6,1,5)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (8,1,5)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (7,2,5)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (7,1,6)
+
 With weight: 4
 
 On point:    location: -1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (0,2,5)
+
 pt[0]:    location: -1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (0,2,5)
+
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (0,2,4)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (0,1,5)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.75  0.75
-   is located on boundary: 0
    idx:     (-1,2,5)
+
 With weight: 2.66667
 pt[4]:    location: -1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (0,3,5)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (0,2,6)
+
 With weight: 4
 pt[6]:    location: -2.25 -0.75  0.25
-   is located on boundary: 0
    idx:     (-1,2,4)
+
 With weight: 1.13062e-15
 
 On point:    location:  1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (7,2,5)
+
 pt[0]:    location:  1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (7,2,5)
+
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (7,2,4)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (7,1,5)
+
 With weight: 4
 pt[3]:    location:  2.25 -0.75  0.75
-   is located on boundary: 0
    idx:     (8,2,5)
+
 With weight: 2.66667
 pt[4]:    location:  1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (7,3,5)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (7,2,6)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (7,3,4)
+
 With weight: 2.60649e-16
 
 On point:    location: -1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (0,3,5)
+
 pt[0]:    location: -1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (0,3,5)
+
 With weight: -18.6667
 pt[1]:    location: -1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (0,3,4)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (0,2,5)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.25  0.75
-   is located on boundary: 0
    idx:     (-1,3,5)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  0.25  0.75
-   is located on boundary: 0
    idx:     (0,4,5)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (0,3,6)
+
 With weight: 4
 pt[6]:    location: -1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (0,2,4)
+
 With weight: -7.27074e-16
 
 On point:    location:  1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (7,3,5)
+
 pt[0]:    location:  1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (7,3,5)
+
 With weight: -18.6667
 pt[1]:    location:  1.75 -0.25  0.25
-   is located on boundary: 0
    idx:     (7,3,4)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (7,2,5)
+
 With weight: 4
 pt[3]:    location:  2.25 -0.25  0.75
-   is located on boundary: 0
    idx:     (8,3,5)
+
 With weight: 2.66667
 pt[4]:    location: 1.75 0.25 0.75
-   is located on boundary: 0
    idx:     (7,4,5)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (7,3,6)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.75  0.25
-   is located on boundary: 0
    idx:     (7,2,4)
+
 With weight: -7.27074e-16
 
 On point:    location: -1.75  0.25  0.75
-   is located on boundary: 0
    idx:     (0,4,5)
+
 pt[0]:    location: -1.75  0.25  0.75
-   is located on boundary: 0
    idx:     (0,4,5)
+
 With weight: -18.6667
 pt[1]:    location: -1.75  0.25  0.25
-   is located on boundary: 0
    idx:     (0,4,4)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (0,3,5)
+
 With weight: 4
 pt[3]:    location: -2.25  0.25  0.75
-   is located on boundary: 0
    idx:     (-1,4,5)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  0.75  0.75
-   is located on boundary: 0
    idx:     (0,5,5)
+
 With weight: 4
 pt[5]:    location: -1.75  0.25  1.25
-   is located on boundary: 0
    idx:     (0,4,6)
+
 With weight: 4
 pt[6]:    location: -2.25  0.25  0.25
-   is located on boundary: 0
    idx:     (-1,4,4)
+
 With weight: 1.13062e-15
 
 On point:    location: 1.75 0.25 0.75
-   is located on boundary: 0
    idx:     (7,4,5)
+
 pt[0]:    location: 1.75 0.25 0.75
-   is located on boundary: 0
    idx:     (7,4,5)
+
 With weight: -18.6667
 pt[1]:    location: 1.75 0.25 0.25
-   is located on boundary: 0
    idx:     (7,4,4)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (7,3,5)
+
 With weight: 4
 pt[3]:    location: 2.25 0.25 0.75
-   is located on boundary: 0
    idx:     (8,4,5)
+
 With weight: 2.66667
 pt[4]:    location: 1.75 0.75 0.75
-   is located on boundary: 0
    idx:     (7,5,5)
+
 With weight: 4
 pt[5]:    location: 1.75 0.25 1.25
-   is located on boundary: 0
    idx:     (7,4,6)
+
 With weight: 4
 pt[6]:    location: 1.75 0.75 0.25
-   is located on boundary: 0
    idx:     (7,5,4)
+
 With weight: 2.60649e-16
 
 On point:    location: -1.75  0.75  0.75
-   is located on boundary: 0
    idx:     (0,5,5)
+
 pt[0]:    location: -1.75  0.75  0.75
-   is located on boundary: 0
    idx:     (0,5,5)
+
 With weight: -18.6667
 pt[1]:    location: -1.75  0.75  0.25
-   is located on boundary: 0
    idx:     (0,5,4)
+
 With weight: 4
 pt[2]:    location: -1.75  0.25  0.75
-   is located on boundary: 0
    idx:     (0,4,5)
+
 With weight: 4
 pt[3]:    location: -2.25  0.75  0.75
-   is located on boundary: 0
    idx:     (-1,5,5)
+
 With weight: 2.66667
 pt[4]:    location: -1.75  1.25  0.75
-   is located on boundary: 0
    idx:     (0,6,5)
+
 With weight: 4
 pt[5]:    location: -1.75  0.75  1.25
-   is located on boundary: 0
    idx:     (0,5,6)
+
 With weight: 4
 pt[6]:    location: -1.75  0.25  0.25
-   is located on boundary: 0
    idx:     (0,4,4)
+
 With weight: -7.27074e-16
 
 On point:    location: 1.75 0.75 0.75
-   is located on boundary: 0
    idx:     (7,5,5)
+
 pt[0]:    location: 1.75 0.75 0.75
-   is located on boundary: 0
    idx:     (7,5,5)
+
 With weight: -18.6667
 pt[1]:    location: 1.75 0.75 0.25
-   is located on boundary: 0
    idx:     (7,5,4)
+
 With weight: 4
 pt[2]:    location: 1.75 0.25 0.75
-   is located on boundary: 0
    idx:     (7,4,5)
+
 With weight: 4
 pt[3]:    location: 2.25 0.75 0.75
-   is located on boundary: 0
    idx:     (8,5,5)
+
 With weight: 2.66667
 pt[4]:    location: 1.75 1.25 0.75
-   is located on boundary: 0
    idx:     (7,6,5)
+
 With weight: 4
 pt[5]:    location: 1.75 0.75 1.25
-   is located on boundary: 0
    idx:     (7,5,6)
+
 With weight: 4
 pt[6]:    location: 1.75 0.25 0.25
-   is located on boundary: 0
    idx:     (7,4,4)
+
 With weight: -7.27074e-16
 
 On point:    location: -1.75  1.25  0.75
-   is located on boundary: 0
    idx:     (0,6,5)
+
 pt[0]:    location: -1.75  1.25  0.75
-   is located on boundary: 0
    idx:     (0,6,5)
+
 With weight: -24
 pt[1]:    location: -1.75  1.25  0.25
-   is located on boundary: 0
    idx:     (0,6,4)
+
 With weight: 4
 pt[2]:    location: -1.75  0.75  0.75
-   is located on boundary: 0
    idx:     (0,5,5)
+
 With weight: 4
 pt[3]:    location: -2.25  1.25  0.75
-   is located on boundary: 0
    idx:     (-1,6,5)
+
 With weight: 4
 pt[4]:    location: -1.25  1.25  0.75
-   is located on boundary: 0
    idx:     (1,6,5)
+
 With weight: 4
 pt[5]:    location: -1.75  1.75  0.75
-   is located on boundary: 0
    idx:     (0,7,5)
+
 With weight: 4
 pt[6]:    location: -1.75  1.25  1.25
-   is located on boundary: 0
    idx:     (0,6,6)
+
 With weight: 4
 
 On point:    location: -1.25  1.25  0.75
-   is located on boundary: 0
    idx:     (1,6,5)
+
 pt[0]:    location: -1.25  1.25  0.75
-   is located on boundary: 0
    idx:     (1,6,5)
+
 With weight: -13.3333
 pt[1]:    location: -1.25  1.25  0.25
-   is located on boundary: 0
    idx:     (1,6,4)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.75
-   is located on boundary: 0
    idx:     (0,6,5)
+
 With weight: 2.66667
 pt[3]:    location: -1.25  1.75  0.75
-   is located on boundary: 0
    idx:     (1,7,5)
+
 With weight: 2.66667
 pt[4]:    location: -1.25  1.25  1.25
-   is located on boundary: 0
    idx:     (1,6,6)
+
 With weight: 4
 pt[5]:    location: -1.75  1.25  0.25
-   is located on boundary: 0
    idx:     (0,6,4)
+
 With weight: 3.03817e-17
 pt[6]:    location: -1.25  1.75  0.25
-   is located on boundary: 0
    idx:     (1,7,4)
+
 With weight: -3.14198e-16
 
 On point:    location: 1.25 1.25 0.75
-   is located on boundary: 0
    idx:     (6,6,5)
+
 pt[0]:    location: 1.25 1.25 0.75
-   is located on boundary: 0
    idx:     (6,6,5)
+
 With weight: -13.9608
 pt[1]:    location: 1.25 1.25 0.25
-   is located on boundary: 0
    idx:     (6,6,4)
+
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.75
-   is located on boundary: 0
    idx:     (7,6,5)
+
 With weight: 3.29412
 pt[3]:    location: 1.25 1.75 0.75
-   is located on boundary: 0
    idx:     (6,7,5)
+
 With weight: 0.784314
 pt[4]:    location: 1.25 1.25 1.25
-   is located on boundary: 0
    idx:     (6,6,6)
+
 With weight: 4
 pt[5]:    location: 1.25 1.75 0.25
-   is located on boundary: 0
    idx:     (6,7,4)
+
 With weight: 2.01571e-16
 pt[6]:    location: 0.75 1.75 0.75
-   is located on boundary: 0
    idx:     (5,7,5)
+
 With weight: 1.88235
 
 On point:    location: 1.75 1.25 0.75
-   is located on boundary: 0
    idx:     (7,6,5)
+
 pt[0]:    location: 1.75 1.25 0.75
-   is located on boundary: 0
    idx:     (7,6,5)
+
 With weight: -24
 pt[1]:    location: 1.75 1.25 0.25
-   is located on boundary: 0
    idx:     (7,6,4)
+
 With weight: 4
 pt[2]:    location: 1.75 0.75 0.75
-   is located on boundary: 0
    idx:     (7,5,5)
+
 With weight: 4
 pt[3]:    location: 1.25 1.25 0.75
-   is located on boundary: 0
    idx:     (6,6,5)
+
 With weight: 4
 pt[4]:    location: 2.25 1.25 0.75
-   is located on boundary: 0
    idx:     (8,6,5)
+
 With weight: 4
 pt[5]:    location: 1.75 1.75 0.75
-   is located on boundary: 0
    idx:     (7,7,5)
+
 With weight: 4
 pt[6]:    location: 1.75 1.25 1.25
-   is located on boundary: 0
    idx:     (7,6,6)
+
 With weight: 4
 
 On point:    location: -1.75  1.75  0.75
-   is located on boundary: 0
    idx:     (0,7,5)
+
 pt[0]:    location: -1.75  1.75  0.75
-   is located on boundary: 0
    idx:     (0,7,5)
+
 With weight: -24
 pt[1]:    location: -1.75  1.75  0.25
-   is located on boundary: 0
    idx:     (0,7,4)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25  0.75
-   is located on boundary: 0
    idx:     (0,6,5)
+
 With weight: 4
 pt[3]:    location: -2.25  1.75  0.75
-   is located on boundary: 0
    idx:     (-1,7,5)
+
 With weight: 4
 pt[4]:    location: -1.25  1.75  0.75
-   is located on boundary: 0
    idx:     (1,7,5)
+
 With weight: 4
 pt[5]:    location: -1.75  2.25  0.75
-   is located on boundary: 0
    idx:     (0,8,5)
+
 With weight: 4
 pt[6]:    location: -1.75  1.75  1.25
-   is located on boundary: 0
    idx:     (0,7,6)
+
 With weight: 4
 
 On point:    location: -1.25  1.75  0.75
-   is located on boundary: 0
    idx:     (1,7,5)
+
 pt[0]:    location: -1.25  1.75  0.75
-   is located on boundary: 0
    idx:     (1,7,5)
+
 With weight: -24
 pt[1]:    location: -1.25  1.75  0.25
-   is located on boundary: 0
    idx:     (1,7,4)
+
 With weight: 4
 pt[2]:    location: -1.25  1.25  0.75
-   is located on boundary: 0
    idx:     (1,6,5)
+
 With weight: 4
 pt[3]:    location: -1.75  1.75  0.75
-   is located on boundary: 0
    idx:     (0,7,5)
+
 With weight: 4
 pt[4]:    location: -0.75  1.75  0.75
-   is located on boundary: 0
    idx:     (2,7,5)
+
 With weight: 4
 pt[5]:    location: -1.25  2.25  0.75
-   is located on boundary: 0
    idx:     (1,8,5)
+
 With weight: 4
 pt[6]:    location: -1.25  1.75  1.25
-   is located on boundary: 0
    idx:     (1,7,6)
+
 With weight: 4
 
 On point:    location: -0.75  1.75  0.75
-   is located on boundary: 0
    idx:     (2,7,5)
+
 pt[0]:    location: -0.75  1.75  0.75
-   is located on boundary: 0
    idx:     (2,7,5)
+
 With weight: -18.6667
 pt[1]:    location: -0.75  1.75  0.25
-   is located on boundary: 0
    idx:     (2,7,4)
+
 With weight: 4
 pt[2]:    location: -1.25  1.75  0.75
-   is located on boundary: 0
    idx:     (1,7,5)
+
 With weight: 4
 pt[3]:    location: -0.25  1.75  0.75
-   is located on boundary: 0
    idx:     (3,7,5)
+
 With weight: 4
 pt[4]:    location: -0.75  2.25  0.75
-   is located on boundary: 0
    idx:     (2,8,5)
+
 With weight: 2.66667
 pt[5]:    location: -0.75  1.75  1.25
-   is located on boundary: 0
    idx:     (2,7,6)
+
 With weight: 4
 pt[6]:    location: -0.25  1.75  0.25
-   is located on boundary: 0
    idx:     (3,7,4)
+
 With weight: 1.09747e-15
 
 On point:    location: -0.25  1.75  0.75
-   is located on boundary: 0
    idx:     (3,7,5)
+
 pt[0]:    location: -0.25  1.75  0.75
-   is located on boundary: 0
    idx:     (3,7,5)
+
 With weight: -18.6667
 pt[1]:    location: -0.25  1.75  0.25
-   is located on boundary: 0
    idx:     (3,7,4)
+
 With weight: 4
 pt[2]:    location: -0.75  1.75  0.75
-   is located on boundary: 0
    idx:     (2,7,5)
+
 With weight: 4
 pt[3]:    location: 0.25 1.75 0.75
-   is located on boundary: 0
    idx:     (4,7,5)
+
 With weight: 4
 pt[4]:    location: -0.25  2.25  0.75
-   is located on boundary: 0
    idx:     (3,8,5)
+
 With weight: 2.66667
 pt[5]:    location: -0.25  1.75  1.25
-   is located on boundary: 0
    idx:     (3,7,6)
+
 With weight: 4
 pt[6]:    location: -0.75  1.75  0.25
-   is located on boundary: 0
    idx:     (2,7,4)
+
 With weight: 8.23102e-16
 
 On point:    location: 0.25 1.75 0.75
-   is located on boundary: 0
    idx:     (4,7,5)
+
 pt[0]:    location: 0.25 1.75 0.75
-   is located on boundary: 0
    idx:     (4,7,5)
+
 With weight: -18.6667
 pt[1]:    location: 0.25 1.75 0.25
-   is located on boundary: 0
    idx:     (4,7,4)
+
 With weight: 4
 pt[2]:    location: -0.25  1.75  0.75
-   is located on boundary: 0
    idx:     (3,7,5)
+
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.75
-   is located on boundary: 0
    idx:     (5,7,5)
+
 With weight: 4
 pt[4]:    location: 0.25 2.25 0.75
-   is located on boundary: 0
    idx:     (4,8,5)
+
 With weight: 2.66667
 pt[5]:    location: 0.25 1.75 1.25
-   is located on boundary: 0
    idx:     (4,7,6)
+
 With weight: 4
 pt[6]:    location: 0.75 1.75 0.25
-   is located on boundary: 0
    idx:     (5,7,4)
+
 With weight: 1.09747e-15
 
 On point:    location: 0.75 1.75 0.75
-   is located on boundary: 0
    idx:     (5,7,5)
+
 pt[0]:    location: 0.75 1.75 0.75
-   is located on boundary: 0
    idx:     (5,7,5)
+
 With weight: -18.6667
 pt[1]:    location: 0.75 1.75 0.25
-   is located on boundary: 0
    idx:     (5,7,4)
+
 With weight: 4
 pt[2]:    location: 0.25 1.75 0.75
-   is located on boundary: 0
    idx:     (4,7,5)
+
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.75
-   is located on boundary: 0
    idx:     (6,7,5)
+
 With weight: 4
 pt[4]:    location: 0.75 2.25 0.75
-   is located on boundary: 0
    idx:     (5,8,5)
+
 With weight: 2.66667
 pt[5]:    location: 0.75 1.75 1.25
-   is located on boundary: 0
    idx:     (5,7,6)
+
 With weight: 4
 pt[6]:    location: 0.25 1.75 0.25
-   is located on boundary: 0
    idx:     (4,7,4)
+
 With weight: 8.23102e-16
 
 On point:    location: 1.25 1.75 0.75
-   is located on boundary: 0
    idx:     (6,7,5)
+
 pt[0]:    location: 1.25 1.75 0.75
-   is located on boundary: 0
    idx:     (6,7,5)
+
 With weight: -24
 pt[1]:    location: 1.25 1.75 0.25
-   is located on boundary: 0
    idx:     (6,7,4)
+
 With weight: 4
 pt[2]:    location: 1.25 1.25 0.75
-   is located on boundary: 0
    idx:     (6,6,5)
+
 With weight: 4
 pt[3]:    location: 0.75 1.75 0.75
-   is located on boundary: 0
    idx:     (5,7,5)
+
 With weight: 4
 pt[4]:    location: 1.75 1.75 0.75
-   is located on boundary: 0
    idx:     (7,7,5)
+
 With weight: 4
 pt[5]:    location: 1.25 2.25 0.75
-   is located on boundary: 0
    idx:     (6,8,5)
+
 With weight: 4
 pt[6]:    location: 1.25 1.75 1.25
-   is located on boundary: 0
    idx:     (6,7,6)
+
 With weight: 4
 
 On point:    location: 1.75 1.75 0.75
-   is located on boundary: 0
    idx:     (7,7,5)
+
 pt[0]:    location: 1.75 1.75 0.75
-   is located on boundary: 0
    idx:     (7,7,5)
+
 With weight: -24
 pt[1]:    location: 1.75 1.75 0.25
-   is located on boundary: 0
    idx:     (7,7,4)
+
 With weight: 4
 pt[2]:    location: 1.75 1.25 0.75
-   is located on boundary: 0
    idx:     (7,6,5)
+
 With weight: 4
 pt[3]:    location: 1.25 1.75 0.75
-   is located on boundary: 0
    idx:     (6,7,5)
+
 With weight: 4
 pt[4]:    location: 2.25 1.75 0.75
-   is located on boundary: 0
    idx:     (8,7,5)
+
 With weight: 4
 pt[5]:    location: 1.75 2.25 0.75
-   is located on boundary: 0
    idx:     (7,8,5)
+
 With weight: 4
 pt[6]:    location: 1.75 1.75 1.25
-   is located on boundary: 0
    idx:     (7,7,6)
+
 With weight: 4
 
 On point:    location: -1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (0,0,6)
+
 pt[0]:    location: -1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (0,0,6)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (0,0,5)
+
 With weight: 4
 pt[2]:    location: -1.75 -2.25  1.25
-   is located on boundary: 0
    idx:     (0,-1,6)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (-1,0,6)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (1,0,6)
+
 With weight: 4
 pt[5]:    location: -1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (0,1,6)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (0,0,7)
+
 With weight: 4
 
 On point:    location: -1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (1,0,6)
+
 pt[0]:    location: -1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (1,0,6)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (1,0,5)
+
 With weight: 4
 pt[2]:    location: -1.25 -2.25  1.25
-   is located on boundary: 0
    idx:     (1,-1,6)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (0,0,6)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (2,0,6)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (1,1,6)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (1,0,7)
+
 With weight: 4
 
 On point:    location: -0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (2,0,6)
+
 pt[0]:    location: -0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (2,0,6)
+
 With weight: -24
 pt[1]:    location: -0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (2,0,5)
+
 With weight: 4
 pt[2]:    location: -0.75 -2.25  1.25
-   is located on boundary: 0
    idx:     (2,-1,6)
+
 With weight: 4
 pt[3]:    location: -1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (1,0,6)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (3,0,6)
+
 With weight: 4
 pt[5]:    location: -0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (2,1,6)
+
 With weight: 4
 pt[6]:    location: -0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (2,0,7)
+
 With weight: 4
 
 On point:    location: -0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (3,0,6)
+
 pt[0]:    location: -0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (3,0,6)
+
 With weight: -24
 pt[1]:    location: -0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (3,0,5)
+
 With weight: 4
 pt[2]:    location: -0.25 -2.25  1.25
-   is located on boundary: 0
    idx:     (3,-1,6)
+
 With weight: 4
 pt[3]:    location: -0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (2,0,6)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (4,0,6)
+
 With weight: 4
 pt[5]:    location: -0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (3,1,6)
+
 With weight: 4
 pt[6]:    location: -0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (3,0,7)
+
 With weight: 4
 
 On point:    location:  0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (4,0,6)
+
 pt[0]:    location:  0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (4,0,6)
+
 With weight: -24
 pt[1]:    location:  0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (4,0,5)
+
 With weight: 4
 pt[2]:    location:  0.25 -2.25  1.25
-   is located on boundary: 0
    idx:     (4,-1,6)
+
 With weight: 4
 pt[3]:    location: -0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (3,0,6)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (5,0,6)
+
 With weight: 4
 pt[5]:    location:  0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (4,1,6)
+
 With weight: 4
 pt[6]:    location:  0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (4,0,7)
+
 With weight: 4
 
 On point:    location:  0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (5,0,6)
+
 pt[0]:    location:  0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (5,0,6)
+
 With weight: -24
 pt[1]:    location:  0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (5,0,5)
+
 With weight: 4
 pt[2]:    location:  0.75 -2.25  1.25
-   is located on boundary: 0
    idx:     (5,-1,6)
+
 With weight: 4
 pt[3]:    location:  0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (4,0,6)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (6,0,6)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (5,1,6)
+
 With weight: 4
 pt[6]:    location:  0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (5,0,7)
+
 With weight: 4
 
 On point:    location:  1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (6,0,6)
+
 pt[0]:    location:  1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (6,0,6)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (6,0,5)
+
 With weight: 4
 pt[2]:    location:  1.25 -2.25  1.25
-   is located on boundary: 0
    idx:     (6,-1,6)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (5,0,6)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (7,0,6)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (6,1,6)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (6,0,7)
+
 With weight: 4
 
 On point:    location:  1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (7,0,6)
+
 pt[0]:    location:  1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (7,0,6)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (7,0,5)
+
 With weight: 4
 pt[2]:    location:  1.75 -2.25  1.25
-   is located on boundary: 0
    idx:     (7,-1,6)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (6,0,6)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (8,0,6)
+
 With weight: 4
 pt[5]:    location:  1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (7,1,6)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (7,0,7)
+
 With weight: 4
 
 On point:    location: -1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (0,1,6)
+
 pt[0]:    location: -1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (0,1,6)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (0,1,5)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (0,0,6)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (-1,1,6)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (1,1,6)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (0,2,6)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (0,1,7)
+
 With weight: 4
 
 On point:    location: -1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (1,1,6)
+
 pt[0]:    location: -1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (1,1,6)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (1,1,5)
+
 With weight: 4
 pt[2]:    location: -1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (1,0,6)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (0,1,6)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (2,1,6)
+
 With weight: 4
 pt[5]:    location: -1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (1,2,6)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (1,1,7)
+
 With weight: 4
 
 On point:    location: -0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (2,1,6)
+
 pt[0]:    location: -0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (2,1,6)
+
 With weight: -13.9608
 pt[1]:    location: -0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (2,0,6)
+
 With weight: 0.784314
 pt[2]:    location: -1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (1,1,6)
+
 With weight: 4
 pt[3]:    location: -0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (3,1,6)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (2,1,7)
+
 With weight: 3.29412
 pt[5]:    location: -0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (2,0,5)
+
 With weight: 1.88235
 pt[6]:    location: -0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (3,0,6)
+
 With weight: 6.38308e-16
 
 On point:    location: -0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (3,1,6)
+
 pt[0]:    location: -0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (3,1,6)
+
 With weight: -13.9608
 pt[1]:    location: -0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (3,0,6)
+
 With weight: 0.784314
 pt[2]:    location: -0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (2,1,6)
+
 With weight: 4
 pt[3]:    location:  0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (4,1,6)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (3,1,7)
+
 With weight: 3.29412
 pt[5]:    location: -0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (3,0,5)
+
 With weight: 1.88235
 pt[6]:    location: -0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (2,0,6)
+
 With weight: -7.72689e-16
 
 On point:    location:  0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (4,1,6)
+
 pt[0]:    location:  0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (4,1,6)
+
 With weight: -13.9608
 pt[1]:    location:  0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (4,0,6)
+
 With weight: 0.784314
 pt[2]:    location: -0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (3,1,6)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (5,1,6)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (4,1,7)
+
 With weight: 3.29412
 pt[5]:    location:  0.25 -1.75  0.75
-   is located on boundary: 0
    idx:     (4,0,5)
+
 With weight: 1.88235
 pt[6]:    location:  0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (5,0,6)
+
 With weight: 6.38308e-16
 
 On point:    location:  0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (5,1,6)
+
 pt[0]:    location:  0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (5,1,6)
+
 With weight: -14.1867
 pt[1]:    location:  0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (5,0,6)
+
 With weight: 1.38667
 pt[2]:    location:  0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (4,1,6)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (6,1,6)
+
 With weight: 2.72
 pt[4]:    location:  0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (5,1,7)
+
 With weight: 3.52
 pt[5]:    location:  0.75 -1.75  0.75
-   is located on boundary: 0
    idx:     (5,0,5)
+
 With weight: 1.28
 pt[6]:    location:  1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (6,1,5)
+
 With weight: 1.28
 
 On point:    location:  1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (6,1,6)
+
 pt[0]:    location:  1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (6,1,6)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (6,1,5)
+
 With weight: 4
 pt[2]:    location:  1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (6,0,6)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (5,1,6)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (7,1,6)
+
 With weight: 4
 pt[5]:    location:  1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (6,2,6)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (6,1,7)
+
 With weight: 4
 
 On point:    location:  1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (7,1,6)
+
 pt[0]:    location:  1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (7,1,6)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.25  0.75
-   is located on boundary: 0
    idx:     (7,1,5)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (7,0,6)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (6,1,6)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (8,1,6)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (7,2,6)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (7,1,7)
+
 With weight: 4
 
 On point:    location: -1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (0,2,6)
+
 pt[0]:    location: -1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (0,2,6)
+
 With weight: -24
 pt[1]:    location: -1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (0,2,5)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (0,1,6)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (-1,2,6)
+
 With weight: 4
 pt[4]:    location: -1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (1,2,6)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (0,3,6)
+
 With weight: 4
 pt[6]:    location: -1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (0,2,7)
+
 With weight: 4
 
 On point:    location: -1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (1,2,6)
+
 pt[0]:    location: -1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (1,2,6)
+
 With weight: -13.9608
 pt[1]:    location: -1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (1,1,6)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (0,2,6)
+
 With weight: 0.784314
 pt[3]:    location: -1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (1,3,6)
+
 With weight: 4
 pt[4]:    location: -1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (1,2,7)
+
 With weight: 3.29412
 pt[5]:    location: -1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (0,2,5)
+
 With weight: 1.88235
 pt[6]:    location: -1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (0,3,6)
+
 With weight: 4.70333e-16
 
 On point:    location:  1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (6,2,6)
+
 pt[0]:    location:  1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (6,2,6)
+
 With weight: -14.1867
 pt[1]:    location:  1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (6,1,6)
+
 With weight: 2.72
 pt[2]:    location:  1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (7,2,6)
+
 With weight: 1.38667
 pt[3]:    location:  1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (6,3,6)
+
 With weight: 4
 pt[4]:    location:  1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (6,2,7)
+
 With weight: 3.52
 pt[5]:    location:  1.25 -1.25  0.75
-   is located on boundary: 0
    idx:     (6,1,5)
+
 With weight: 1.28
 pt[6]:    location:  1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (7,2,5)
+
 With weight: 1.28
 
 On point:    location:  1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (7,2,6)
+
 pt[0]:    location:  1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (7,2,6)
+
 With weight: -24
 pt[1]:    location:  1.75 -0.75  0.75
-   is located on boundary: 0
    idx:     (7,2,5)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (7,1,6)
+
 With weight: 4
 pt[3]:    location:  1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (6,2,6)
+
 With weight: 4
 pt[4]:    location:  2.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (8,2,6)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (7,3,6)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (7,2,7)
+
 With weight: 4
 
 On point:    location: -1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (0,3,6)
+
 pt[0]:    location: -1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (0,3,6)
+
 With weight: -24
 pt[1]:    location: -1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (0,3,5)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (0,2,6)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (-1,3,6)
+
 With weight: 4
 pt[4]:    location: -1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (1,3,6)
+
 With weight: 4
 pt[5]:    location: -1.75  0.25  1.25
-   is located on boundary: 0
    idx:     (0,4,6)
+
 With weight: 4
 pt[6]:    location: -1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (0,3,7)
+
 With weight: 4
 
 On point:    location: -1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (1,3,6)
+
 pt[0]:    location: -1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (1,3,6)
+
 With weight: -13.9608
 pt[1]:    location: -1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (1,2,6)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (0,3,6)
+
 With weight: 0.784314
 pt[3]:    location: -1.25  0.25  1.25
-   is located on boundary: 0
    idx:     (1,4,6)
+
 With weight: 4
 pt[4]:    location: -1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (1,3,7)
+
 With weight: 3.29412
 pt[5]:    location: -1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (0,3,5)
+
 With weight: 1.88235
 pt[6]:    location: -1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (0,2,6)
+
 With weight: -6.71904e-16
 
 On point:    location:  1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (6,3,6)
+
 pt[0]:    location:  1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (6,3,6)
+
 With weight: -13.9608
 pt[1]:    location:  1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (6,2,6)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (7,3,6)
+
 With weight: 0.784314
 pt[3]:    location: 1.25 0.25 1.25
-   is located on boundary: 0
    idx:     (6,4,6)
+
 With weight: 4
 pt[4]:    location:  1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (6,3,7)
+
 With weight: 3.29412
 pt[5]:    location:  1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (7,3,5)
+
 With weight: 1.88235
 pt[6]:    location:  1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (7,2,6)
+
 With weight: -6.71904e-16
 
 On point:    location:  1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (7,3,6)
+
 pt[0]:    location:  1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (7,3,6)
+
 With weight: -24
 pt[1]:    location:  1.75 -0.25  0.75
-   is located on boundary: 0
    idx:     (7,3,5)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (7,2,6)
+
 With weight: 4
 pt[3]:    location:  1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (6,3,6)
+
 With weight: 4
 pt[4]:    location:  2.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (8,3,6)
+
 With weight: 4
 pt[5]:    location: 1.75 0.25 1.25
-   is located on boundary: 0
    idx:     (7,4,6)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (7,3,7)
+
 With weight: 4
 
 On point:    location: -1.75  0.25  1.25
-   is located on boundary: 0
    idx:     (0,4,6)
+
 pt[0]:    location: -1.75  0.25  1.25
-   is located on boundary: 0
    idx:     (0,4,6)
+
 With weight: -24
 pt[1]:    location: -1.75  0.25  0.75
-   is located on boundary: 0
    idx:     (0,4,5)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (0,3,6)
+
 With weight: 4
 pt[3]:    location: -2.25  0.25  1.25
-   is located on boundary: 0
    idx:     (-1,4,6)
+
 With weight: 4
 pt[4]:    location: -1.25  0.25  1.25
-   is located on boundary: 0
    idx:     (1,4,6)
+
 With weight: 4
 pt[5]:    location: -1.75  0.75  1.25
-   is located on boundary: 0
    idx:     (0,5,6)
+
 With weight: 4
 pt[6]:    location: -1.75  0.25  1.75
-   is located on boundary: 0
    idx:     (0,4,7)
+
 With weight: 4
 
 On point:    location: -1.25  0.25  1.25
-   is located on boundary: 0
    idx:     (1,4,6)
+
 pt[0]:    location: -1.25  0.25  1.25
-   is located on boundary: 0
    idx:     (1,4,6)
+
 With weight: -13.9608
 pt[1]:    location: -1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (1,3,6)
+
 With weight: 4
 pt[2]:    location: -1.75  0.25  1.25
-   is located on boundary: 0
    idx:     (0,4,6)
+
 With weight: 0.784314
 pt[3]:    location: -1.25  0.75  1.25
-   is located on boundary: 0
    idx:     (1,5,6)
+
 With weight: 4
 pt[4]:    location: -1.25  0.25  1.75
-   is located on boundary: 0
    idx:     (1,4,7)
+
 With weight: 3.29412
 pt[5]:    location: -1.75  0.25  0.75
-   is located on boundary: 0
    idx:     (0,4,5)
+
 With weight: 1.88235
 pt[6]:    location: -1.75  0.75  1.25
-   is located on boundary: 0
    idx:     (0,5,6)
+
 With weight: 4.70333e-16
 
 On point:    location: 1.25 0.25 1.25
-   is located on boundary: 0
    idx:     (6,4,6)
+
 pt[0]:    location: 1.25 0.25 1.25
-   is located on boundary: 0
    idx:     (6,4,6)
+
 With weight: -14.8571
 pt[1]:    location:  1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (6,3,6)
+
 With weight: 4
 pt[2]:    location: 1.75 0.25 1.25
-   is located on boundary: 0
    idx:     (7,4,6)
+
 With weight: 1.14286
 pt[3]:    location: 1.25 0.75 1.25
-   is located on boundary: 0
    idx:     (6,5,6)
+
 With weight: 4
 pt[4]:    location: 1.25 0.25 1.75
-   is located on boundary: 0
    idx:     (6,4,7)
+
 With weight: 1.14286
 pt[5]:    location: 1.75 0.25 0.75
-   is located on boundary: 0
    idx:     (7,4,5)
+
 With weight: 2.28571
 pt[6]:    location: 0.75 0.25 1.75
-   is located on boundary: 0
    idx:     (5,4,7)
+
 With weight: 2.28571
 
 On point:    location: 1.75 0.25 1.25
-   is located on boundary: 0
    idx:     (7,4,6)
+
 pt[0]:    location: 1.75 0.25 1.25
-   is located on boundary: 0
    idx:     (7,4,6)
+
 With weight: -24
 pt[1]:    location: 1.75 0.25 0.75
-   is located on boundary: 0
    idx:     (7,4,5)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (7,3,6)
+
 With weight: 4
 pt[3]:    location: 1.25 0.25 1.25
-   is located on boundary: 0
    idx:     (6,4,6)
+
 With weight: 4
 pt[4]:    location: 2.25 0.25 1.25
-   is located on boundary: 0
    idx:     (8,4,6)
+
 With weight: 4
 pt[5]:    location: 1.75 0.75 1.25
-   is located on boundary: 0
    idx:     (7,5,6)
+
 With weight: 4
 pt[6]:    location: 1.75 0.25 1.75
-   is located on boundary: 0
    idx:     (7,4,7)
+
 With weight: 4
 
 On point:    location: -1.75  0.75  1.25
-   is located on boundary: 0
    idx:     (0,5,6)
+
 pt[0]:    location: -1.75  0.75  1.25
-   is located on boundary: 0
    idx:     (0,5,6)
+
 With weight: -24
 pt[1]:    location: -1.75  0.75  0.75
-   is located on boundary: 0
    idx:     (0,5,5)
+
 With weight: 4
 pt[2]:    location: -1.75  0.25  1.25
-   is located on boundary: 0
    idx:     (0,4,6)
+
 With weight: 4
 pt[3]:    location: -2.25  0.75  1.25
-   is located on boundary: 0
    idx:     (-1,5,6)
+
 With weight: 4
 pt[4]:    location: -1.25  0.75  1.25
-   is located on boundary: 0
    idx:     (1,5,6)
+
 With weight: 4
 pt[5]:    location: -1.75  1.25  1.25
-   is located on boundary: 0
    idx:     (0,6,6)
+
 With weight: 4
 pt[6]:    location: -1.75  0.75  1.75
-   is located on boundary: 0
    idx:     (0,5,7)
+
 With weight: 4
 
 On point:    location: -1.25  0.75  1.25
-   is located on boundary: 0
    idx:     (1,5,6)
+
 pt[0]:    location: -1.25  0.75  1.25
-   is located on boundary: 0
    idx:     (1,5,6)
+
 With weight: -13.9608
 pt[1]:    location: -1.25  0.25  1.25
-   is located on boundary: 0
    idx:     (1,4,6)
+
 With weight: 4
 pt[2]:    location: -1.75  0.75  1.25
-   is located on boundary: 0
    idx:     (0,5,6)
+
 With weight: 0.784314
 pt[3]:    location: -1.25  1.25  1.25
-   is located on boundary: 0
    idx:     (1,6,6)
+
 With weight: 4
 pt[4]:    location: -1.25  0.75  1.75
-   is located on boundary: 0
    idx:     (1,5,7)
+
 With weight: 3.29412
 pt[5]:    location: -1.75  0.75  0.75
-   is located on boundary: 0
    idx:     (0,5,5)
+
 With weight: 1.88235
 pt[6]:    location: -1.75  0.25  1.25
-   is located on boundary: 0
    idx:     (0,4,6)
+
 With weight: -6.71904e-16
 
 On point:    location: 1.25 0.75 1.25
-   is located on boundary: 0
    idx:     (6,5,6)
+
 pt[0]:    location: 1.25 0.75 1.25
-   is located on boundary: 0
    idx:     (6,5,6)
+
 With weight: -14.1867
 pt[1]:    location: 1.25 0.25 1.25
-   is located on boundary: 0
    idx:     (6,4,6)
+
 With weight: 4
 pt[2]:    location: 1.75 0.75 1.25
-   is located on boundary: 0
    idx:     (7,5,6)
+
 With weight: 1.38667
 pt[3]:    location: 1.25 1.25 1.25
-   is located on boundary: 0
    idx:     (6,6,6)
+
 With weight: 2.72
 pt[4]:    location: 1.25 0.75 1.75
-   is located on boundary: 0
    idx:     (6,5,7)
+
 With weight: 3.52
 pt[5]:    location: 1.75 0.75 0.75
-   is located on boundary: 0
    idx:     (7,5,5)
+
 With weight: 1.28
 pt[6]:    location: 1.25 1.25 0.75
-   is located on boundary: 0
    idx:     (6,6,5)
+
 With weight: 1.28
 
 On point:    location: 1.75 0.75 1.25
-   is located on boundary: 0
    idx:     (7,5,6)
+
 pt[0]:    location: 1.75 0.75 1.25
-   is located on boundary: 0
    idx:     (7,5,6)
+
 With weight: -24
 pt[1]:    location: 1.75 0.75 0.75
-   is located on boundary: 0
    idx:     (7,5,5)
+
 With weight: 4
 pt[2]:    location: 1.75 0.25 1.25
-   is located on boundary: 0
    idx:     (7,4,6)
+
 With weight: 4
 pt[3]:    location: 1.25 0.75 1.25
-   is located on boundary: 0
    idx:     (6,5,6)
+
 With weight: 4
 pt[4]:    location: 2.25 0.75 1.25
-   is located on boundary: 0
    idx:     (8,5,6)
+
 With weight: 4
 pt[5]:    location: 1.75 1.25 1.25
-   is located on boundary: 0
    idx:     (7,6,6)
+
 With weight: 4
 pt[6]:    location: 1.75 0.75 1.75
-   is located on boundary: 0
    idx:     (7,5,7)
+
 With weight: 4
 
 On point:    location: -1.75  1.25  1.25
-   is located on boundary: 0
    idx:     (0,6,6)
+
 pt[0]:    location: -1.75  1.25  1.25
-   is located on boundary: 0
    idx:     (0,6,6)
+
 With weight: -24
 pt[1]:    location: -1.75  1.25  0.75
-   is located on boundary: 0
    idx:     (0,6,5)
+
 With weight: 4
 pt[2]:    location: -1.75  0.75  1.25
-   is located on boundary: 0
    idx:     (0,5,6)
+
 With weight: 4
 pt[3]:    location: -2.25  1.25  1.25
-   is located on boundary: 0
    idx:     (-1,6,6)
+
 With weight: 4
 pt[4]:    location: -1.25  1.25  1.25
-   is located on boundary: 0
    idx:     (1,6,6)
+
 With weight: 4
 pt[5]:    location: -1.75  1.75  1.25
-   is located on boundary: 0
    idx:     (0,7,6)
+
 With weight: 4
 pt[6]:    location: -1.75  1.25  1.75
-   is located on boundary: 0
    idx:     (0,6,7)
+
 With weight: 4
 
 On point:    location: -1.25  1.25  1.25
-   is located on boundary: 0
    idx:     (1,6,6)
+
 pt[0]:    location: -1.25  1.25  1.25
-   is located on boundary: 0
    idx:     (1,6,6)
+
 With weight: -24
 pt[1]:    location: -1.25  1.25  0.75
-   is located on boundary: 0
    idx:     (1,6,5)
+
 With weight: 4
 pt[2]:    location: -1.25  0.75  1.25
-   is located on boundary: 0
    idx:     (1,5,6)
+
 With weight: 4
 pt[3]:    location: -1.75  1.25  1.25
-   is located on boundary: 0
    idx:     (0,6,6)
+
 With weight: 4
 pt[4]:    location: -0.75  1.25  1.25
-   is located on boundary: 0
    idx:     (2,6,6)
+
 With weight: 4
 pt[5]:    location: -1.25  1.75  1.25
-   is located on boundary: 0
    idx:     (1,7,6)
+
 With weight: 4
 pt[6]:    location: -1.25  1.25  1.75
-   is located on boundary: 0
    idx:     (1,6,7)
+
 With weight: 4
 
 On point:    location: -0.75  1.25  1.25
-   is located on boundary: 0
    idx:     (2,6,6)
+
 pt[0]:    location: -0.75  1.25  1.25
-   is located on boundary: 0
    idx:     (2,6,6)
+
 With weight: -13.9608
 pt[1]:    location: -1.25  1.25  1.25
-   is located on boundary: 0
    idx:     (1,6,6)
+
 With weight: 4
 pt[2]:    location: -0.25  1.25  1.25
-   is located on boundary: 0
    idx:     (3,6,6)
+
 With weight: 4
 pt[3]:    location: -0.75  1.75  1.25
-   is located on boundary: 0
    idx:     (2,7,6)
+
 With weight: 0.784314
 pt[4]:    location: -0.75  1.25  1.75
-   is located on boundary: 0
    idx:     (2,6,7)
+
 With weight: 3.29412
 pt[5]:    location: -0.75  1.75  0.75
-   is located on boundary: 0
    idx:     (2,7,5)
+
 With weight: 1.88235
 pt[6]:    location: -0.25  1.75  1.25
-   is located on boundary: 0
    idx:     (3,7,6)
+
 With weight: -1.27662e-15
 
 On point:    location: -0.25  1.25  1.25
-   is located on boundary: 0
    idx:     (3,6,6)
+
 pt[0]:    location: -0.25  1.25  1.25
-   is located on boundary: 0
    idx:     (3,6,6)
+
 With weight: -13.9608
 pt[1]:    location: -0.75  1.25  1.25
-   is located on boundary: 0
    idx:     (2,6,6)
+
 With weight: 4
 pt[2]:    location: 0.25 1.25 1.25
-   is located on boundary: 0
    idx:     (4,6,6)
+
 With weight: 4
 pt[3]:    location: -0.25  1.75  1.25
-   is located on boundary: 0
    idx:     (3,7,6)
+
 With weight: 0.784314
 pt[4]:    location: -0.25  1.25  1.75
-   is located on boundary: 0
    idx:     (3,6,7)
+
 With weight: 3.29412
 pt[5]:    location: -0.25  1.75  0.75
-   is located on boundary: 0
    idx:     (3,7,5)
+
 With weight: 1.88235
 pt[6]:    location: -0.75  1.75  1.25
-   is located on boundary: 0
    idx:     (2,7,6)
+
 With weight: 0
 
 On point:    location: 0.25 1.25 1.25
-   is located on boundary: 0
    idx:     (4,6,6)
+
 pt[0]:    location: 0.25 1.25 1.25
-   is located on boundary: 0
    idx:     (4,6,6)
+
 With weight: -13.9608
 pt[1]:    location: -0.25  1.25  1.25
-   is located on boundary: 0
    idx:     (3,6,6)
+
 With weight: 4
 pt[2]:    location: 0.75 1.25 1.25
-   is located on boundary: 0
    idx:     (5,6,6)
+
 With weight: 4
 pt[3]:    location: 0.25 1.75 1.25
-   is located on boundary: 0
    idx:     (4,7,6)
+
 With weight: 3.29412
 pt[4]:    location: 0.25 1.25 1.75
-   is located on boundary: 0
    idx:     (4,6,7)
+
 With weight: 0.784314
 pt[5]:    location: 0.75 1.75 1.25
-   is located on boundary: 0
    idx:     (5,7,6)
+
 With weight: -6.31835e-16
 pt[6]:    location: 0.25 0.75 1.75
-   is located on boundary: 0
    idx:     (4,5,7)
+
 With weight: 1.88235
 
 On point:    location: 0.75 1.25 1.25
-   is located on boundary: 0
    idx:     (5,6,6)
+
 pt[0]:    location: 0.75 1.25 1.25
-   is located on boundary: 0
    idx:     (5,6,6)
+
 With weight: -13.9608
 pt[1]:    location: 0.25 1.25 1.25
-   is located on boundary: 0
    idx:     (4,6,6)
+
 With weight: 4
 pt[2]:    location: 1.25 1.25 1.25
-   is located on boundary: 0
    idx:     (6,6,6)
+
 With weight: 2.11765
 pt[3]:    location: 0.75 1.75 1.25
-   is located on boundary: 0
    idx:     (5,7,6)
+
 With weight: 2.66667
 pt[4]:    location: 0.75 1.25 1.75
-   is located on boundary: 0
    idx:     (5,6,7)
+
 With weight: 3.29412
 pt[5]:    location: 1.25 1.25 0.75
-   is located on boundary: 0
    idx:     (6,6,5)
+
 With weight: 1.88235
 pt[6]:    location: 0.25 1.75 1.25
-   is located on boundary: 0
    idx:     (4,7,6)
+
 With weight: -9.72009e-16
 
 On point:    location: 1.25 1.25 1.25
-   is located on boundary: 0
    idx:     (6,6,6)
+
 pt[0]:    location: 1.25 1.25 1.25
-   is located on boundary: 0
    idx:     (6,6,6)
+
 With weight: -24
 pt[1]:    location: 1.25 1.25 0.75
-   is located on boundary: 0
    idx:     (6,6,5)
+
 With weight: 4
 pt[2]:    location: 1.25 0.75 1.25
-   is located on boundary: 0
    idx:     (6,5,6)
+
 With weight: 4
 pt[3]:    location: 0.75 1.25 1.25
-   is located on boundary: 0
    idx:     (5,6,6)
+
 With weight: 4
 pt[4]:    location: 1.75 1.25 1.25
-   is located on boundary: 0
    idx:     (7,6,6)
+
 With weight: 4
 pt[5]:    location: 1.25 1.75 1.25
-   is located on boundary: 0
    idx:     (6,7,6)
+
 With weight: 4
 pt[6]:    location: 1.25 1.25 1.75
-   is located on boundary: 0
    idx:     (6,6,7)
+
 With weight: 4
 
 On point:    location: 1.75 1.25 1.25
-   is located on boundary: 0
    idx:     (7,6,6)
+
 pt[0]:    location: 1.75 1.25 1.25
-   is located on boundary: 0
    idx:     (7,6,6)
+
 With weight: -24
 pt[1]:    location: 1.75 1.25 0.75
-   is located on boundary: 0
    idx:     (7,6,5)
+
 With weight: 4
 pt[2]:    location: 1.75 0.75 1.25
-   is located on boundary: 0
    idx:     (7,5,6)
+
 With weight: 4
 pt[3]:    location: 1.25 1.25 1.25
-   is located on boundary: 0
    idx:     (6,6,6)
+
 With weight: 4
 pt[4]:    location: 2.25 1.25 1.25
-   is located on boundary: 0
    idx:     (8,6,6)
+
 With weight: 4
 pt[5]:    location: 1.75 1.75 1.25
-   is located on boundary: 0
    idx:     (7,7,6)
+
 With weight: 4
 pt[6]:    location: 1.75 1.25 1.75
-   is located on boundary: 0
    idx:     (7,6,7)
+
 With weight: 4
 
 On point:    location: -1.75  1.75  1.25
-   is located on boundary: 0
    idx:     (0,7,6)
+
 pt[0]:    location: -1.75  1.75  1.25
-   is located on boundary: 0
    idx:     (0,7,6)
+
 With weight: -24
 pt[1]:    location: -1.75  1.75  0.75
-   is located on boundary: 0
    idx:     (0,7,5)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25  1.25
-   is located on boundary: 0
    idx:     (0,6,6)
+
 With weight: 4
 pt[3]:    location: -2.25  1.75  1.25
-   is located on boundary: 0
    idx:     (-1,7,6)
+
 With weight: 4
 pt[4]:    location: -1.25  1.75  1.25
-   is located on boundary: 0
    idx:     (1,7,6)
+
 With weight: 4
 pt[5]:    location: -1.75  2.25  1.25
-   is located on boundary: 0
    idx:     (0,8,6)
+
 With weight: 4
 pt[6]:    location: -1.75  1.75  1.75
-   is located on boundary: 0
    idx:     (0,7,7)
+
 With weight: 4
 
 On point:    location: -1.25  1.75  1.25
-   is located on boundary: 0
    idx:     (1,7,6)
+
 pt[0]:    location: -1.25  1.75  1.25
-   is located on boundary: 0
    idx:     (1,7,6)
+
 With weight: -24
 pt[1]:    location: -1.25  1.75  0.75
-   is located on boundary: 0
    idx:     (1,7,5)
+
 With weight: 4
 pt[2]:    location: -1.25  1.25  1.25
-   is located on boundary: 0
    idx:     (1,6,6)
+
 With weight: 4
 pt[3]:    location: -1.75  1.75  1.25
-   is located on boundary: 0
    idx:     (0,7,6)
+
 With weight: 4
 pt[4]:    location: -0.75  1.75  1.25
-   is located on boundary: 0
    idx:     (2,7,6)
+
 With weight: 4
 pt[5]:    location: -1.25  2.25  1.25
-   is located on boundary: 0
    idx:     (1,8,6)
+
 With weight: 4
 pt[6]:    location: -1.25  1.75  1.75
-   is located on boundary: 0
    idx:     (1,7,7)
+
 With weight: 4
 
 On point:    location: -0.75  1.75  1.25
-   is located on boundary: 0
    idx:     (2,7,6)
+
 pt[0]:    location: -0.75  1.75  1.25
-   is located on boundary: 0
    idx:     (2,7,6)
+
 With weight: -24
 pt[1]:    location: -0.75  1.75  0.75
-   is located on boundary: 0
    idx:     (2,7,5)
+
 With weight: 4
 pt[2]:    location: -0.75  1.25  1.25
-   is located on boundary: 0
    idx:     (2,6,6)
+
 With weight: 4
 pt[3]:    location: -1.25  1.75  1.25
-   is located on boundary: 0
    idx:     (1,7,6)
+
 With weight: 4
 pt[4]:    location: -0.25  1.75  1.25
-   is located on boundary: 0
    idx:     (3,7,6)
+
 With weight: 4
 pt[5]:    location: -0.75  2.25  1.25
-   is located on boundary: 0
    idx:     (2,8,6)
+
 With weight: 4
 pt[6]:    location: -0.75  1.75  1.75
-   is located on boundary: 0
    idx:     (2,7,7)
+
 With weight: 4
 
 On point:    location: -0.25  1.75  1.25
-   is located on boundary: 0
    idx:     (3,7,6)
+
 pt[0]:    location: -0.25  1.75  1.25
-   is located on boundary: 0
    idx:     (3,7,6)
+
 With weight: -24
 pt[1]:    location: -0.25  1.75  0.75
-   is located on boundary: 0
    idx:     (3,7,5)
+
 With weight: 4
 pt[2]:    location: -0.25  1.25  1.25
-   is located on boundary: 0
    idx:     (3,6,6)
+
 With weight: 4
 pt[3]:    location: -0.75  1.75  1.25
-   is located on boundary: 0
    idx:     (2,7,6)
+
 With weight: 4
 pt[4]:    location: 0.25 1.75 1.25
-   is located on boundary: 0
    idx:     (4,7,6)
+
 With weight: 4
 pt[5]:    location: -0.25  2.25  1.25
-   is located on boundary: 0
    idx:     (3,8,6)
+
 With weight: 4
 pt[6]:    location: -0.25  1.75  1.75
-   is located on boundary: 0
    idx:     (3,7,7)
+
 With weight: 4
 
 On point:    location: 0.25 1.75 1.25
-   is located on boundary: 0
    idx:     (4,7,6)
+
 pt[0]:    location: 0.25 1.75 1.25
-   is located on boundary: 0
    idx:     (4,7,6)
+
 With weight: -24
 pt[1]:    location: 0.25 1.75 0.75
-   is located on boundary: 0
    idx:     (4,7,5)
+
 With weight: 4
 pt[2]:    location: 0.25 1.25 1.25
-   is located on boundary: 0
    idx:     (4,6,6)
+
 With weight: 4
 pt[3]:    location: -0.25  1.75  1.25
-   is located on boundary: 0
    idx:     (3,7,6)
+
 With weight: 4
 pt[4]:    location: 0.75 1.75 1.25
-   is located on boundary: 0
    idx:     (5,7,6)
+
 With weight: 4
 pt[5]:    location: 0.25 2.25 1.25
-   is located on boundary: 0
    idx:     (4,8,6)
+
 With weight: 4
 pt[6]:    location: 0.25 1.75 1.75
-   is located on boundary: 0
    idx:     (4,7,7)
+
 With weight: 4
 
 On point:    location: 0.75 1.75 1.25
-   is located on boundary: 0
    idx:     (5,7,6)
+
 pt[0]:    location: 0.75 1.75 1.25
-   is located on boundary: 0
    idx:     (5,7,6)
+
 With weight: -24
 pt[1]:    location: 0.75 1.75 0.75
-   is located on boundary: 0
    idx:     (5,7,5)
+
 With weight: 4
 pt[2]:    location: 0.75 1.25 1.25
-   is located on boundary: 0
    idx:     (5,6,6)
+
 With weight: 4
 pt[3]:    location: 0.25 1.75 1.25
-   is located on boundary: 0
    idx:     (4,7,6)
+
 With weight: 4
 pt[4]:    location: 1.25 1.75 1.25
-   is located on boundary: 0
    idx:     (6,7,6)
+
 With weight: 4
 pt[5]:    location: 0.75 2.25 1.25
-   is located on boundary: 0
    idx:     (5,8,6)
+
 With weight: 4
 pt[6]:    location: 0.75 1.75 1.75
-   is located on boundary: 0
    idx:     (5,7,7)
+
 With weight: 4
 
 On point:    location: 1.25 1.75 1.25
-   is located on boundary: 0
    idx:     (6,7,6)
+
 pt[0]:    location: 1.25 1.75 1.25
-   is located on boundary: 0
    idx:     (6,7,6)
+
 With weight: -24
 pt[1]:    location: 1.25 1.75 0.75
-   is located on boundary: 0
    idx:     (6,7,5)
+
 With weight: 4
 pt[2]:    location: 1.25 1.25 1.25
-   is located on boundary: 0
    idx:     (6,6,6)
+
 With weight: 4
 pt[3]:    location: 0.75 1.75 1.25
-   is located on boundary: 0
    idx:     (5,7,6)
+
 With weight: 4
 pt[4]:    location: 1.75 1.75 1.25
-   is located on boundary: 0
    idx:     (7,7,6)
+
 With weight: 4
 pt[5]:    location: 1.25 2.25 1.25
-   is located on boundary: 0
    idx:     (6,8,6)
+
 With weight: 4
 pt[6]:    location: 1.25 1.75 1.75
-   is located on boundary: 0
    idx:     (6,7,7)
+
 With weight: 4
 
 On point:    location: 1.75 1.75 1.25
-   is located on boundary: 0
    idx:     (7,7,6)
+
 pt[0]:    location: 1.75 1.75 1.25
-   is located on boundary: 0
    idx:     (7,7,6)
+
 With weight: -24
 pt[1]:    location: 1.75 1.75 0.75
-   is located on boundary: 0
    idx:     (7,7,5)
+
 With weight: 4
 pt[2]:    location: 1.75 1.25 1.25
-   is located on boundary: 0
    idx:     (7,6,6)
+
 With weight: 4
 pt[3]:    location: 1.25 1.75 1.25
-   is located on boundary: 0
    idx:     (6,7,6)
+
 With weight: 4
 pt[4]:    location: 2.25 1.75 1.25
-   is located on boundary: 0
    idx:     (8,7,6)
+
 With weight: 4
 pt[5]:    location: 1.75 2.25 1.25
-   is located on boundary: 0
    idx:     (7,8,6)
+
 With weight: 4
 pt[6]:    location: 1.75 1.75 1.75
-   is located on boundary: 0
    idx:     (7,7,7)
+
 With weight: 4
 
 On point:    location: -1.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (0,0,7)
+
 pt[0]:    location: -1.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (0,0,7)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (0,0,6)
+
 With weight: 4
 pt[2]:    location: -1.75 -2.25  1.75
-   is located on boundary: 0
    idx:     (0,-1,7)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (-1,0,7)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (1,0,7)
+
 With weight: 4
 pt[5]:    location: -1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (0,1,7)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.75  2.25
-   is located on boundary: 0
    idx:     (0,0,8)
+
 With weight: 4
 
 On point:    location: -1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (1,0,7)
+
 pt[0]:    location: -1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (1,0,7)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (1,0,6)
+
 With weight: 4
 pt[2]:    location: -1.25 -2.25  1.75
-   is located on boundary: 0
    idx:     (1,-1,7)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (0,0,7)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (2,0,7)
+
 With weight: 4
 pt[5]:    location: -1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (1,1,7)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.75  2.25
-   is located on boundary: 0
    idx:     (1,0,8)
+
 With weight: 4
 
 On point:    location: -0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (2,0,7)
+
 pt[0]:    location: -0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (2,0,7)
+
 With weight: -24
 pt[1]:    location: -0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (2,0,6)
+
 With weight: 4
 pt[2]:    location: -0.75 -2.25  1.75
-   is located on boundary: 0
    idx:     (2,-1,7)
+
 With weight: 4
 pt[3]:    location: -1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (1,0,7)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (3,0,7)
+
 With weight: 4
 pt[5]:    location: -0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (2,1,7)
+
 With weight: 4
 pt[6]:    location: -0.75 -1.75  2.25
-   is located on boundary: 0
    idx:     (2,0,8)
+
 With weight: 4
 
 On point:    location: -0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (3,0,7)
+
 pt[0]:    location: -0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (3,0,7)
+
 With weight: -24
 pt[1]:    location: -0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (3,0,6)
+
 With weight: 4
 pt[2]:    location: -0.25 -2.25  1.75
-   is located on boundary: 0
    idx:     (3,-1,7)
+
 With weight: 4
 pt[3]:    location: -0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (2,0,7)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (4,0,7)
+
 With weight: 4
 pt[5]:    location: -0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (3,1,7)
+
 With weight: 4
 pt[6]:    location: -0.25 -1.75  2.25
-   is located on boundary: 0
    idx:     (3,0,8)
+
 With weight: 4
 
 On point:    location:  0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (4,0,7)
+
 pt[0]:    location:  0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (4,0,7)
+
 With weight: -24
 pt[1]:    location:  0.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (4,0,6)
+
 With weight: 4
 pt[2]:    location:  0.25 -2.25  1.75
-   is located on boundary: 0
    idx:     (4,-1,7)
+
 With weight: 4
 pt[3]:    location: -0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (3,0,7)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (5,0,7)
+
 With weight: 4
 pt[5]:    location:  0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (4,1,7)
+
 With weight: 4
 pt[6]:    location:  0.25 -1.75  2.25
-   is located on boundary: 0
    idx:     (4,0,8)
+
 With weight: 4
 
 On point:    location:  0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (5,0,7)
+
 pt[0]:    location:  0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (5,0,7)
+
 With weight: -24
 pt[1]:    location:  0.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (5,0,6)
+
 With weight: 4
 pt[2]:    location:  0.75 -2.25  1.75
-   is located on boundary: 0
    idx:     (5,-1,7)
+
 With weight: 4
 pt[3]:    location:  0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (4,0,7)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (6,0,7)
+
 With weight: 4
 pt[5]:    location:  0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (5,1,7)
+
 With weight: 4
 pt[6]:    location:  0.75 -1.75  2.25
-   is located on boundary: 0
    idx:     (5,0,8)
+
 With weight: 4
 
 On point:    location:  1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (6,0,7)
+
 pt[0]:    location:  1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (6,0,7)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.75  1.25
-   is located on boundary: 0
    idx:     (6,0,6)
+
 With weight: 4
 pt[2]:    location:  1.25 -2.25  1.75
-   is located on boundary: 0
    idx:     (6,-1,7)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (5,0,7)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (7,0,7)
+
 With weight: 4
 pt[5]:    location:  1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (6,1,7)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.75  2.25
-   is located on boundary: 0
    idx:     (6,0,8)
+
 With weight: 4
 
 On point:    location:  1.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (7,0,7)
+
 pt[0]:    location:  1.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (7,0,7)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.75  1.25
-   is located on boundary: 0
    idx:     (7,0,6)
+
 With weight: 4
 pt[2]:    location:  1.75 -2.25  1.75
-   is located on boundary: 0
    idx:     (7,-1,7)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (6,0,7)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (8,0,7)
+
 With weight: 4
 pt[5]:    location:  1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (7,1,7)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.75  2.25
-   is located on boundary: 0
    idx:     (7,0,8)
+
 With weight: 4
 
 On point:    location: -1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (0,1,7)
+
 pt[0]:    location: -1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (0,1,7)
+
 With weight: -24
 pt[1]:    location: -1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (0,1,6)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (0,0,7)
+
 With weight: 4
 pt[3]:    location: -2.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (-1,1,7)
+
 With weight: 4
 pt[4]:    location: -1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (1,1,7)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (0,2,7)
+
 With weight: 4
 pt[6]:    location: -1.75 -1.25  2.25
-   is located on boundary: 0
    idx:     (0,1,8)
+
 With weight: 4
 
 On point:    location: -1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (1,1,7)
+
 pt[0]:    location: -1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (1,1,7)
+
 With weight: -24
 pt[1]:    location: -1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (1,1,6)
+
 With weight: 4
 pt[2]:    location: -1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (1,0,7)
+
 With weight: 4
 pt[3]:    location: -1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (0,1,7)
+
 With weight: 4
 pt[4]:    location: -0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (2,1,7)
+
 With weight: 4
 pt[5]:    location: -1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (1,2,7)
+
 With weight: 4
 pt[6]:    location: -1.25 -1.25  2.25
-   is located on boundary: 0
    idx:     (1,1,8)
+
 With weight: 4
 
 On point:    location: -0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (2,1,7)
+
 pt[0]:    location: -0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (2,1,7)
+
 With weight: -24
 pt[1]:    location: -0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (2,1,6)
+
 With weight: 4
 pt[2]:    location: -0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (2,0,7)
+
 With weight: 4
 pt[3]:    location: -1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (1,1,7)
+
 With weight: 4
 pt[4]:    location: -0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (3,1,7)
+
 With weight: 4
 pt[5]:    location: -0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (2,2,7)
+
 With weight: 4
 pt[6]:    location: -0.75 -1.25  2.25
-   is located on boundary: 0
    idx:     (2,1,8)
+
 With weight: 4
 
 On point:    location: -0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (3,1,7)
+
 pt[0]:    location: -0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (3,1,7)
+
 With weight: -24
 pt[1]:    location: -0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (3,1,6)
+
 With weight: 4
 pt[2]:    location: -0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (3,0,7)
+
 With weight: 4
 pt[3]:    location: -0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (2,1,7)
+
 With weight: 4
 pt[4]:    location:  0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (4,1,7)
+
 With weight: 4
 pt[5]:    location: -0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (3,2,7)
+
 With weight: 4
 pt[6]:    location: -0.25 -1.25  2.25
-   is located on boundary: 0
    idx:     (3,1,8)
+
 With weight: 4
 
 On point:    location:  0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (4,1,7)
+
 pt[0]:    location:  0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (4,1,7)
+
 With weight: -24
 pt[1]:    location:  0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (4,1,6)
+
 With weight: 4
 pt[2]:    location:  0.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (4,0,7)
+
 With weight: 4
 pt[3]:    location: -0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (3,1,7)
+
 With weight: 4
 pt[4]:    location:  0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (5,1,7)
+
 With weight: 4
 pt[5]:    location:  0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (4,2,7)
+
 With weight: 4
 pt[6]:    location:  0.25 -1.25  2.25
-   is located on boundary: 0
    idx:     (4,1,8)
+
 With weight: 4
 
 On point:    location:  0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (5,1,7)
+
 pt[0]:    location:  0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (5,1,7)
+
 With weight: -24
 pt[1]:    location:  0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (5,1,6)
+
 With weight: 4
 pt[2]:    location:  0.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (5,0,7)
+
 With weight: 4
 pt[3]:    location:  0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (4,1,7)
+
 With weight: 4
 pt[4]:    location:  1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (6,1,7)
+
 With weight: 4
 pt[5]:    location:  0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (5,2,7)
+
 With weight: 4
 pt[6]:    location:  0.75 -1.25  2.25
-   is located on boundary: 0
    idx:     (5,1,8)
+
 With weight: 4
 
 On point:    location:  1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (6,1,7)
+
 pt[0]:    location:  1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (6,1,7)
+
 With weight: -24
 pt[1]:    location:  1.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (6,1,6)
+
 With weight: 4
 pt[2]:    location:  1.25 -1.75  1.75
-   is located on boundary: 0
    idx:     (6,0,7)
+
 With weight: 4
 pt[3]:    location:  0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (5,1,7)
+
 With weight: 4
 pt[4]:    location:  1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (7,1,7)
+
 With weight: 4
 pt[5]:    location:  1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (6,2,7)
+
 With weight: 4
 pt[6]:    location:  1.25 -1.25  2.25
-   is located on boundary: 0
    idx:     (6,1,8)
+
 With weight: 4
 
 On point:    location:  1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (7,1,7)
+
 pt[0]:    location:  1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (7,1,7)
+
 With weight: -24
 pt[1]:    location:  1.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (7,1,6)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.75  1.75
-   is located on boundary: 0
    idx:     (7,0,7)
+
 With weight: 4
 pt[3]:    location:  1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (6,1,7)
+
 With weight: 4
 pt[4]:    location:  2.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (8,1,7)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (7,2,7)
+
 With weight: 4
 pt[6]:    location:  1.75 -1.25  2.25
-   is located on boundary: 0
    idx:     (7,1,8)
+
 With weight: 4
 
 On point:    location: -1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (0,2,7)
+
 pt[0]:    location: -1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (0,2,7)
+
 With weight: -24
 pt[1]:    location: -1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (0,2,6)
+
 With weight: 4
 pt[2]:    location: -1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (0,1,7)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (-1,2,7)
+
 With weight: 4
 pt[4]:    location: -1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (1,2,7)
+
 With weight: 4
 pt[5]:    location: -1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (0,3,7)
+
 With weight: 4
 pt[6]:    location: -1.75 -0.75  2.25
-   is located on boundary: 0
    idx:     (0,2,8)
+
 With weight: 4
 
 On point:    location: -1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (1,2,7)
+
 pt[0]:    location: -1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (1,2,7)
+
 With weight: -24
 pt[1]:    location: -1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (1,2,6)
+
 With weight: 4
 pt[2]:    location: -1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (1,1,7)
+
 With weight: 4
 pt[3]:    location: -1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (0,2,7)
+
 With weight: 4
 pt[4]:    location: -0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (2,2,7)
+
 With weight: 4
 pt[5]:    location: -1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (1,3,7)
+
 With weight: 4
 pt[6]:    location: -1.25 -0.75  2.25
-   is located on boundary: 0
    idx:     (1,2,8)
+
 With weight: 4
 
 On point:    location: -0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (2,2,7)
+
 pt[0]:    location: -0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (2,2,7)
+
 With weight: -18.6667
 pt[1]:    location: -0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (2,1,7)
+
 With weight: 4
 pt[2]:    location: -1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (1,2,7)
+
 With weight: 4
 pt[3]:    location: -0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (3,2,7)
+
 With weight: 4
 pt[4]:    location: -0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (2,3,7)
+
 With weight: 4
 pt[5]:    location: -0.75 -0.75  2.25
-   is located on boundary: 0
    idx:     (2,2,8)
+
 With weight: 2.66667
 pt[6]:    location: -0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (3,1,7)
+
 With weight: 1.65992e-15
 
 On point:    location: -0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (3,2,7)
+
 pt[0]:    location: -0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (3,2,7)
+
 With weight: -19.2941
 pt[1]:    location: -0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (3,1,7)
+
 With weight: 2.11765
 pt[2]:    location: -0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (2,2,7)
+
 With weight: 4
 pt[3]:    location:  0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (4,2,7)
+
 With weight: 4
 pt[4]:    location: -0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (3,3,7)
+
 With weight: 4
 pt[5]:    location: -0.25 -0.75  2.25
-   is located on boundary: 0
    idx:     (3,2,8)
+
 With weight: 3.29412
 pt[6]:    location: -0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (3,1,6)
+
 With weight: 1.88235
 
 On point:    location:  0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (4,2,7)
+
 pt[0]:    location:  0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (4,2,7)
+
 With weight: -19.2941
 pt[1]:    location:  0.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (4,1,7)
+
 With weight: 2.11765
 pt[2]:    location: -0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (3,2,7)
+
 With weight: 4
 pt[3]:    location:  0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (5,2,7)
+
 With weight: 4
 pt[4]:    location:  0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (4,3,7)
+
 With weight: 4
 pt[5]:    location:  0.25 -0.75  2.25
-   is located on boundary: 0
    idx:     (4,2,8)
+
 With weight: 3.29412
 pt[6]:    location:  0.25 -1.25  1.25
-   is located on boundary: 0
    idx:     (4,1,6)
+
 With weight: 1.88235
 
 On point:    location:  0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (5,2,7)
+
 pt[0]:    location:  0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (5,2,7)
+
 With weight: -19.2941
 pt[1]:    location:  0.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (5,1,7)
+
 With weight: 2.11765
 pt[2]:    location:  0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (4,2,7)
+
 With weight: 4
 pt[3]:    location:  1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (6,2,7)
+
 With weight: 4
 pt[4]:    location:  0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (5,3,7)
+
 With weight: 4
 pt[5]:    location:  0.75 -0.75  2.25
-   is located on boundary: 0
    idx:     (5,2,8)
+
 With weight: 3.29412
 pt[6]:    location:  0.75 -1.25  1.25
-   is located on boundary: 0
    idx:     (5,1,6)
+
 With weight: 1.88235
 
 On point:    location:  1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (6,2,7)
+
 pt[0]:    location:  1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (6,2,7)
+
 With weight: -24
 pt[1]:    location:  1.25 -0.75  1.25
-   is located on boundary: 0
    idx:     (6,2,6)
+
 With weight: 4
 pt[2]:    location:  1.25 -1.25  1.75
-   is located on boundary: 0
    idx:     (6,1,7)
+
 With weight: 4
 pt[3]:    location:  0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (5,2,7)
+
 With weight: 4
 pt[4]:    location:  1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (7,2,7)
+
 With weight: 4
 pt[5]:    location:  1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (6,3,7)
+
 With weight: 4
 pt[6]:    location:  1.25 -0.75  2.25
-   is located on boundary: 0
    idx:     (6,2,8)
+
 With weight: 4
 
 On point:    location:  1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (7,2,7)
+
 pt[0]:    location:  1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (7,2,7)
+
 With weight: -24
 pt[1]:    location:  1.75 -0.75  1.25
-   is located on boundary: 0
    idx:     (7,2,6)
+
 With weight: 4
 pt[2]:    location:  1.75 -1.25  1.75
-   is located on boundary: 0
    idx:     (7,1,7)
+
 With weight: 4
 pt[3]:    location:  1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (6,2,7)
+
 With weight: 4
 pt[4]:    location:  2.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (8,2,7)
+
 With weight: 4
 pt[5]:    location:  1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (7,3,7)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.75  2.25
-   is located on boundary: 0
    idx:     (7,2,8)
+
 With weight: 4
 
 On point:    location: -1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (0,3,7)
+
 pt[0]:    location: -1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (0,3,7)
+
 With weight: -24
 pt[1]:    location: -1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (0,3,6)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (0,2,7)
+
 With weight: 4
 pt[3]:    location: -2.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (-1,3,7)
+
 With weight: 4
 pt[4]:    location: -1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (1,3,7)
+
 With weight: 4
 pt[5]:    location: -1.75  0.25  1.75
-   is located on boundary: 0
    idx:     (0,4,7)
+
 With weight: 4
 pt[6]:    location: -1.75 -0.25  2.25
-   is located on boundary: 0
    idx:     (0,3,8)
+
 With weight: 4
 
 On point:    location: -1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (1,3,7)
+
 pt[0]:    location: -1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (1,3,7)
+
 With weight: -24
 pt[1]:    location: -1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (1,3,6)
+
 With weight: 4
 pt[2]:    location: -1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (1,2,7)
+
 With weight: 4
 pt[3]:    location: -1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (0,3,7)
+
 With weight: 4
 pt[4]:    location: -0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (2,3,7)
+
 With weight: 4
 pt[5]:    location: -1.25  0.25  1.75
-   is located on boundary: 0
    idx:     (1,4,7)
+
 With weight: 4
 pt[6]:    location: -1.25 -0.25  2.25
-   is located on boundary: 0
    idx:     (1,3,8)
+
 With weight: 4
 
 On point:    location: -0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (2,3,7)
+
 pt[0]:    location: -0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (2,3,7)
+
 With weight: -19.2941
 pt[1]:    location: -0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (2,2,7)
+
 With weight: 4
 pt[2]:    location: -1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (1,3,7)
+
 With weight: 2.11765
 pt[3]:    location: -0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (3,3,7)
+
 With weight: 4
 pt[4]:    location: -0.75  0.25  1.75
-   is located on boundary: 0
    idx:     (2,4,7)
+
 With weight: 4
 pt[5]:    location: -0.75 -0.25  2.25
-   is located on boundary: 0
    idx:     (2,3,8)
+
 With weight: 3.29412
 pt[6]:    location: -1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (1,3,6)
+
 With weight: 1.88235
 
 On point:    location: -0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (3,3,7)
+
 pt[0]:    location: -0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (3,3,7)
+
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (3,2,7)
+
 With weight: 4
 pt[2]:    location: -0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (2,3,7)
+
 With weight: 4
 pt[3]:    location:  0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (4,3,7)
+
 With weight: 4
 pt[4]:    location: -0.25  0.25  1.75
-   is located on boundary: 0
    idx:     (3,4,7)
+
 With weight: 4
 pt[5]:    location: -0.25 -0.25  2.25
-   is located on boundary: 0
    idx:     (3,3,8)
+
 With weight: 2.66667
 pt[6]:    location: -0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (2,2,7)
+
 With weight: 1.70108e-15
 
 On point:    location:  0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (4,3,7)
+
 pt[0]:    location:  0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (4,3,7)
+
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (4,2,7)
+
 With weight: 4
 pt[2]:    location: -0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (3,3,7)
+
 With weight: 4
 pt[3]:    location:  0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (5,3,7)
+
 With weight: 4
 pt[4]:    location: 0.25 0.25 1.75
-   is located on boundary: 0
    idx:     (4,4,7)
+
 With weight: 4
 pt[5]:    location:  0.25 -0.25  2.25
-   is located on boundary: 0
    idx:     (4,3,8)
+
 With weight: 2.66667
 pt[6]:    location:  0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (5,2,7)
+
 With weight: 1.65992e-15
 
 On point:    location:  0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (5,3,7)
+
 pt[0]:    location:  0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (5,3,7)
+
 With weight: -19.2941
 pt[1]:    location:  0.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (5,2,7)
+
 With weight: 4
 pt[2]:    location:  0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (4,3,7)
+
 With weight: 4
 pt[3]:    location:  1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (6,3,7)
+
 With weight: 2.11765
 pt[4]:    location: 0.75 0.25 1.75
-   is located on boundary: 0
    idx:     (5,4,7)
+
 With weight: 4
 pt[5]:    location:  0.75 -0.25  2.25
-   is located on boundary: 0
    idx:     (5,3,8)
+
 With weight: 3.29412
 pt[6]:    location:  1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (6,3,6)
+
 With weight: 1.88235
 
 On point:    location:  1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (6,3,7)
+
 pt[0]:    location:  1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (6,3,7)
+
 With weight: -24
 pt[1]:    location:  1.25 -0.25  1.25
-   is located on boundary: 0
    idx:     (6,3,6)
+
 With weight: 4
 pt[2]:    location:  1.25 -0.75  1.75
-   is located on boundary: 0
    idx:     (6,2,7)
+
 With weight: 4
 pt[3]:    location:  0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (5,3,7)
+
 With weight: 4
 pt[4]:    location:  1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (7,3,7)
+
 With weight: 4
 pt[5]:    location: 1.25 0.25 1.75
-   is located on boundary: 0
    idx:     (6,4,7)
+
 With weight: 4
 pt[6]:    location:  1.25 -0.25  2.25
-   is located on boundary: 0
    idx:     (6,3,8)
+
 With weight: 4
 
 On point:    location:  1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (7,3,7)
+
 pt[0]:    location:  1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (7,3,7)
+
 With weight: -24
 pt[1]:    location:  1.75 -0.25  1.25
-   is located on boundary: 0
    idx:     (7,3,6)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.75  1.75
-   is located on boundary: 0
    idx:     (7,2,7)
+
 With weight: 4
 pt[3]:    location:  1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (6,3,7)
+
 With weight: 4
 pt[4]:    location:  2.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (8,3,7)
+
 With weight: 4
 pt[5]:    location: 1.75 0.25 1.75
-   is located on boundary: 0
    idx:     (7,4,7)
+
 With weight: 4
 pt[6]:    location:  1.75 -0.25  2.25
-   is located on boundary: 0
    idx:     (7,3,8)
+
 With weight: 4
 
 On point:    location: -1.75  0.25  1.75
-   is located on boundary: 0
    idx:     (0,4,7)
+
 pt[0]:    location: -1.75  0.25  1.75
-   is located on boundary: 0
    idx:     (0,4,7)
+
 With weight: -24
 pt[1]:    location: -1.75  0.25  1.25
-   is located on boundary: 0
    idx:     (0,4,6)
+
 With weight: 4
 pt[2]:    location: -1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (0,3,7)
+
 With weight: 4
 pt[3]:    location: -2.25  0.25  1.75
-   is located on boundary: 0
    idx:     (-1,4,7)
+
 With weight: 4
 pt[4]:    location: -1.25  0.25  1.75
-   is located on boundary: 0
    idx:     (1,4,7)
+
 With weight: 4
 pt[5]:    location: -1.75  0.75  1.75
-   is located on boundary: 0
    idx:     (0,5,7)
+
 With weight: 4
 pt[6]:    location: -1.75  0.25  2.25
-   is located on boundary: 0
    idx:     (0,4,8)
+
 With weight: 4
 
 On point:    location: -1.25  0.25  1.75
-   is located on boundary: 0
    idx:     (1,4,7)
+
 pt[0]:    location: -1.25  0.25  1.75
-   is located on boundary: 0
    idx:     (1,4,7)
+
 With weight: -24
 pt[1]:    location: -1.25  0.25  1.25
-   is located on boundary: 0
    idx:     (1,4,6)
+
 With weight: 4
 pt[2]:    location: -1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (1,3,7)
+
 With weight: 4
 pt[3]:    location: -1.75  0.25  1.75
-   is located on boundary: 0
    idx:     (0,4,7)
+
 With weight: 4
 pt[4]:    location: -0.75  0.25  1.75
-   is located on boundary: 0
    idx:     (2,4,7)
+
 With weight: 4
 pt[5]:    location: -1.25  0.75  1.75
-   is located on boundary: 0
    idx:     (1,5,7)
+
 With weight: 4
 pt[6]:    location: -1.25  0.25  2.25
-   is located on boundary: 0
    idx:     (1,4,8)
+
 With weight: 4
 
 On point:    location: -0.75  0.25  1.75
-   is located on boundary: 0
    idx:     (2,4,7)
+
 pt[0]:    location: -0.75  0.25  1.75
-   is located on boundary: 0
    idx:     (2,4,7)
+
 With weight: -19.2941
 pt[1]:    location: -0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (2,3,7)
+
 With weight: 4
 pt[2]:    location: -1.25  0.25  1.75
-   is located on boundary: 0
    idx:     (1,4,7)
+
 With weight: 2.11765
 pt[3]:    location: -0.25  0.25  1.75
-   is located on boundary: 0
    idx:     (3,4,7)
+
 With weight: 4
 pt[4]:    location: -0.75  0.75  1.75
-   is located on boundary: 0
    idx:     (2,5,7)
+
 With weight: 4
 pt[5]:    location: -0.75  0.25  2.25
-   is located on boundary: 0
    idx:     (2,4,8)
+
 With weight: 3.29412
 pt[6]:    location: -1.25  0.25  1.25
-   is located on boundary: 0
    idx:     (1,4,6)
+
 With weight: 1.88235
 
 On point:    location: -0.25  0.25  1.75
-   is located on boundary: 0
    idx:     (3,4,7)
+
 pt[0]:    location: -0.25  0.25  1.75
-   is located on boundary: 0
    idx:     (3,4,7)
+
 With weight: -18.6667
 pt[1]:    location: -0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (3,3,7)
+
 With weight: 4
 pt[2]:    location: -0.75  0.25  1.75
-   is located on boundary: 0
    idx:     (2,4,7)
+
 With weight: 4
 pt[3]:    location: 0.25 0.25 1.75
-   is located on boundary: 0
    idx:     (4,4,7)
+
 With weight: 4
 pt[4]:    location: -0.25  0.75  1.75
-   is located on boundary: 0
    idx:     (3,5,7)
+
 With weight: 4
 pt[5]:    location: -0.25  0.25  2.25
-   is located on boundary: 0
    idx:     (3,4,8)
+
 With weight: 2.66667
 pt[6]:    location: -0.75  0.75  1.75
-   is located on boundary: 0
    idx:     (2,5,7)
+
 With weight: -5.76172e-16
 
 On point:    location: 0.25 0.25 1.75
-   is located on boundary: 0
    idx:     (4,4,7)
+
 pt[0]:    location: 0.25 0.25 1.75
-   is located on boundary: 0
    idx:     (4,4,7)
+
 With weight: -18.6667
 pt[1]:    location:  0.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (4,3,7)
+
 With weight: 4
 pt[2]:    location: -0.25  0.25  1.75
-   is located on boundary: 0
    idx:     (3,4,7)
+
 With weight: 4
 pt[3]:    location: 0.75 0.25 1.75
-   is located on boundary: 0
    idx:     (5,4,7)
+
 With weight: 4
 pt[4]:    location: 0.25 0.75 1.75
-   is located on boundary: 0
    idx:     (4,5,7)
+
 With weight: 4
 pt[5]:    location: 0.25 0.25 2.25
-   is located on boundary: 0
    idx:     (4,4,8)
+
 With weight: 2.66667
 pt[6]:    location: 0.75 0.75 1.75
-   is located on boundary: 0
    idx:     (5,5,7)
+
 With weight: -0
 
 On point:    location: 0.75 0.25 1.75
-   is located on boundary: 0
    idx:     (5,4,7)
+
 pt[0]:    location: 0.75 0.25 1.75
-   is located on boundary: 0
    idx:     (5,4,7)
+
 With weight: -19.2941
 pt[1]:    location:  0.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (5,3,7)
+
 With weight: 4
 pt[2]:    location: 0.25 0.25 1.75
-   is located on boundary: 0
    idx:     (4,4,7)
+
 With weight: 4
 pt[3]:    location: 1.25 0.25 1.75
-   is located on boundary: 0
    idx:     (6,4,7)
+
 With weight: 2.11765
 pt[4]:    location: 0.75 0.75 1.75
-   is located on boundary: 0
    idx:     (5,5,7)
+
 With weight: 4
 pt[5]:    location: 0.75 0.25 2.25
-   is located on boundary: 0
    idx:     (5,4,8)
+
 With weight: 3.29412
 pt[6]:    location: 1.25 0.25 1.25
-   is located on boundary: 0
    idx:     (6,4,6)
+
 With weight: 1.88235
 
 On point:    location: 1.25 0.25 1.75
-   is located on boundary: 0
    idx:     (6,4,7)
+
 pt[0]:    location: 1.25 0.25 1.75
-   is located on boundary: 0
    idx:     (6,4,7)
+
 With weight: -24
 pt[1]:    location: 1.25 0.25 1.25
-   is located on boundary: 0
    idx:     (6,4,6)
+
 With weight: 4
 pt[2]:    location:  1.25 -0.25  1.75
-   is located on boundary: 0
    idx:     (6,3,7)
+
 With weight: 4
 pt[3]:    location: 0.75 0.25 1.75
-   is located on boundary: 0
    idx:     (5,4,7)
+
 With weight: 4
 pt[4]:    location: 1.75 0.25 1.75
-   is located on boundary: 0
    idx:     (7,4,7)
+
 With weight: 4
 pt[5]:    location: 1.25 0.75 1.75
-   is located on boundary: 0
    idx:     (6,5,7)
+
 With weight: 4
 pt[6]:    location: 1.25 0.25 2.25
-   is located on boundary: 0
    idx:     (6,4,8)
+
 With weight: 4
 
 On point:    location: 1.75 0.25 1.75
-   is located on boundary: 0
    idx:     (7,4,7)
+
 pt[0]:    location: 1.75 0.25 1.75
-   is located on boundary: 0
    idx:     (7,4,7)
+
 With weight: -24
 pt[1]:    location: 1.75 0.25 1.25
-   is located on boundary: 0
    idx:     (7,4,6)
+
 With weight: 4
 pt[2]:    location:  1.75 -0.25  1.75
-   is located on boundary: 0
    idx:     (7,3,7)
+
 With weight: 4
 pt[3]:    location: 1.25 0.25 1.75
-   is located on boundary: 0
    idx:     (6,4,7)
+
 With weight: 4
 pt[4]:    location: 2.25 0.25 1.75
-   is located on boundary: 0
    idx:     (8,4,7)
+
 With weight: 4
 pt[5]:    location: 1.75 0.75 1.75
-   is located on boundary: 0
    idx:     (7,5,7)
+
 With weight: 4
 pt[6]:    location: 1.75 0.25 2.25
-   is located on boundary: 0
    idx:     (7,4,8)
+
 With weight: 4
 
 On point:    location: -1.75  0.75  1.75
-   is located on boundary: 0
    idx:     (0,5,7)
+
 pt[0]:    location: -1.75  0.75  1.75
-   is located on boundary: 0
    idx:     (0,5,7)
+
 With weight: -24
 pt[1]:    location: -1.75  0.75  1.25
-   is located on boundary: 0
    idx:     (0,5,6)
+
 With weight: 4
 pt[2]:    location: -1.75  0.25  1.75
-   is located on boundary: 0
    idx:     (0,4,7)
+
 With weight: 4
 pt[3]:    location: -2.25  0.75  1.75
-   is located on boundary: 0
    idx:     (-1,5,7)
+
 With weight: 4
 pt[4]:    location: -1.25  0.75  1.75
-   is located on boundary: 0
    idx:     (1,5,7)
+
 With weight: 4
 pt[5]:    location: -1.75  1.25  1.75
-   is located on boundary: 0
    idx:     (0,6,7)
+
 With weight: 4
 pt[6]:    location: -1.75  0.75  2.25
-   is located on boundary: 0
    idx:     (0,5,8)
+
 With weight: 4
 
 On point:    location: -1.25  0.75  1.75
-   is located on boundary: 0
    idx:     (1,5,7)
+
 pt[0]:    location: -1.25  0.75  1.75
-   is located on boundary: 0
    idx:     (1,5,7)
+
 With weight: -24
 pt[1]:    location: -1.25  0.75  1.25
-   is located on boundary: 0
    idx:     (1,5,6)
+
 With weight: 4
 pt[2]:    location: -1.25  0.25  1.75
-   is located on boundary: 0
    idx:     (1,4,7)
+
 With weight: 4
 pt[3]:    location: -1.75  0.75  1.75
-   is located on boundary: 0
    idx:     (0,5,7)
+
 With weight: 4
 pt[4]:    location: -0.75  0.75  1.75
-   is located on boundary: 0
    idx:     (2,5,7)
+
 With weight: 4
 pt[5]:    location: -1.25  1.25  1.75
-   is located on boundary: 0
    idx:     (1,6,7)
+
 With weight: 4
 pt[6]:    location: -1.25  0.75  2.25
-   is located on boundary: 0
    idx:     (1,5,8)
+
 With weight: 4
 
 On point:    location: -0.75  0.75  1.75
-   is located on boundary: 0
    idx:     (2,5,7)
+
 pt[0]:    location: -0.75  0.75  1.75
-   is located on boundary: 0
    idx:     (2,5,7)
+
 With weight: -19.2941
 pt[1]:    location: -0.75  0.25  1.75
-   is located on boundary: 0
    idx:     (2,4,7)
+
 With weight: 4
 pt[2]:    location: -1.25  0.75  1.75
-   is located on boundary: 0
    idx:     (1,5,7)
+
 With weight: 4
 pt[3]:    location: -0.25  0.75  1.75
-   is located on boundary: 0
    idx:     (3,5,7)
+
 With weight: 4
 pt[4]:    location: -0.75  1.25  1.75
-   is located on boundary: 0
    idx:     (2,6,7)
+
 With weight: 2.11765
 pt[5]:    location: -0.75  0.75  2.25
-   is located on boundary: 0
    idx:     (2,5,8)
+
 With weight: 3.29412
 pt[6]:    location: -0.75  1.25  1.25
-   is located on boundary: 0
    idx:     (2,6,6)
+
 With weight: 1.88235
 
 On point:    location: -0.25  0.75  1.75
-   is located on boundary: 0
    idx:     (3,5,7)
+
 pt[0]:    location: -0.25  0.75  1.75
-   is located on boundary: 0
    idx:     (3,5,7)
+
 With weight: -19.2941
 pt[1]:    location: -0.25  0.25  1.75
-   is located on boundary: 0
    idx:     (3,4,7)
+
 With weight: 4
 pt[2]:    location: -0.75  0.75  1.75
-   is located on boundary: 0
    idx:     (2,5,7)
+
 With weight: 4
 pt[3]:    location: 0.25 0.75 1.75
-   is located on boundary: 0
    idx:     (4,5,7)
+
 With weight: 4
 pt[4]:    location: -0.25  1.25  1.75
-   is located on boundary: 0
    idx:     (3,6,7)
+
 With weight: 2.11765
 pt[5]:    location: -0.25  0.75  2.25
-   is located on boundary: 0
    idx:     (3,5,8)
+
 With weight: 3.29412
 pt[6]:    location: -0.25  1.25  1.25
-   is located on boundary: 0
    idx:     (3,6,6)
+
 With weight: 1.88235
 
 On point:    location: 0.25 0.75 1.75
-   is located on boundary: 0
    idx:     (4,5,7)
+
 pt[0]:    location: 0.25 0.75 1.75
-   is located on boundary: 0
    idx:     (4,5,7)
+
 With weight: -19.2941
 pt[1]:    location: 0.25 0.25 1.75
-   is located on boundary: 0
    idx:     (4,4,7)
+
 With weight: 4
 pt[2]:    location: -0.25  0.75  1.75
-   is located on boundary: 0
    idx:     (3,5,7)
+
 With weight: 4
 pt[3]:    location: 0.75 0.75 1.75
-   is located on boundary: 0
    idx:     (5,5,7)
+
 With weight: 4
 pt[4]:    location: 0.25 1.25 1.75
-   is located on boundary: 0
    idx:     (4,6,7)
+
 With weight: 2.11765
 pt[5]:    location: 0.25 0.75 2.25
-   is located on boundary: 0
    idx:     (4,5,8)
+
 With weight: 3.29412
 pt[6]:    location: 0.25 1.25 1.25
-   is located on boundary: 0
    idx:     (4,6,6)
+
 With weight: 1.88235
 
 On point:    location: 0.75 0.75 1.75
-   is located on boundary: 0
    idx:     (5,5,7)
+
 pt[0]:    location: 0.75 0.75 1.75
-   is located on boundary: 0
    idx:     (5,5,7)
+
 With weight: -19.2941
 pt[1]:    location: 0.75 0.25 1.75
-   is located on boundary: 0
    idx:     (5,4,7)
+
 With weight: 4
 pt[2]:    location: 0.25 0.75 1.75
-   is located on boundary: 0
    idx:     (4,5,7)
+
 With weight: 4
 pt[3]:    location: 1.25 0.75 1.75
-   is located on boundary: 0
    idx:     (6,5,7)
+
 With weight: 4
 pt[4]:    location: 0.75 1.25 1.75
-   is located on boundary: 0
    idx:     (5,6,7)
+
 With weight: 2.11765
 pt[5]:    location: 0.75 0.75 2.25
-   is located on boundary: 0
    idx:     (5,5,8)
+
 With weight: 3.29412
 pt[6]:    location: 0.75 1.25 1.25
-   is located on boundary: 0
    idx:     (5,6,6)
+
 With weight: 1.88235
 
 On point:    location: 1.25 0.75 1.75
-   is located on boundary: 0
    idx:     (6,5,7)
+
 pt[0]:    location: 1.25 0.75 1.75
-   is located on boundary: 0
    idx:     (6,5,7)
+
 With weight: -24
 pt[1]:    location: 1.25 0.75 1.25
-   is located on boundary: 0
    idx:     (6,5,6)
+
 With weight: 4
 pt[2]:    location: 1.25 0.25 1.75
-   is located on boundary: 0
    idx:     (6,4,7)
+
 With weight: 4
 pt[3]:    location: 0.75 0.75 1.75
-   is located on boundary: 0
    idx:     (5,5,7)
+
 With weight: 4
 pt[4]:    location: 1.75 0.75 1.75
-   is located on boundary: 0
    idx:     (7,5,7)
+
 With weight: 4
 pt[5]:    location: 1.25 1.25 1.75
-   is located on boundary: 0
    idx:     (6,6,7)
+
 With weight: 4
 pt[6]:    location: 1.25 0.75 2.25
-   is located on boundary: 0
    idx:     (6,5,8)
+
 With weight: 4
 
 On point:    location: 1.75 0.75 1.75
-   is located on boundary: 0
    idx:     (7,5,7)
+
 pt[0]:    location: 1.75 0.75 1.75
-   is located on boundary: 0
    idx:     (7,5,7)
+
 With weight: -24
 pt[1]:    location: 1.75 0.75 1.25
-   is located on boundary: 0
    idx:     (7,5,6)
+
 With weight: 4
 pt[2]:    location: 1.75 0.25 1.75
-   is located on boundary: 0
    idx:     (7,4,7)
+
 With weight: 4
 pt[3]:    location: 1.25 0.75 1.75
-   is located on boundary: 0
    idx:     (6,5,7)
+
 With weight: 4
 pt[4]:    location: 2.25 0.75 1.75
-   is located on boundary: 0
    idx:     (8,5,7)
+
 With weight: 4
 pt[5]:    location: 1.75 1.25 1.75
-   is located on boundary: 0
    idx:     (7,6,7)
+
 With weight: 4
 pt[6]:    location: 1.75 0.75 2.25
-   is located on boundary: 0
    idx:     (7,5,8)
+
 With weight: 4
 
 On point:    location: -1.75  1.25  1.75
-   is located on boundary: 0
    idx:     (0,6,7)
+
 pt[0]:    location: -1.75  1.25  1.75
-   is located on boundary: 0
    idx:     (0,6,7)
+
 With weight: -24
 pt[1]:    location: -1.75  1.25  1.25
-   is located on boundary: 0
    idx:     (0,6,6)
+
 With weight: 4
 pt[2]:    location: -1.75  0.75  1.75
-   is located on boundary: 0
    idx:     (0,5,7)
+
 With weight: 4
 pt[3]:    location: -2.25  1.25  1.75
-   is located on boundary: 0
    idx:     (-1,6,7)
+
 With weight: 4
 pt[4]:    location: -1.25  1.25  1.75
-   is located on boundary: 0
    idx:     (1,6,7)
+
 With weight: 4
 pt[5]:    location: -1.75  1.75  1.75
-   is located on boundary: 0
    idx:     (0,7,7)
+
 With weight: 4
 pt[6]:    location: -1.75  1.25  2.25
-   is located on boundary: 0
    idx:     (0,6,8)
+
 With weight: 4
 
 On point:    location: -1.25  1.25  1.75
-   is located on boundary: 0
    idx:     (1,6,7)
+
 pt[0]:    location: -1.25  1.25  1.75
-   is located on boundary: 0
    idx:     (1,6,7)
+
 With weight: -24
 pt[1]:    location: -1.25  1.25  1.25
-   is located on boundary: 0
    idx:     (1,6,6)
+
 With weight: 4
 pt[2]:    location: -1.25  0.75  1.75
-   is located on boundary: 0
    idx:     (1,5,7)
+
 With weight: 4
 pt[3]:    location: -1.75  1.25  1.75
-   is located on boundary: 0
    idx:     (0,6,7)
+
 With weight: 4
 pt[4]:    location: -0.75  1.25  1.75
-   is located on boundary: 0
    idx:     (2,6,7)
+
 With weight: 4
 pt[5]:    location: -1.25  1.75  1.75
-   is located on boundary: 0
    idx:     (1,7,7)
+
 With weight: 4
 pt[6]:    location: -1.25  1.25  2.25
-   is located on boundary: 0
    idx:     (1,6,8)
+
 With weight: 4
 
 On point:    location: -0.75  1.25  1.75
-   is located on boundary: 0
    idx:     (2,6,7)
+
 pt[0]:    location: -0.75  1.25  1.75
-   is located on boundary: 0
    idx:     (2,6,7)
+
 With weight: -24
 pt[1]:    location: -0.75  1.25  1.25
-   is located on boundary: 0
    idx:     (2,6,6)
+
 With weight: 4
 pt[2]:    location: -0.75  0.75  1.75
-   is located on boundary: 0
    idx:     (2,5,7)
+
 With weight: 4
 pt[3]:    location: -1.25  1.25  1.75
-   is located on boundary: 0
    idx:     (1,6,7)
+
 With weight: 4
 pt[4]:    location: -0.25  1.25  1.75
-   is located on boundary: 0
    idx:     (3,6,7)
+
 With weight: 4
 pt[5]:    location: -0.75  1.75  1.75
-   is located on boundary: 0
    idx:     (2,7,7)
+
 With weight: 4
 pt[6]:    location: -0.75  1.25  2.25
-   is located on boundary: 0
    idx:     (2,6,8)
+
 With weight: 4
 
 On point:    location: -0.25  1.25  1.75
-   is located on boundary: 0
    idx:     (3,6,7)
+
 pt[0]:    location: -0.25  1.25  1.75
-   is located on boundary: 0
    idx:     (3,6,7)
+
 With weight: -24
 pt[1]:    location: -0.25  1.25  1.25
-   is located on boundary: 0
    idx:     (3,6,6)
+
 With weight: 4
 pt[2]:    location: -0.25  0.75  1.75
-   is located on boundary: 0
    idx:     (3,5,7)
+
 With weight: 4
 pt[3]:    location: -0.75  1.25  1.75
-   is located on boundary: 0
    idx:     (2,6,7)
+
 With weight: 4
 pt[4]:    location: 0.25 1.25 1.75
-   is located on boundary: 0
    idx:     (4,6,7)
+
 With weight: 4
 pt[5]:    location: -0.25  1.75  1.75
-   is located on boundary: 0
    idx:     (3,7,7)
+
 With weight: 4
 pt[6]:    location: -0.25  1.25  2.25
-   is located on boundary: 0
    idx:     (3,6,8)
+
 With weight: 4
 
 On point:    location: 0.25 1.25 1.75
-   is located on boundary: 0
    idx:     (4,6,7)
+
 pt[0]:    location: 0.25 1.25 1.75
-   is located on boundary: 0
    idx:     (4,6,7)
+
 With weight: -24
 pt[1]:    location: 0.25 1.25 1.25
-   is located on boundary: 0
    idx:     (4,6,6)
+
 With weight: 4
 pt[2]:    location: 0.25 0.75 1.75
-   is located on boundary: 0
    idx:     (4,5,7)
+
 With weight: 4
 pt[3]:    location: -0.25  1.25  1.75
-   is located on boundary: 0
    idx:     (3,6,7)
+
 With weight: 4
 pt[4]:    location: 0.75 1.25 1.75
-   is located on boundary: 0
    idx:     (5,6,7)
+
 With weight: 4
 pt[5]:    location: 0.25 1.75 1.75
-   is located on boundary: 0
    idx:     (4,7,7)
+
 With weight: 4
 pt[6]:    location: 0.25 1.25 2.25
-   is located on boundary: 0
    idx:     (4,6,8)
+
 With weight: 4
 
 On point:    location: 0.75 1.25 1.75
-   is located on boundary: 0
    idx:     (5,6,7)
+
 pt[0]:    location: 0.75 1.25 1.75
-   is located on boundary: 0
    idx:     (5,6,7)
+
 With weight: -24
 pt[1]:    location: 0.75 1.25 1.25
-   is located on boundary: 0
    idx:     (5,6,6)
+
 With weight: 4
 pt[2]:    location: 0.75 0.75 1.75
-   is located on boundary: 0
    idx:     (5,5,7)
+
 With weight: 4
 pt[3]:    location: 0.25 1.25 1.75
-   is located on boundary: 0
    idx:     (4,6,7)
+
 With weight: 4
 pt[4]:    location: 1.25 1.25 1.75
-   is located on boundary: 0
    idx:     (6,6,7)
+
 With weight: 4
 pt[5]:    location: 0.75 1.75 1.75
-   is located on boundary: 0
    idx:     (5,7,7)
+
 With weight: 4
 pt[6]:    location: 0.75 1.25 2.25
-   is located on boundary: 0
    idx:     (5,6,8)
+
 With weight: 4
 
 On point:    location: 1.25 1.25 1.75
-   is located on boundary: 0
    idx:     (6,6,7)
+
 pt[0]:    location: 1.25 1.25 1.75
-   is located on boundary: 0
    idx:     (6,6,7)
+
 With weight: -24
 pt[1]:    location: 1.25 1.25 1.25
-   is located on boundary: 0
    idx:     (6,6,6)
+
 With weight: 4
 pt[2]:    location: 1.25 0.75 1.75
-   is located on boundary: 0
    idx:     (6,5,7)
+
 With weight: 4
 pt[3]:    location: 0.75 1.25 1.75
-   is located on boundary: 0
    idx:     (5,6,7)
+
 With weight: 4
 pt[4]:    location: 1.75 1.25 1.75
-   is located on boundary: 0
    idx:     (7,6,7)
+
 With weight: 4
 pt[5]:    location: 1.25 1.75 1.75
-   is located on boundary: 0
    idx:     (6,7,7)
+
 With weight: 4
 pt[6]:    location: 1.25 1.25 2.25
-   is located on boundary: 0
    idx:     (6,6,8)
+
 With weight: 4
 
 On point:    location: 1.75 1.25 1.75
-   is located on boundary: 0
    idx:     (7,6,7)
+
 pt[0]:    location: 1.75 1.25 1.75
-   is located on boundary: 0
    idx:     (7,6,7)
+
 With weight: -24
 pt[1]:    location: 1.75 1.25 1.25
-   is located on boundary: 0
    idx:     (7,6,6)
+
 With weight: 4
 pt[2]:    location: 1.75 0.75 1.75
-   is located on boundary: 0
    idx:     (7,5,7)
+
 With weight: 4
 pt[3]:    location: 1.25 1.25 1.75
-   is located on boundary: 0
    idx:     (6,6,7)
+
 With weight: 4
 pt[4]:    location: 2.25 1.25 1.75
-   is located on boundary: 0
    idx:     (8,6,7)
+
 With weight: 4
 pt[5]:    location: 1.75 1.75 1.75
-   is located on boundary: 0
    idx:     (7,7,7)
+
 With weight: 4
 pt[6]:    location: 1.75 1.25 2.25
-   is located on boundary: 0
    idx:     (7,6,8)
+
 With weight: 4
 
 On point:    location: -1.75  1.75  1.75
-   is located on boundary: 0
    idx:     (0,7,7)
+
 pt[0]:    location: -1.75  1.75  1.75
-   is located on boundary: 0
    idx:     (0,7,7)
+
 With weight: -24
 pt[1]:    location: -1.75  1.75  1.25
-   is located on boundary: 0
    idx:     (0,7,6)
+
 With weight: 4
 pt[2]:    location: -1.75  1.25  1.75
-   is located on boundary: 0
    idx:     (0,6,7)
+
 With weight: 4
 pt[3]:    location: -2.25  1.75  1.75
-   is located on boundary: 0
    idx:     (-1,7,7)
+
 With weight: 4
 pt[4]:    location: -1.25  1.75  1.75
-   is located on boundary: 0
    idx:     (1,7,7)
+
 With weight: 4
 pt[5]:    location: -1.75  2.25  1.75
-   is located on boundary: 0
    idx:     (0,8,7)
+
 With weight: 4
 pt[6]:    location: -1.75  1.75  2.25
-   is located on boundary: 0
    idx:     (0,7,8)
+
 With weight: 4
 
 On point:    location: -1.25  1.75  1.75
-   is located on boundary: 0
    idx:     (1,7,7)
+
 pt[0]:    location: -1.25  1.75  1.75
-   is located on boundary: 0
    idx:     (1,7,7)
+
 With weight: -24
 pt[1]:    location: -1.25  1.75  1.25
-   is located on boundary: 0
    idx:     (1,7,6)
+
 With weight: 4
 pt[2]:    location: -1.25  1.25  1.75
-   is located on boundary: 0
    idx:     (1,6,7)
+
 With weight: 4
 pt[3]:    location: -1.75  1.75  1.75
-   is located on boundary: 0
    idx:     (0,7,7)
+
 With weight: 4
 pt[4]:    location: -0.75  1.75  1.75
-   is located on boundary: 0
    idx:     (2,7,7)
+
 With weight: 4
 pt[5]:    location: -1.25  2.25  1.75
-   is located on boundary: 0
    idx:     (1,8,7)
+
 With weight: 4
 pt[6]:    location: -1.25  1.75  2.25
-   is located on boundary: 0
    idx:     (1,7,8)
+
 With weight: 4
 
 On point:    location: -0.75  1.75  1.75
-   is located on boundary: 0
    idx:     (2,7,7)
+
 pt[0]:    location: -0.75  1.75  1.75
-   is located on boundary: 0
    idx:     (2,7,7)
+
 With weight: -24
 pt[1]:    location: -0.75  1.75  1.25
-   is located on boundary: 0
    idx:     (2,7,6)
+
 With weight: 4
 pt[2]:    location: -0.75  1.25  1.75
-   is located on boundary: 0
    idx:     (2,6,7)
+
 With weight: 4
 pt[3]:    location: -1.25  1.75  1.75
-   is located on boundary: 0
    idx:     (1,7,7)
+
 With weight: 4
 pt[4]:    location: -0.25  1.75  1.75
-   is located on boundary: 0
    idx:     (3,7,7)
+
 With weight: 4
 pt[5]:    location: -0.75  2.25  1.75
-   is located on boundary: 0
    idx:     (2,8,7)
+
 With weight: 4
 pt[6]:    location: -0.75  1.75  2.25
-   is located on boundary: 0
    idx:     (2,7,8)
+
 With weight: 4
 
 On point:    location: -0.25  1.75  1.75
-   is located on boundary: 0
    idx:     (3,7,7)
+
 pt[0]:    location: -0.25  1.75  1.75
-   is located on boundary: 0
    idx:     (3,7,7)
+
 With weight: -24
 pt[1]:    location: -0.25  1.75  1.25
-   is located on boundary: 0
    idx:     (3,7,6)
+
 With weight: 4
 pt[2]:    location: -0.25  1.25  1.75
-   is located on boundary: 0
    idx:     (3,6,7)
+
 With weight: 4
 pt[3]:    location: -0.75  1.75  1.75
-   is located on boundary: 0
    idx:     (2,7,7)
+
 With weight: 4
 pt[4]:    location: 0.25 1.75 1.75
-   is located on boundary: 0
    idx:     (4,7,7)
+
 With weight: 4
 pt[5]:    location: -0.25  2.25  1.75
-   is located on boundary: 0
    idx:     (3,8,7)
+
 With weight: 4
 pt[6]:    location: -0.25  1.75  2.25
-   is located on boundary: 0
    idx:     (3,7,8)
+
 With weight: 4
 
 On point:    location: 0.25 1.75 1.75
-   is located on boundary: 0
    idx:     (4,7,7)
+
 pt[0]:    location: 0.25 1.75 1.75
-   is located on boundary: 0
    idx:     (4,7,7)
+
 With weight: -24
 pt[1]:    location: 0.25 1.75 1.25
-   is located on boundary: 0
    idx:     (4,7,6)
+
 With weight: 4
 pt[2]:    location: 0.25 1.25 1.75
-   is located on boundary: 0
    idx:     (4,6,7)
+
 With weight: 4
 pt[3]:    location: -0.25  1.75  1.75
-   is located on boundary: 0
    idx:     (3,7,7)
+
 With weight: 4
 pt[4]:    location: 0.75 1.75 1.75
-   is located on boundary: 0
    idx:     (5,7,7)
+
 With weight: 4
 pt[5]:    location: 0.25 2.25 1.75
-   is located on boundary: 0
    idx:     (4,8,7)
+
 With weight: 4
 pt[6]:    location: 0.25 1.75 2.25
-   is located on boundary: 0
    idx:     (4,7,8)
+
 With weight: 4
 
 On point:    location: 0.75 1.75 1.75
-   is located on boundary: 0
    idx:     (5,7,7)
+
 pt[0]:    location: 0.75 1.75 1.75
-   is located on boundary: 0
    idx:     (5,7,7)
+
 With weight: -24
 pt[1]:    location: 0.75 1.75 1.25
-   is located on boundary: 0
    idx:     (5,7,6)
+
 With weight: 4
 pt[2]:    location: 0.75 1.25 1.75
-   is located on boundary: 0
    idx:     (5,6,7)
+
 With weight: 4
 pt[3]:    location: 0.25 1.75 1.75
-   is located on boundary: 0
    idx:     (4,7,7)
+
 With weight: 4
 pt[4]:    location: 1.25 1.75 1.75
-   is located on boundary: 0
    idx:     (6,7,7)
+
 With weight: 4
 pt[5]:    location: 0.75 2.25 1.75
-   is located on boundary: 0
    idx:     (5,8,7)
+
 With weight: 4
 pt[6]:    location: 0.75 1.75 2.25
-   is located on boundary: 0
    idx:     (5,7,8)
+
 With weight: 4
 
 On point:    location: 1.25 1.75 1.75
-   is located on boundary: 0
    idx:     (6,7,7)
+
 pt[0]:    location: 1.25 1.75 1.75
-   is located on boundary: 0
    idx:     (6,7,7)
+
 With weight: -24
 pt[1]:    location: 1.25 1.75 1.25
-   is located on boundary: 0
    idx:     (6,7,6)
+
 With weight: 4
 pt[2]:    location: 1.25 1.25 1.75
-   is located on boundary: 0
    idx:     (6,6,7)
+
 With weight: 4
 pt[3]:    location: 0.75 1.75 1.75
-   is located on boundary: 0
    idx:     (5,7,7)
+
 With weight: 4
 pt[4]:    location: 1.75 1.75 1.75
-   is located on boundary: 0
    idx:     (7,7,7)
+
 With weight: 4
 pt[5]:    location: 1.25 2.25 1.75
-   is located on boundary: 0
    idx:     (6,8,7)
+
 With weight: 4
 pt[6]:    location: 1.25 1.75 2.25
-   is located on boundary: 0
    idx:     (6,7,8)
+
 With weight: 4
 
 On point:    location: 1.75 1.75 1.75
-   is located on boundary: 0
    idx:     (7,7,7)
+
 pt[0]:    location: 1.75 1.75 1.75
-   is located on boundary: 0
    idx:     (7,7,7)
+
 With weight: -24
 pt[1]:    location: 1.75 1.75 1.25
-   is located on boundary: 0
    idx:     (7,7,6)
+
 With weight: 4
 pt[2]:    location: 1.75 1.25 1.75
-   is located on boundary: 0
    idx:     (7,6,7)
+
 With weight: 4
 pt[3]:    location: 1.25 1.75 1.75
-   is located on boundary: 0
    idx:     (6,7,7)
+
 With weight: 4
 pt[4]:    location: 2.25 1.75 1.75
-   is located on boundary: 0
    idx:     (8,7,7)
+
 With weight: 4
 pt[5]:    location: 1.75 2.25 1.75
-   is located on boundary: 0
    idx:     (7,8,7)
+
 With weight: 4
 pt[6]:    location: 1.75 1.75 2.25
-   is located on boundary: 0
    idx:     (7,7,8)
+
 With weight: 4
 


### PR DESCRIPTION
Add a class that knows about ghost points. Previously, we used a libMesh `Node` object. This adds a stand-alone `GhostPoint` class