### PR TITLE
Update FDWeightsCache to allow each cached point to have multiple weights.

### DIFF
--- a/include/ADS/FDWeightsCache.h
+++ b/include/ADS/FDWeightsCache.h
@@ -67,13 +67,13 @@ public:
     /*!
      * \brief Get the map between a point and it's list of FD weights.
      */
-    const std::map<FDPoint, std::vector<double>>&
+    const std::multimap<FDPoint, std::vector<double>>&
     getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch);
 
     /*!
      * \brief Get the map between a point and it's list of FD points.
      */
-    const std::map<FDPoint, std::vector<FDPoint>>&
+    const std::multimap<FDPoint, std::vector<FDPoint>>&
     getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch);
 
     /*!
@@ -83,15 +83,19 @@ public:
 
     /*!
      * \brief Get the vector of FD weights for a given patch and point pair.
+     *
+     * \note This function returns a copy of the weights.
      */
-    const std::vector<double>& getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
-                                               const FDPoint& pt);
+    std::vector<std::vector<double>> getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
+                                                     const FDPoint& pt);
 
     /*!
      * \brief Get the vector of FD points for a given patch and point pair.
+     *
+     * \note This function returns a copy of the points.
      */
-    const std::vector<FDPoint>& getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
-                                               const FDPoint& pt);
+    std::vector<std::vector<FDPoint>> getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
+                                                     const FDPoint& pt);
 
     /*!
      * \brief Determine if this patch and point pair has associated FD weights
@@ -104,6 +108,11 @@ public:
     virtual void clearCache();
 
     /*!
+     * \brief Eliminate a point and it's associated weights from the cache.
+     */
+    void clearPoint(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDPoint& pt);
+
+    /*!
      * Debugging function. Prints all the cached points and their associated FD points to the given output.
      */
     virtual void printPtMap(std::ostream& os, SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy);
@@ -113,8 +122,8 @@ protected:
 
     // Weight and point information
     using PtVecMap = std::map<SAMRAI::hier::Patch<NDIM>*, std::set<FDPoint>>;
-    using PtPairVecMap = std::map<SAMRAI::hier::Patch<NDIM>*, std::map<FDPoint, std::vector<FDPoint>>>;
-    using WeightVecMap = std::map<SAMRAI::hier::Patch<NDIM>*, std::map<FDPoint, std::vector<double>>>;
+    using PtPairVecMap = std::map<SAMRAI::hier::Patch<NDIM>*, std::multimap<FDPoint, std::vector<FDPoint>>>;
+    using WeightVecMap = std::map<SAMRAI::hier::Patch<NDIM>*, std::multimap<FDPoint, std::vector<double>>>;
     PtVecMap d_base_pt_set;
     PtPairVecMap d_pair_pt_map;
     WeightVecMap d_pt_weight_map;

--- a/include/ADS/RBFFDWeightsCache.h
+++ b/include/ADS/RBFFDWeightsCache.h
@@ -8,6 +8,7 @@
 #include <ibtk/config.h>
 
 #include "ADS/FEMeshPartitioner.h"
+#include <ADS/FDPoint.h>
 #include <ADS/FDWeightsCache.h>
 
 #include "ibtk/HierarchyGhostCellInterpolation.h"
@@ -67,10 +68,10 @@ public:
         d_ls_idx = ls_idx;
     }
 
-    void registerPolyFcn(
-        std::function<IBTK::MatrixXd(const std::vector<IBTK::VectorNd>&, int, double, const IBTK::VectorNd&)> poly_fcn,
-        std::function<double(double)> rbf_fcn,
-        std::function<double(double)> Lrbf_fcn)
+    void
+    registerPolyFcn(std::function<IBTK::MatrixXd(const std::vector<FDPoint>&, int, double, const FDPoint&)> poly_fcn,
+                    std::function<double(double)> rbf_fcn,
+                    std::function<double(double)> Lrbf_fcn)
     {
         d_poly_fcn = poly_fcn;
         d_rbf_fcn = rbf_fcn;
@@ -127,7 +128,7 @@ private:
     std::shared_ptr<FEMeshPartitioner> d_fe_mesh_partitioner;
     std::map<SAMRAI::hier::Patch<NDIM>*, std::vector<libMesh::Node*>> d_idx_node_vec, d_idx_node_ghost_vec;
 
-    std::function<IBTK::MatrixXd(const std::vector<IBTK::VectorNd>&, int, double, const IBTK::VectorNd&)> d_poly_fcn;
+    std::function<IBTK::MatrixXd(const std::vector<FDPoint>&, int, double, const FDPoint&)> d_poly_fcn;
     std::function<double(double)> d_rbf_fcn, d_Lrbf_fcn;
 
     bool d_weights_found = false;

--- a/include/ADS/RBFLaplaceOperator.h
+++ b/include/ADS/RBFLaplaceOperator.h
@@ -194,7 +194,7 @@ private:
     std::unique_ptr<RBFFDWeightsCache> d_fd_weights;
 
     std::function<double(double)> d_rbf, d_lap_rbf;
-    std::function<IBTK::MatrixXd(std::vector<IBTK::VectorNd>, int, double, const IBTK::VectorNd&)> d_polys;
+    std::function<IBTK::MatrixXd(std::vector<FDPoint>, int, double, const FDPoint&)> d_polys;
 };
 } // namespace ADS
 

