### PR TITLE
Add a condition counter

### DIFF
--- a/include/ADS/ConditionCounter.h
+++ b/include/ADS/ConditionCounter.h
@@ -1,0 +1,99 @@
+/////////////////////////////// INCLUDE GUARD ////////////////////////////////
+
+#ifndef included_ADS_ConditionCounter
+#define included_ADS_ConditionCounter
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include <ibtk/config.h>
+
+#include <ADS/FDPoint.h>
+#include <ADS/FDWeightsCache.h>
+
+#include <mpi.h>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+namespace ADS
+{
+/*!
+ * ConditionCounter is a class that counts the number of conditions being applied to points. This is useful when we want
+ * to enforce multiple conditions at a single location (e.g boundary condition and PDE operator).
+ *
+ * This class maintains a map between finite difference points and their global condition number. Note that each point
+ * can contain multiple conditions.
+ */
+class ConditionCounter
+{
+public:
+    /*!
+     * \brief ConditionCounter constructor. Does nothing interesting. Leaves the object in an uninitialized state.
+     */
+    ConditionCounter(std::string object_name);
+
+    /*!
+     * \brief ConditionCounter constructor. Assigns conditions to each finite difference weight stored in the cache.
+     */
+    ConditionCounter(std::string object_name,
+                     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy,
+                     const FDWeightsCache& fd_cache);
+
+    /*!
+     * \brief Default destructor.
+     */
+    ~ConditionCounter() = default;
+
+    /*!
+     * \brief Get the number of conditions per processor.
+     */
+    const std::vector<unsigned int>& getNumConditionsPerProc()
+    {
+        return d_conditions_per_proc;
+    }
+
+    /*!
+     * \brief Get the map between FD points and the global condition index.
+     */
+    const std::multimap<FDPoint, unsigned int>& getFDConditionMapPatch(SAMRAI::hier::Patch<NDIM>* p)
+    {
+        return d_fd_condition_map.at(p);
+    }
+    const std::map<SAMRAI::hier::Patch<NDIM>*, std::multimap<FDPoint, unsigned int>>& getFDConditionMap()
+    {
+        return d_fd_condition_map;
+    }
+
+    /*!
+     * \brief Clear the condition counter
+     */
+    void clearConditions();
+
+    /*!
+     * \brief Add conditions based on those stored in the cache
+     */
+    void addCondition(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy,
+                      const FDWeightsCache& fd_cache);
+
+    /*!
+     * \brief Add a condition that depends on the point pt. Returns the index of the condition.
+     */
+    unsigned int addCondition(SAMRAI::hier::Patch<NDIM>*, FDPoint pt);
+
+    /*!
+     * \brief Update the global condition count. This assigns unique global conditions.
+     *
+     * \note This requires an all-to-all communication pattern so should only be done after all conditions are
+     * registered.
+     */
+    void updateGlobalConditionCount();
+
+private:
+    std::string d_object_name;
+
+    // Map between a finite difference point and it's global condition number.
+    std::map<SAMRAI::hier::Patch<NDIM>*, std::multimap<FDPoint, unsigned int>> d_fd_condition_map;
+    std::vector<unsigned int> d_conditions_per_proc;
+};
+} // namespace ADS
+
+#endif // included_ADS_ConditionCounter

