### PR TITLE
Fix advection terms.

### DIFF
--- a/include/ADS/LSAdvDiffIntegrator.h
+++ b/include/ADS/LSAdvDiffIntegrator.h
@@ -188,7 +188,6 @@ protected:
     std::map<SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>>,
              std::shared_ptr<AdvectiveReconstructionOperator>>
         d_Q_adv_reconstruct_map;
-    std::shared_ptr<AdvectiveReconstructionOperator> d_default_adv_reconstruct;
     AdvReconstructType d_default_adv_reconstruct_type = AdvReconstructType::RBF;
 
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_u_s_var;

--- a/src/LSAdvDiffIntegrator.cpp
+++ b/src/LSAdvDiffIntegrator.cpp
@@ -1677,20 +1677,20 @@ LSAdvDiffIntegrator::evaluateMappingOnHierarchy(const int xstar_idx,
 void
 LSAdvDiffIntegrator::setDefaultReconstructionOperator(Pointer<CellVariable<NDIM, double>> Q_var)
 {
-    if (!d_default_adv_reconstruct)
+    if (!d_Q_adv_reconstruct_map[Q_var])
     {
         switch (d_default_adv_reconstruct_type)
         {
         case AdvReconstructType::ZSPLINES:
-            d_default_adv_reconstruct =
+            d_Q_adv_reconstruct_map[Q_var] =
                 std::make_shared<ZSplineReconstructions>(Q_var->getName() + "::DefaultReconstruct", 2);
             break;
         case AdvReconstructType::RBF:
-            d_default_adv_reconstruct = std::make_shared<RBFReconstructions>(
+            d_Q_adv_reconstruct_map[Q_var] = std::make_shared<RBFReconstructions>(
                 Q_var->getName() + "::DefaultReconstruct", d_rbf_poly_order, d_rbf_stencil_size);
             break;
         case AdvReconstructType::LINEAR:
-            d_default_adv_reconstruct =
+            d_Q_adv_reconstruct_map[Q_var] =
                 std::make_shared<LinearReconstructions>(Q_var->getName() + "::DefaultReconstruct");
             break;
         default:
@@ -1698,6 +1698,5 @@ LSAdvDiffIntegrator::setDefaultReconstructionOperator(Pointer<CellVariable<NDIM,
             break;
         }
     }
-    d_Q_adv_reconstruct_map[Q_var] = d_default_adv_reconstruct;
 }
 } // namespace ADS


### PR DESCRIPTION
Revert part of #22. We need separate reconstruction operators to apply the correct boundary conditions.