### PR TITLE
Fix velocity functions

### DIFF
--- a/include/ADS/ls_utilities.h
+++ b/include/ADS/ls_utilities.h
@@ -69,8 +69,8 @@ public:
             d_elem->set_id(0);
             d_elem->set_node(n) = d_nodes[n].get();
         }
-	// TODO: This is potentially a problem if the parent element current configuration changes significantly from the reference configuration.
-	// We should pass in the current location to the constructor.
+        // TODO: This is potentially a problem if the parent element current configuration changes significantly from
+        // the reference configuration. We should pass in the current location to the constructor.
         for (size_t n = 0; n < d_parent_cur_pts.size(); ++n) d_parent_cur_pts[n] = d_parent_elem->point(n);
     }
 

--- a/src/LSAdvDiffIntegrator.cpp
+++ b/src/LSAdvDiffIntegrator.cpp
@@ -750,6 +750,16 @@ LSAdvDiffIntegrator::integrateHierarchy(const double current_time, const double 
     }
     else if (cycle_num == 1)
     {
+        // We need to set velocity at final time...
+        for (const auto& u_var : d_u_var)
+        {
+            const int u_new_idx = var_db->mapVariableAndContextToIndex(u_var, getNewContext());
+            if (d_u_fcn.at(u_var))
+            {
+                d_u_fcn.at(u_var)->setDataOnPatchHierarchy(
+                    u_new_idx, u_var, d_hierarchy, new_time, false, 0, d_hierarchy->getFinestLevelNumber());
+            }
+        }
         // Update Level sets
         for (size_t l = 0; l < d_ls_vars.size(); ++l)
         {

--- a/src/SBAdvDiffIntegrator.cpp
+++ b/src/SBAdvDiffIntegrator.cpp
@@ -217,6 +217,16 @@ SBAdvDiffIntegrator::integrateHierarchy(const double current_time, const double 
     // integrateHierarchyCallback is called.
     if ((d_used_with_ib && cycle_num == 500) || (!d_used_with_ib && cycle_num == 1))
     {
+        // We need to set velocity at final time...
+        for (const auto& u_var : d_u_var)
+        {
+            const int u_new_idx = var_db->mapVariableAndContextToIndex(u_var, getNewContext());
+            if (d_u_fcn.at(u_var))
+            {
+                d_u_fcn.at(u_var)->setDataOnPatchHierarchy(
+                    u_new_idx, u_var, d_hierarchy, new_time, false, 0, d_hierarchy->getFinestLevelNumber());
+            }
+        }
         // Update Level sets
         for (size_t l = 0; l < d_ls_vars.size(); ++l)
         {


### PR DESCRIPTION
The velocity was filled before integrating the hierarchy. This can cause issues if (for example) we don't know the velocity at the end step before we integrate. This adds in a function call to fill the velocity before we integrate the advection equation.