--- a/include/ADS/ConditionCounter.h
+++ b/include/ADS/ConditionCounter.h
@@ -17,11 +17,13 @@
 namespace ADS
 {
 /*!
- * ConditionCounter is a class that counts the number of conditions being applied to points. This is useful when we want
- * to enforce multiple conditions at a single location (e.g boundary condition and PDE operator).
+ * ConditionCounter is a class that counts the number of conditions being applied to points. This is useful when we have
+ * an explicit matrix representation of the operator. This class can keep track of which row in the matrix corresponds
+ * to which FDPoint.
  *
- * This class maintains a map between finite difference points and their global condition number. Note that each point
- * can contain multiple conditions.
+ * This class maintains a map between finite difference points and their global condition number. Each point can only
+ * hold one condition. For problems that expressive multiple conditions at a single point, you should have multiple
+ * condition counters.
  */
 class ConditionCounter
 {
@@ -46,7 +48,7 @@ public:
     /*!
      * \brief Get the number of conditions per processor.
      */
-    const std::vector<unsigned int>& getNumConditionsPerProc()
+    const std::vector<unsigned int>& getNumConditionsPerProc() const
     {
         return d_conditions_per_proc;
     }
@@ -54,11 +56,11 @@ public:
     /*!
      * \brief Get the map between FD points and the global condition index.
      */
-    const std::multimap<FDPoint, unsigned int>& getFDConditionMapPatch(SAMRAI::hier::Patch<NDIM>* p)
+    const std::map<FDPoint, unsigned int>& getFDConditionMapPatch(SAMRAI::hier::Patch<NDIM>* p) const
     {
         return d_fd_condition_map.at(p);
     }
-    const std::map<SAMRAI::hier::Patch<NDIM>*, std::multimap<FDPoint, unsigned int>>& getFDConditionMap()
+    const std::map<SAMRAI::hier::Patch<NDIM>*, std::map<FDPoint, unsigned int>>& getFDConditionMap() const
     {
         return d_fd_condition_map;
     }
@@ -90,8 +92,8 @@ public:
 private:
     std::string d_object_name;
 
-    // Map between a finite difference point and it's global condition number.
-    std::map<SAMRAI::hier::Patch<NDIM>*, std::multimap<FDPoint, unsigned int>> d_fd_condition_map;
+    // Map between a finite difference point and it's local condition number.
+    std::map<SAMRAI::hier::Patch<NDIM>*, std::map<FDPoint, unsigned int>> d_fd_condition_map;
     std::vector<unsigned int> d_conditions_per_proc;
 };
 } // namespace ADS

--- a/include/ADS/FDWeightsCache.h
+++ b/include/ADS/FDWeightsCache.h
@@ -68,35 +68,35 @@ public:
      * \brief Get the map between a point and it's list of FD weights.
      */
     const std::map<FDPoint, std::vector<double>>&
-    getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch);
+    getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch) const;
 
     /*!
      * \brief Get the map between a point and it's list of FD points.
      */
     const std::map<FDPoint, std::vector<FDPoint>>&
-    getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch);
+    getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch) const;
 
     /*!
      * \brief Get the set of base points that have cached FD weights.
      */
-    const std::set<FDPoint>& getRBFFDBasePoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch);
+    const std::set<FDPoint>& getRBFFDBasePoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch) const;
 
     /*!
      * \brief Get the vector of FD weights for a given patch and point pair.
      */
     const std::vector<double>& getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
-                                               const FDPoint& pt);
+                                               const FDPoint& pt) const;
 
     /*!
      * \brief Get the vector of FD points for a given patch and point pair.
      */
     const std::vector<FDPoint>& getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
-                                               const FDPoint& pt);
+                                               const FDPoint& pt) const;
 
     /*!
      * \brief Determine if this patch and point pair has associated FD weights
      */
-    bool isBasePoint(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDPoint& pt);
+    bool isBasePoint(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDPoint& pt) const;
 
     /*!
      * \brief Clear the cache.
@@ -106,7 +106,8 @@ public:
     /*!
      * Debugging function. Prints all the cached points and their associated FD points to the given output.
      */
-    virtual void printPtMap(std::ostream& os, SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy);
+    virtual void printPtMap(std::ostream& os,
+                            SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy) const;
 
 protected:
     std::string d_object_name;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ SET(CXX_SRC
     VolumeBoundaryMeshMapping.cpp
     ZSplineReconstructions.cpp
 
+    solvers/ConditionCounter.cpp
     solvers/LSCutCellBoundaryConditions.cpp
     solvers/LSCutCellLaplaceOperator.cpp
     solvers/PETScAugmentedKrylovLinearSolver.cpp

--- a/src/FDWeightsCache.cpp
+++ b/src/FDWeightsCache.cpp
@@ -83,49 +83,49 @@ FDWeightsCache::cachePoint(Pointer<Patch<NDIM>> patch,
 }
 
 const std::map<FDPoint, std::vector<double>>&
-FDWeightsCache::getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch)
+FDWeightsCache::getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch) const
 {
-    return d_pt_weight_map[patch.getPointer()];
+    return d_pt_weight_map.at(patch.getPointer());
 }
 
 const std::map<FDPoint, std::vector<FDPoint>>&
