### PR TITLE
Fix cases where the mesh is aligned with the grid

### DIFF
--- a/include/ADS/ls_utilities.h
+++ b/include/ADS/ls_utilities.h
@@ -69,6 +69,8 @@ public:
             d_elem->set_id(0);
             d_elem->set_node(n) = d_nodes[n].get();
         }
+	// TODO: This is potentially a problem if the parent element current configuration changes significantly from the reference configuration.
+	// We should pass in the current location to the constructor.
         for (size_t n = 0; n < d_parent_cur_pts.size(); ++n) d_parent_cur_pts[n] = d_parent_elem->point(n);
     }
 

--- a/src/LSFromMesh.cpp
+++ b/src/LSFromMesh.cpp
@@ -411,7 +411,7 @@ LSFromMesh::floodFillForLS(const int ln, const double eps)
         for (NodeIterator<NDIM> ni(box); ni; ni++)
         {
             const NodeIndex<NDIM>& idx = ni();
-            if ((*phi_data)(idx) < 0.0)
+            if ((*phi_data)(idx) <= 0.0)
             {
                 idx_queue.push(idx);
                 found_pt = true;
@@ -423,7 +423,7 @@ LSFromMesh::floodFillForLS(const int ln, const double eps)
         {
             const NodeIndex<NDIM>& idx = idx_queue.front();
             // If this point is uninitialized, it is interior
-            if (idx_touched(idx) == 0 && ((*phi_data)(idx) == eps || (*phi_data)(idx) < 0.0))
+            if (idx_touched(idx) == 0 && ((*phi_data)(idx) == eps || (*phi_data)(idx) <= 0.0))
             {
                 // Insert the point into touched list
                 idx_touched(idx) = 1;


### PR DESCRIPTION
When updating the level set away from the interface, we should check if the computed level set is exactly zero.