--- a/include/ADS/private/PolynomialBasis_inc.h
+++ b/include/ADS/private/PolynomialBasis_inc.h
@@ -31,7 +31,7 @@ formMonomials(const std::vector<Point>& pts, int deg, double ds, const Point& sh
     for (size_t row = 0; row < pts.size(); ++row)
     {
         Point pt = pts[row];
-        pt = (pt - shft) / ds;
+        for (unsigned int d = 0; d < NDIM; ++d) pt(d) = (pt(d) - shft(d)) / ds;
         int col = 0;
 #if (NDIM == 2)
         for (int i = 0; i <= deg; ++i)
@@ -81,7 +81,7 @@ laplacianMonomials(const std::vector<Point>& pts, int deg, double ds, const Poin
     for (size_t row = 0; row < pts.size(); ++row)
     {
         Point pt = pts[row];
-        pt = (pt - shft) / ds;
+        for (unsigned int d = 0; d < NDIM; ++d) pt(d) = (pt(d) - shft(d)) / ds;
         int col = 0;
 #if (NDIM == 2)
         for (int i = 0; i <= deg; ++i)
@@ -139,7 +139,7 @@ dPdxMonomials(const std::vector<Point>& pts, int deg, double ds, const Point& sh
     for (size_t row = 0; row < pts.size(); ++row)
     {
         Point pt = pts[row];
-        pt = (pt - shft) / ds;
+        for (unsigned int d = 0; d < NDIM; ++d) pt(d) = (pt(d) - shft(d)) / ds;
         int col = 0;
 #if (NDIM == 2)
         for (int i = 0; i <= deg; ++i)
@@ -190,7 +190,7 @@ dPdyMonomials(const std::vector<Point>& pts, int deg, double ds, const Point& sh
     for (size_t row = 0; row < pts.size(); ++row)
     {
         Point pt = pts[row];
-        pt = (pt - shft) / ds;
+        for (unsigned int d = 0; d < NDIM; ++d) pt(d) = (pt(d) - shft(d)) / ds;
         int col = 0;
 #if (NDIM == 2)
         for (int i = 0; i <= deg; ++i)
@@ -243,7 +243,7 @@ dPdzMonomials(const std::vector<Point>& pts, int deg, double ds, const Point& sh
     for (size_t row = 0; row < pts.size(); ++row)
     {
         Point pt = pts[row];
-        pt = (pt - shft) / ds;
+        for (unsigned int d = 0; d < NDIM; ++d) pt(d) = (pt(d) - shft(d)) / ds;
         int col = 0;
         for (int i = 0; i <= deg; ++i)
         {

--- a/include/ADS/reconstructions.h
+++ b/include/ADS/reconstructions.h
@@ -136,35 +136,5 @@ double bilinearReconstruction(const IBTK::VectorNd& x_loc,
                               const SAMRAI::pdat::CellIndex<NDIM>& idx_ll,
                               const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
                               const double* const dx);
-
-template <class Point, class MultiArray>
-std::vector<IBTK::VectorNd>
-shift_and_scale_pts(const std::vector<Point>& pts, IBTK::VectorNd shift, const MultiArray scale)
-{
-    std::vector<IBTK::VectorNd> new_pts(pts.size());
-    for (size_t i = 0; i < pts.size(); ++i)
-    {
-        const Point& pt = pts[i];
-        IBTK::VectorNd new_vec;
-        for (unsigned int d = 0; d < NDIM; ++d) new_vec[d] = (pt(d) - shift(d)) / scale[d];
-        new_pts[i] = new_vec;
-    }
-    return new_pts;
-}
-
-template <class Point>
-std::vector<IBTK::VectorNd>
-shift_pts(const std::vector<Point>& pts, IBTK::VectorNd shift)
-{
-    std::vector<IBTK::VectorNd> new_pts(pts.size());
-    for (size_t i = 0; i < pts.size(); ++i)
-    {
-        const Point& pt = pts[i];
-        IBTK::VectorNd new_vec;
-        for (unsigned int d = 0; d < NDIM; ++d) new_vec[d] = pt(d) - shift(d);
-        new_pts[i] = new_vec;
-    }
-    return new_pts;
-}
 } // namespace Reconstruct
 #endif

--- a/src/RBFFDWeightsCache.cpp
+++ b/src/RBFFDWeightsCache.cpp
@@ -190,7 +190,8 @@ RBFFDWeightsCache::sortLagDOFsToCells()
                 std::vector<double> distance_vec;
                 FDPoint base_pt(patch, idx);
                 d_base_pt_set[patch.getPointer()].insert(base_pt);
-                d_pair_pt_map[patch.getPointer()][base_pt].reserve(d_stencil_size);
+                std::vector<FDPoint> fd_pts;
+                fd_pts.reserve(d_stencil_size);
 #if (1)
                 // Use KNN search.
                 tree.knnSearch(FDPoint(patch, idx), d_stencil_size, idx_vec, distance_vec);
@@ -202,8 +203,8 @@ RBFFDWeightsCache::sortLagDOFsToCells()
                 tree.cuboid_query(FDPoint(patch, idx), bbox, idx_vec, distance_vec);
 #endif
                 // Add these points to the vector
-                for (const auto& idx_in_pts : idx_vec)
-                    d_pair_pt_map[patch.getPointer()][base_pt].push_back(pts[idx_in_pts]);
+                for (const auto& idx_in_pts : idx_vec) fd_pts.push_back(pts[idx_in_pts]);
+                d_pair_pt_map[patch.getPointer()].insert(std::make_pair(base_pt, fd_pts));
             }
         }
         // Now do Lagrangian points
@@ -220,11 +221,12 @@ RBFFDWeightsCache::sortLagDOFsToCells()
             std::vector<double> distance_vec;
             FDPoint base_pt(node_pt, node);
             d_base_pt_set[patch.getPointer()].insert(base_pt);
-            d_pair_pt_map[patch.getPointer()][base_pt].reserve(d_stencil_size);
+            std::vector<FDPoint> fd_pts;
+            fd_pts.reserve(d_stencil_size);
             tree.knnSearch(FDPoint(node_pt, node), d_stencil_size, idx_vec, distance_vec);
             // Add these points to the vector
-            for (const auto& idx_in_pts : idx_vec)
-                d_pair_pt_map[patch.getPointer()][base_pt].push_back(pts[idx_in_pts]);
+            for (const auto& idx_in_pts : idx_vec) fd_pts.push_back(pts[idx_in_pts]);
+            d_pair_pt_map[patch.getPointer()].insert(std::make_pair(base_pt, fd_pts));
         }
     }
 }
@@ -248,43 +250,48 @@ RBFFDWeightsCache::findRBFFDWeights()
         // All data have been sorted. We need to loop through d_base_pt_vec.
         for (const auto& base_pt : d_base_pt_set[patch.getPointer()])
         {
-            const std::vector<FDPoint>& pt_vec = d_pair_pt_map[patch.getPointer()][base_pt];
-            const std::vector<VectorNd>& shft_vec = Reconstruct::shift_pts(pt_vec, IBTK::VectorNd::Zero());
-            d_pt_weight_map[patch.getPointer()][base_pt].reserve(pt_vec.size());
-            // Note if we use a KNN search, interp_size is fixed.
-            const int interp_size = pt_vec.size();
-#if !defined(NDEBUG)
-            TBOX_ASSERT(interp_size == d_stencil_size);
-#endif
-            MatrixXd A(MatrixXd::Zero(interp_size, interp_size));
-            MatrixXd B = PolynomialBasis::formMonomials(shft_vec, d_poly_degree, dx[0], base_pt.getVec());
-            const int poly_size = B.cols();
-            VectorXd U(VectorXd::Zero(interp_size + poly_size));
-            VectorNd pt0 = base_pt.getVec();
-            for (int i = 0; i < interp_size; ++i)
+            auto pt_iters = d_pair_pt_map[patch.getPointer()].equal_range(base_pt);
+            for (auto it = pt_iters.first; it != pt_iters.second; ++it)
             {
-                VectorNd pti = pt_vec[i].getVec();
-                for (int j = 0; j < interp_size; ++j)
+                const std::vector<FDPoint>& pt_vec = it->second;
+                std::vector<double> wgts;
+                wgts.reserve(pt_vec.size());
+                // Note if we use a KNN search, interp_size is fixed.
+                const int interp_size = pt_vec.size();
+#if !defined(NDEBUG)
+                TBOX_ASSERT(interp_size == d_stencil_size);
+#endif
+                MatrixXd A(MatrixXd::Zero(interp_size, interp_size));
+                MatrixXd B = PolynomialBasis::formMonomials(pt_vec, d_poly_degree, dx[0], base_pt);
+                const int poly_size = B.cols();
+                VectorXd U(VectorXd::Zero(interp_size + poly_size));
+                VectorNd pt0 = base_pt.getVec();
+                for (int i = 0; i < interp_size; ++i)
                 {
-                    VectorNd ptj = pt_vec[j].getVec();
-                    A(i, j) = d_rbf_fcn((pti - ptj).norm());
+                    VectorNd pti = pt_vec[i].getVec();
+                    for (int j = 0; j < interp_size; ++j)
+                    {
+                        VectorNd ptj = pt_vec[j].getVec();
+                        A(i, j) = d_rbf_fcn((pti - ptj).norm());
+                    }
+                    // Determine rhs
+                    U(i) = d_Lrbf_fcn((pt0 - pti).norm());
                 }
-                // Determine rhs
-                U(i) = d_Lrbf_fcn((pt0 - pti).norm());
-            }
-            // Add quadratic polynomials
-            std::vector<VectorNd> zeros = { base_pt.getVec() };
-            MatrixXd Ulow = d_poly_fcn(zeros, d_poly_degree, dx[0], base_pt.getVec());
-            U.block(interp_size, 0, Ulow.cols(), 1) = Ulow.transpose();
-            MatrixXd final_mat(MatrixXd::Zero(interp_size + poly_size, interp_size + poly_size));
-            final_mat.block(0, 0, interp_size, interp_size) = A;
-            final_mat.block(0, interp_size, interp_size, poly_size) = B;
-            final_mat.block(interp_size, 0, poly_size, interp_size) = B.transpose();
+                // Add quadratic polynomials
+                std::vector<FDPoint> zeros = { base_pt };
+                MatrixXd Ulow = d_poly_fcn(zeros, d_poly_degree, dx[0], base_pt);
+                U.block(interp_size, 0, Ulow.cols(), 1) = Ulow.transpose();
+                MatrixXd final_mat(MatrixXd::Zero(interp_size + poly_size, interp_size + poly_size));
+                final_mat.block(0, 0, interp_size, interp_size) = A;
+                final_mat.block(0, interp_size, interp_size, poly_size) = B;
+                final_mat.block(interp_size, 0, poly_size, interp_size) = B.transpose();
 
-            VectorXd x = final_mat.colPivHouseholderQr().solve(U);
-            // Now cache FD stencil
-            VectorXd weights = x.block(0, 0, interp_size, 1);
-            for (int i = 0; i < interp_size; ++i) d_pt_weight_map[patch.getPointer()][base_pt].push_back(weights(i));
+                VectorXd x = final_mat.colPivHouseholderQr().solve(U);
+                // Now cache FD stencil
+                VectorXd weights = x.block(0, 0, interp_size, 1);
+                for (int i = 0; i < interp_size; ++i) wgts.push_back(weights(i));
+                d_pt_weight_map[patch.getPointer()].insert(std::make_pair(base_pt, wgts));
+            }
         }
     }
 }


### PR DESCRIPTION
`FDWeightsCache` only allowed one set of finite difference weights at any given `FDPoint`. This is an issue if we want to store multiple conditions at a single point. This replaces the `std::map` in the cache with a `std::multimap`.

This isn't an optimal change. When retrieving weights from this cache, you now have to be concerned about multiple stencils at a single point. Moreover, there's no easy way to differentiate between which stencil you're getting.