-FDWeightsCache::getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch)
+FDWeightsCache::getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch) const
 {
-    return d_pair_pt_map[patch.getPointer()];
+    return d_pair_pt_map.at(patch.getPointer());
 }
 
 const std::set<FDPoint>&
-FDWeightsCache::getRBFFDBasePoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch)
+FDWeightsCache::getRBFFDBasePoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch) const
 {
-    return d_base_pt_set[patch.getPointer()];
+    return d_base_pt_set.at(patch.getPointer());
 }
 
 const std::vector<double>&
-FDWeightsCache::getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDPoint& pt)
+FDWeightsCache::getRBFFDWeights(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDPoint& pt) const
 {
 #if !defined(NDEBUG)
     if (!isBasePoint(patch, pt)) TBOX_ERROR("pt " << pt << " is not a base point on this patch");
 #endif
-    return d_pt_weight_map[patch.getPointer()][pt];
+    return d_pt_weight_map.at(patch.getPointer()).at(pt);
 }
 
 const std::vector<FDPoint>&
-FDWeightsCache::getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDPoint& pt)
+FDWeightsCache::getRBFFDPoints(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDPoint& pt) const
 {
 #if !defined(NDEBUG)
     if (!isBasePoint(patch, pt)) TBOX_ERROR("pt " << pt << " is not a base point on this patch");
 #endif
-    return d_pair_pt_map[patch.getPointer()][pt];
+    return d_pair_pt_map.at(patch.getPointer()).at(pt);
 }
 
 bool
-FDWeightsCache::isBasePoint(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDPoint& pt)
+FDWeightsCache::isBasePoint(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch, const FDPoint& pt) const
 {
-    return d_base_pt_set[patch.getPointer()].find(pt) != d_base_pt_set[patch.getPointer()].end();
+    return d_base_pt_set.at(patch.getPointer()).find(pt) != d_base_pt_set.at(patch.getPointer()).end();
 }
 
 void
-FDWeightsCache::printPtMap(std::ostream& os, Pointer<PatchHierarchy<NDIM>> hierarchy)
+FDWeightsCache::printPtMap(std::ostream& os, Pointer<PatchHierarchy<NDIM>> hierarchy) const
 {
     const int ln = hierarchy->getFinestLevelNumber();
     Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
@@ -134,10 +134,10 @@ FDWeightsCache::printPtMap(std::ostream& os, Pointer<PatchHierarchy<NDIM>> hiera
     {
         Pointer<Patch<NDIM>> patch = level->getPatch(p());
         os << "On patch number: " << patch_num << "\n";
-        os << "There are " << d_base_pt_set[patch.getPointer()].size() << " key-value pairs present\n";
-        for (const auto& pt : d_base_pt_set[patch.getPointer()])
+        os << "There are " << d_base_pt_set.at(patch.getPointer()).size() << " key-value pairs present\n";
+        for (const auto& pt : d_base_pt_set.at(patch.getPointer()))
         {
-            const std::vector<FDPoint>& pt_vec = d_pair_pt_map[patch.getPointer()][pt];
+            const std::vector<FDPoint>& pt_vec = d_pair_pt_map.at(patch.getPointer()).at(pt);
             os << "  Looking at point:\n" << pt << "\n";
             os << "  Has points: \n";
             for (const auto& pt_from_vec : pt_vec) os << pt_from_vec << "\n";

--- a/src/solvers/ConditionCounter.cpp
+++ b/src/solvers/ConditionCounter.cpp
@@ -1,0 +1,70 @@
+#include <ADS/ConditionCounter.h>
+#include <ADS/app_namespaces.h>
+
+#include <ibtk/IBTK_MPI.h>
+
+#include <RefineAlgorithm.h>
+
+namespace ADS
+{
+ConditionCounter::ConditionCounter(std::string object_name) : d_object_name(std::move(object_name))
+{
+    // intentionally blank
+}
+
+ConditionCounter::ConditionCounter(std::string object_name,
+                                   Pointer<PatchHierarchy<NDIM>> hierarchy,
+                                   const FDWeightsCache& fd_cache)
+    : d_object_name(std::move(object_name))
+{
+    addCondition(hierarchy, fd_cache);
+    updateGlobalConditionCount();
+}
+
+void
+ConditionCounter::clearConditions()
+{
+    d_fd_condition_map.clear();
+    d_conditions_per_proc.clear();
+}
+
+unsigned int
+ConditionCounter::addCondition(Patch<NDIM>* patch, FDPoint pt)
+{
+    int rank = IBTK_MPI::getRank();
+    d_fd_condition_map[patch].insert(std::make_pair(pt, d_conditions_per_proc[rank]));
+    return d_conditions_per_proc[rank]++;
+}
+
+void
+ConditionCounter::addCondition(Pointer<PatchHierarchy<NDIM>> hierarchy, const FDWeightsCache& fd_cache)
+{
+    for (int ln = 0; ln <= hierarchy->getPatchLevel(ln); ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+
+            const std::set<FDPoint>& fd_pts = fd_cache.getRBFFDBasePoints(patch);
+            for (const auto& fd_pt : fd_pts)
+            {
+                addCondition(patch.getPointer(), fd_pt);
+            }
+        }
+    }
+}
+
+void
+ConditionCounter::updateGlobalConditionCount()
+{
+    const int rank = IBTK_MPI::getRank();
+    const int nodes = IBTK_MPI::getNodes();
+    for (int i = 0; i < nodes; ++i)
+    {
+        if (i == rank) continue;
+        d_conditions_per_proc[i] = 0;
+    }
+    IBTK_MPI::sumReduction(d_conditions_per_proc.data(), nodes);
+}
+} // namespace ADS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ SETUP_2D(examples radial.cpp)
 
 SETUP_2D(find_vol find_vol.cpp)
 
+SETUP_2D(operators condition_counter.cpp)
 SETUP_2D(operators global_indexing.cpp)
 SETUP_2D(operators laplace.cpp)
 SETUP_2D(operators rbf_fd_weights.cpp)

--- a/tests/operators/condition_counter.cpp
+++ b/tests/operators/condition_counter.cpp
@@ -1,0 +1,326 @@
+#include <ibamr/config.h>
+
+#include <ADS/ConditionCounter.h>
+#include <ADS/CutCellVolumeMeshMapping.h>
+#include <ADS/GeneralBoundaryMeshMapping.h>
+#include <ADS/LSCartGridFunction.h>
+#include <ADS/LSCutCellLaplaceOperator.h>
+#include <ADS/LSFromLevelSet.h>
+#include <ADS/PolynomialBasis.h>
+#include <ADS/RBFFDWeightsCache.h>
+#include <ADS/RBFReconstructions.h>
+#include <ADS/app_namespaces.h>
+#include <ADS/ls_utilities.h>
+
+#include <ibtk/AppInitializer.h>
+#include <ibtk/CartGridFunctionSet.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/IBTK_MPI.h>
+#include <ibtk/PETScKrylovPoissonSolver.h>
+#include <ibtk/muParserCartGridFunction.h>
+#include <ibtk/muParserRobinBcCoefs.h>
+
+#include <tbox/Pointer.h>
+
+#include <libmesh/boundary_mesh.h>
+#include <libmesh/equation_systems.h>
+#include <libmesh/mesh.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/mesh_modification.h>
+#include <libmesh/numeric_vector.h>
+
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <LoadBalancer.h>
+#include <SAMRAI_config.h>
+#include <StandardTagAndInitialize.h>
+#include <Variable.h>
+
+class InsideLSFcn : public IBTK::CartGridFunction
+{
+public:
+    InsideLSFcn(string object_name, const double R) : CartGridFunction(std::move(object_name)), d_R(R)
+    {
+#if !defined(NDEBUG)
+        TBOX_ASSERT(!d_object_name.empty());
+#endif
+        return;
+    } // InsideLSFcn
+
+    bool isTimeDependent() const override
+    {
+        return true;
+    }
+
+    void setDataOnPatch(const int data_idx,
+                        Pointer<hier::Variable<NDIM>> var,
+                        Pointer<Patch<NDIM>> patch,
+                        const double data_time,
+                        const bool initial_time,
+                        Pointer<PatchLevel<NDIM>> /*level*/) override
+    {
+        Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
+        const double* const dx = pgeom->getDx();
+        const double* const xlow = pgeom->getXLower();
+        const hier::Index<NDIM>& idx_low = patch->getBox().lower();
+
+        Pointer<NodeData<NDIM, double>> ls_data = patch->getPatchData(data_idx);
+        for (NodeIterator<NDIM> ni(patch->getBox()); ni; ni++)
+        {
+            const NodeIndex<NDIM>& idx = ni();
+            VectorNd X;
+            for (int d = 0; d < NDIM; ++d) X[d] = xlow[d] + dx[d] * static_cast<double>(idx(d) - idx_low(d));
+
+            (*ls_data)(idx) = d_R - X.norm();
+        }
+    } // setDataOnPatch
+
+private:
+    double d_R = std::numeric_limits<double>::quiet_NaN();
+};
+
+enum LS_TYPE
+{
+    LEVEL_SET,
+    ENTIRE_DOMAIN,
+    DEFAULT = -1
+};
+
+std::string
+enum_to_string(LS_TYPE type)
+{
+    switch (type)
+    {
+    case LEVEL_SET:
+        return "LEVEL_SET";
+        break;
+    case ENTIRE_DOMAIN:
+        return "ENTIRE_DOMAIN";
+        break;
+    case DEFAULT:
+    default:
+        TBOX_ERROR("UNKNOWN ENUM\n");
+        break;
+    }
+    return "UNKNOWN_TYPE";
+}
+
+LS_TYPE
+string_to_enum(const std::string& type)
+{
+    if (strcasecmp(type.c_str(), "LEVEL_SET") == 0) return LEVEL_SET;
+    if (strcasecmp(type.c_str(), "ENTIRE_DOMAIN") == 0) return ENTIRE_DOMAIN;
+    return LS_TYPE::DEFAULT;
+}
+
+void fillLSEntireDomain(int ls_idx, Pointer<PatchHierarchy<NDIM>>);
+
+/*******************************************************************************
+ * For each run, the input filename and restart information (if needed) must   *
+ * be given on the command line.  For non-restarted case, command line is:     *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ * For restarted run, command line is:                                         *
+ *                                                                             *
+ *    executable <input file name> <restart directory> <restart number>        *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize PETSc, MPI, and SAMRAI.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+    LibMeshInit& init = ibtk_init.getLibMeshInit();
+
+    // Suppress a warning
+    SAMRAI::tbox::Logger::getInstance()->setWarning(false);
+
+    { // cleanup dynamically allocated objects prior to shutdown
+
+        // Parse command line options, set some standard options from the input
+        // file, initialize the restart database (if this is a restarted run),
+        // and enable file logging.
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "adv_diff.log");
+        Pointer<Database> input_db = app_initializer->getInputDatabase();
+        Pointer<Database> main_db = app_initializer->getComponentDatabase("Main");
+
+        // Get various standard options set in the input file.
+        const bool dump_postproc_data = app_initializer->dumpPostProcessingData();
+        const std::string postproc_data_dump_dirname = app_initializer->getPostProcessingDataDumpDirectory();
+        if (dump_postproc_data && !postproc_data_dump_dirname.empty())
+        {
+            Utilities::recursiveMkdir(postproc_data_dump_dirname);
+        }
+
+        // Create major algorithm and data objects that comprise the
+        // application.  These objects are configured from the input database
+        // and, if this is a restarted run, from the restart database.
+        Pointer<CartesianGridGeometry<NDIM>> grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<PatchHierarchy<NDIM>> patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<BergerRigoutsos<NDIM>> box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<StandardTagAndInitialize<NDIM>> error_detector = new StandardTagAndInitialize<NDIM>(
+            "StandardTagAndInitialize", NULL, app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<LoadBalancer<NDIM>> load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM>> gridding_algorithm =
+            new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                        app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                        error_detector,
+                                        box_generator,
+                                        load_balancer);
+
+        // Set up the finite element mesh
+        // Note we use this to create "augmented" dofs.
+        const double R = input_db->getDouble("RADIUS");
+        const double dx = input_db->getDouble("DX");
+        const double ds = input_db->getDouble("MFAC") * dx;
+        const std::string elem_type = input_db->getString("ELEM_TYPE");
+        Mesh mesh(init.comm(), NDIM);
+        const double num_circum_segments = 2.0 * M_PI * R / ds;
+        const int r = std::log2(0.25 * num_circum_segments);
+        MeshTools::Generation::build_sphere(mesh, R, r, Utility::string_to_enum<ElemType>(elem_type));
+        // Ensure the nodes on the surface are on the analytic boundary.
+        MeshBase::element_iterator el_end = mesh.elements_end();
+        for (MeshBase::element_iterator el = mesh.elements_begin(); el != el_end; ++el)
+        {
+            Elem* const elem = *el;
+            for (unsigned int side = 0; side < elem->n_sides(); ++side)
+            {
+                const bool at_mesh_bdry = !elem->neighbor_ptr(side);
+                if (!at_mesh_bdry) continue;
+                for (unsigned int k = 0; k < elem->n_nodes(); ++k)
+                {
+                    if (!elem->is_node_on_side(k, side)) continue;
+                    Node& n = elem->node_ref(k);
+                    n = R * n.unit();
+                }
+            }
+        }
+        MeshTools::Modification::translate(mesh, input_db->getDouble("XCOM"), input_db->getDouble("YCOM"));
+        mesh.prepare_for_use();
+        // Extract boundary mesh
+        BoundaryMesh bdry_mesh(mesh.comm(), mesh.mesh_dimension() - 1);
+        BoundaryInfo bdry_info = mesh.get_boundary_info();
+        bdry_info.sync(bdry_mesh);
+        bdry_mesh.prepare_for_use();
+
+        // Setup mesh mapping
+        auto mesh_mapping = std::make_shared<GeneralBoundaryMeshMapping>(
+            "MeshMapping", app_initializer->getComponentDatabase("MeshMapping"), &bdry_mesh);
+        mesh_mapping->initializeEquationSystems();
+
+        gridding_algorithm->makeCoarsestLevel(patch_hierarchy, 0.0);
+        int tag_buffer = 1;
+        int ln = 0;
+        bool done = false;
+        while (!done && (gridding_algorithm->levelCanBeRefined(ln)))
+        {
+            gridding_algorithm->makeFinerLevel(patch_hierarchy, 0.0, 0.0, tag_buffer);
+            done = !patch_hierarchy->finerLevelExists(ln);
+            ++ln;
+        }
+
+        const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+
+        Pointer<NodeVariable<NDIM, double>> ls_var = new NodeVariable<NDIM, double>("ls_var");
+        auto var_db = VariableDatabase<NDIM>::getDatabase();
+        Pointer<VariableContext> ctx = var_db->getContext("CTX");
+        const int ls_idx = var_db->registerVariableAndContext(ls_var, ctx, IntVector<NDIM>(4));
+
+        // Allocate data
+        for (int ln = 0; ln <= finest_ln; ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->allocatePatchData(ls_idx);
+        }
+
+        Pointer<InsideLSFcn> ls_fcn = new InsideLSFcn("LSFcn", input_db->getDouble("R"));
+
+        LS_TYPE ls_type = string_to_enum(input_db->getString("LS_TYPE"));
+
+        switch (ls_type)
+        {
+        case LS_TYPE::LEVEL_SET:
+            ls_fcn->setDataOnPatchHierarchy(ls_idx, ls_var, patch_hierarchy, 0.0);
+            break;
+        case LS_TYPE::ENTIRE_DOMAIN:
+            fillLSEntireDomain(ls_idx, patch_hierarchy);
+            break;
+        case LS_TYPE::DEFAULT:
+        default:
+            TBOX_ERROR("UNKNOWN TYPE");
+        }
+
+        // Set up reconstruction
+        Pointer<RBFFDWeightsCache> weights_op =
+            new RBFFDWeightsCache("RBFWeights",
+                                  mesh_mapping->getMeshPartitioner(),
+                                  patch_hierarchy,
+                                  app_initializer->getComponentDatabase("RBFWeights"));
+        auto poly_fcn =
+            [](const std::vector<VectorNd>& pt_vec, int poly_degree, double ds, const VectorNd& shft) -> MatrixXd {
+            return PolynomialBasis::laplacianMonomials(pt_vec, poly_degree, ds, shft);
+        };
+        auto rbf_fcn = [](const double r) -> double { return r * r * r * r * r; };
+#if (NDIM == 2)
+        auto Lrbf_fcn = [](const double r) -> double { return 25.0 * r * r * r * r; };
+#endif
+#if (NDIM == 3)
+        auto Lrbf_fcn = [](const double r) -> double { return 30.0 * r * r * r * r; };
+#endif
+        weights_op->registerPolyFcn(poly_fcn, rbf_fcn, Lrbf_fcn);
+        weights_op->setLS(ls_idx);
+        weights_op->findRBFFDWeights();
+
+        int rank = IBTK_MPI::getRank();
+        int nodes = IBTK_MPI::getNodes();
+        std::vector<unsigned int> num_conds(nodes, 0);
+        for (int ln = 0; ln <= finest_ln; ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+            {
+                Pointer<Patch<NDIM>> patch = level->getPatch(p());
+                const std::set<FDPoint>& base_pts = weights_op->getRBFFDBasePoints(patch);
+                num_conds[rank] += base_pts.size();
+            }
+        }
+        IBTK_MPI::sumReduction(num_conds.data(), nodes);
+
+        // Count conditions
+        ConditionCounter condition_counter("ConditionCounter", patch_hierarchy, *weights_op);
+        // Print out number of conditions
+        const std::vector<unsigned int>& conditions_per_proc = condition_counter.getNumConditionsPerProc();
+        for (unsigned int rank = 0; rank < conditions_per_proc.size(); ++rank)
+        {
+            pout << "On rank " << rank << "\n";
+            pout << "  There are " << conditions_per_proc[rank] << " conditions.\n";
+            pout << "  There are " << num_conds[rank] << " FDPoint base pts.\n";
+        }
+
+        // Deallocate data
+        for (int ln = 0; ln <= finest_ln; ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->deallocatePatchData(ls_idx);
+        }
+    } // cleanup dynamically allocated objects prior to shutdown
+} // main
+
+void
+fillLSEntireDomain(int ls_idx, Pointer<PatchHierarchy<NDIM>> hierarchy)
+{
+    for (int ln = 0; ln <= hierarchy->getFinestLevelNumber(); ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            Pointer<NodeData<NDIM, double>> ls_data = ls_idx == -1 ? nullptr : patch->getPatchData(ls_idx);
+
+            if (ls_data) ls_data->fillAll(-1.0);
+        }
+    }
+}

--- a/tests/operators/condition_counter_2d.mpirun=4.input
+++ b/tests/operators/condition_counter_2d.mpirun=4.input
@@ -1,0 +1,84 @@
+RADIUS = 1
+N = 16
+L = 4.0
+DX = L  / N
+MFAC = 1.0
+ELEM_TYPE = "TRI3"
+XCOM = 100.0
+YCOM = 100.0
+R = 1.0
+LS_TYPE = "LEVEL_SET"
+DT = 0.5 * 4.0 / 256
+
+RBFWeights {
+ dist_to_bdry = 100000000.0
+ eps = 1.0 * DX
+ polynomial_degree = 3
+ stencil_size = 5
+}
+
+MeshMapping {
+max_level = 1
+}
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+// visualization dump parameters
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+
+// timer dump parameters
+   timer_enabled = TRUE
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = -L/2, -L/2      // lower end of computational domain.
+   x_up               = L/2, L/2      // upper end of computational domain.
+   periodic_dimension = 1, 1
+}
+
+GriddingAlgorithm {
+   max_levels = 1                 // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {
+      level_1 = 4, 4              // vector ratio to next coarser level
+   }
+
+   largest_patch_size {
+      level_0 = 512, 512          // largest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4          // smallest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   efficiency_tolerance = 0.70e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller
+                                  // boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+      level_0 = [( N/4 , N/4 ),( N/2 - 1 , N/2 - 1 )] , [( N/2 , N/4 ),( 3*N/4 - 1 , N/2 - 1 )] , [( N/4 , N/2 ),( N/2 - 1 , 3*N/4 - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total = TRUE
+   print_threshold = 1.0
+   timer_list = "IBTK::*::*"
+}


### PR DESCRIPTION
This adds a condition counter class. This is a helper class that counts the number of conditions (or equations) we're specifying. This allows us to build rectangular matrices easier. This also means we no longer are restricted to specifying a single condition per `FDPoint`, which will be useful for enforcing boundary conditions.

It keeps track of the number of conditions (or equations) that each processor is in charge of enforcing. Note that this class has no knowledge of what those conditions are, or how they are being enforced. We should use something like the `FDWeightsCache` to keep track of stencils.