### PR TITLE
Add initialization function to GeneralBoundaryMeshMapping.

### DIFF
--- a/include/ADS/GeneralBoundaryMeshMapping.h
+++ b/include/ADS/GeneralBoundaryMeshMapping.h
@@ -101,6 +101,24 @@ public:
     virtual void updateBoundaryLocation(double time, unsigned int part, bool end_of_timestep = false);
 
     /*!
+     * Set the initial location of the boundary mesh for all parts. By default, this loops through all parts and calls
+     * initializeBoundaryLocation(time, part).
+     *
+     * This is useful in cases where updateBoundaryLocation() requires information that is not initialized until after
+     * initializeFEData() is called.
+     */
+    virtual void initializeBoundaryLocation(double time);
+
+    /*!
+     * Set the initial location of the boundary mesh for the specified part. By default, this calls
+     * updateBoundaryLocation().
+     *
+     * This is useful in cases where updateBoundaryLocation() requires information that is not initialized until after
+     * initializeFEData() is called.
+     */
+    virtual void initializeBoundaryLocation(double time, unsigned int part);
+
+    /*!
      * \brief Create the EquationSystems object for the boundary mesh. If the boundary mesh is a nullptr, this routine
      * calls buildBoundaryMesh.
      */

--- a/include/ADS/LSAdvDiffIntegrator.h
+++ b/include/ADS/LSAdvDiffIntegrator.h
@@ -41,6 +41,12 @@ public:
                                      const bool Q_output = true) override;
 
     /*!
+     * Skip the diffusion solve for the specified variable. This means that all checks for diffusion operators and
+     * solvers will be skipped.
+     */
+    virtual void skipDiffusionSolve(SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> Q_var);
+
+    /*!
      * Register a GeneralBoundaryMeshMapping with the hierarchy integrator. This is important if the level set function
      * computes using the boundary mesh.
      */
@@ -225,6 +231,8 @@ protected:
 
     std::map<SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>>, SAMRAI::tbox::Pointer<ReconstructCache>>
         d_reconstruct_from_centroids_ls_map, d_reconstruct_to_centroids_ls_map;
+
+    std::map<SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>>, bool> d_Q_using_diffusion_solve;
 
 private:
     bool d_use_rbfs = false;

--- a/include/ADS/LSAdvDiffIntegrator.h
+++ b/include/ADS/LSAdvDiffIntegrator.h
@@ -40,6 +40,12 @@ public:
     void registerTransportedQuantity(SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> Q_var,
                                      const bool Q_output = true) override;
 
+    /*!
+     * Register a GeneralBoundaryMeshMapping with the hierarchy integrator. This is important if the level set function
+     * computes using the boundary mesh.
+     */
+    virtual void registerGeneralBoundaryMeshMapping(const std::shared_ptr<GeneralBoundaryMeshMapping>& mesh_mapping);
+
     virtual void registerLevelSetVariable(SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> ls_var);
 
     virtual void registerLevelSetVolFunction(SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> ls_var,
@@ -129,6 +135,7 @@ public:
 
 protected:
     void initializeCompositeHierarchyDataSpecialized(double current_time, bool initial_time) override;
+    void regridHierarchyEndSpecialized() override;
     void resetTimeDependentHierarchyDataSpecialized(double new_time) override;
     void
     resetHierarchyConfigurationSpecialized(SAMRAI::tbox::Pointer<SAMRAI::hier::BasePatchHierarchy<NDIM>> base_hierarchy,
@@ -183,6 +190,8 @@ protected:
     std::map<SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>>,
              SAMRAI::tbox::Pointer<IBAMR::LSInitStrategy>>
         d_ls_strategy_map;
+
+    std::shared_ptr<GeneralBoundaryMeshMapping> d_mesh_mapping;
 
     // Advection reconstruction information
     std::map<SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>>,

--- a/include/ADS/SBAdvDiffIntegrator.h
+++ b/include/ADS/SBAdvDiffIntegrator.h
@@ -45,8 +45,6 @@ public:
 
     static void callbackIntegrateHierarchy(double current_time, double neW_time, int cycle_num, void* ctx);
 
-    void registerGeneralBoundaryMeshMapping(const std::shared_ptr<GeneralBoundaryMeshMapping>& mesh_mapping);
-
     void registerLevelSetSBDataManager(SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> ls_var,
                                        std::shared_ptr<SBSurfaceFluidCouplingManager> sb_data_manager);
 
@@ -62,26 +60,18 @@ public:
     int getNumberOfCycles() const override;
 
     /*!
-     * Prepare to advance the data from current_time to new_time.
-     */
-    void preprocessIntegrateHierarchy(double current_time, double new_time, int num_cycles = 1) override;
-
-    /*!
      * Synchronously advance each level in the hierarchy over the given time
      * increment.
      */
     void integrateHierarchy(double current_time, double new_time, int cycle_num = 0) override;
 
 protected:
-    void initializeCompositeHierarchyDataSpecialized(double current_time, bool initial_time) override;
-    void regridHierarchyEndSpecialized() override;
 
     std::map<SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>>,
              std::shared_ptr<SBSurfaceFluidCouplingManager>>
         d_ls_sb_data_manager_map;
     std::map<SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>>, std::shared_ptr<CutCellMeshMapping>>
         d_ls_cut_cell_mapping_map;
-    std::shared_ptr<GeneralBoundaryMeshMapping> d_mesh_mapping;
     std::map<SAMRAI::tbox::Pointer<SBIntegrator>, SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>>>
         d_sb_integrator_ls_map;
 

--- a/src/GeneralBoundaryMeshMapping.cpp
+++ b/src/GeneralBoundaryMeshMapping.cpp
@@ -85,6 +85,20 @@ GeneralBoundaryMeshMapping::updateBoundaryLocation(const double time,
 }
 
 void
+GeneralBoundaryMeshMapping::initializeBoundaryLocation(const double time)
+{
+    for (unsigned int part = 0; part < d_bdry_meshes.size(); ++part) initializeBoundaryLocation(time, part);
+    return;
+}
+
+void
+GeneralBoundaryMeshMapping::initializeBoundaryLocation(const double time, unsigned int part)
+{
+    updateBoundaryLocation(time, part, /*end_of_timestep*/ false);
+    return;
+}
+
+void
 GeneralBoundaryMeshMapping::initializeEquationSystems()
 {
     const bool from_restart = RestartManager::getManager()->isFromRestart();
@@ -138,7 +152,7 @@ GeneralBoundaryMeshMapping::initializeFEData()
     {
         d_bdry_eq_sys_vec[part]->init();
     }
-    updateBoundaryLocation(0.0, false);
+    initializeBoundaryLocation(0.0);
 }
 
 void

--- a/src/SBAdvDiffIntegrator.cpp
+++ b/src/SBAdvDiffIntegrator.cpp
@@ -142,6 +142,14 @@ SBAdvDiffIntegrator::integrateHierarchy(const double current_time, const double 
             const int Q_cur_idx = var_db->mapVariableAndContextToIndex(Q_var, getCurrentContext());
             const int Q_scr_idx = var_db->mapVariableAndContextToIndex(Q_var, getScratchContext());
 
+            // Should we be skipping this solve?
+            if (!d_Q_using_diffusion_solve.at(Q_var))
+            {
+                const int Q_new_idx = var_db->mapVariableAndContextToIndex(Q_var, getNewContext());
+                d_hier_cc_data_ops->copyData(Q_new_idx, Q_cur_idx);
+                continue;
+            }
+
             const Pointer<NodeVariable<NDIM, double>>& ls_var = d_Q_ls_map[Q_var];
             const size_t l = distance(d_ls_vars.begin(), std::find(d_ls_vars.begin(), d_ls_vars.end(), ls_var));
             const Pointer<CellVariable<NDIM, double>>& vol_var = d_vol_vars[l];
@@ -366,6 +374,10 @@ SBAdvDiffIntegrator::integrateHierarchy(const double current_time, const double 
                 const int Q_cur_idx = var_db->mapVariableAndContextToIndex(Q_var, getCurrentContext());
                 const int Q_scr_idx = var_db->mapVariableAndContextToIndex(Q_var, getScratchContext());
                 const int Q_new_idx = var_db->mapVariableAndContextToIndex(Q_var, getNewContext());
+
+                // Should we be skipping this solve? Note we don't copy data here because Q_new already has the correct
+                // data.
+                if (!d_Q_using_diffusion_solve.at(Q_var)) continue;
 
                 const Pointer<NodeVariable<NDIM, double>>& ls_var = d_Q_ls_map[Q_var];
                 const size_t l = distance(d_ls_vars.begin(), std::find(d_ls_vars.begin(), d_ls_vars.end(), ls_var));

--- a/src/SBAdvDiffIntegrator.cpp
+++ b/src/SBAdvDiffIntegrator.cpp
@@ -66,12 +66,6 @@ SBAdvDiffIntegrator::SBAdvDiffIntegrator(const std::string& object_name,
 }
 
 void
-SBAdvDiffIntegrator::registerGeneralBoundaryMeshMapping(const std::shared_ptr<GeneralBoundaryMeshMapping>& mesh_mapping)
-{
-    d_mesh_mapping = mesh_mapping;
-}
-
-void
 SBAdvDiffIntegrator::registerLevelSetSBDataManager(Pointer<NodeVariable<NDIM, double>> ls_var,
                                                    std::shared_ptr<SBSurfaceFluidCouplingManager> sb_data_manager)
 {
@@ -99,28 +93,6 @@ int
 SBAdvDiffIntegrator::getNumberOfCycles() const
 {
     return 2;
-}
-
-void
-SBAdvDiffIntegrator::preprocessIntegrateHierarchy(const double current_time,
-                                                  const double new_time,
-                                                  const int num_cycles)
-{
-    ADS_TIMER_START(t_preprocess)
-    // TODO: This was placed here for restarts. We should only call reinitElementMappings() when required.
-    if (d_mesh_mapping)
-    {
-        plog << d_object_name + ": Initializing fe mesh mappings\n";
-        for (const auto& fe_mesh_mapping : d_mesh_mapping->getMeshPartitioners())
-        {
-            fe_mesh_mapping->setPatchHierarchy(d_hierarchy);
-            fe_mesh_mapping->reinitElementMappings();
-        }
-    }
-
-    if (d_mesh_mapping) d_mesh_mapping->updateBoundaryLocation(current_time, false);
-    LSAdvDiffIntegrator::preprocessIntegrateHierarchy(current_time, new_time, num_cycles);
-    ADS_TIMER_STOP(t_preprocess);
 }
 
 void
@@ -432,38 +404,6 @@ SBAdvDiffIntegrator::integrateHierarchy(const double current_time, const double 
     }
     executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     ADS_TIMER_STOP(t_integrate_hierarchy);
-}
-
-void
-SBAdvDiffIntegrator::initializeCompositeHierarchyDataSpecialized(const double current_time, const bool initial_time)
-{
-    plog << d_object_name + ": initializing composite Hierarchy data\n";
-    if (initial_time)
-    {
-        if (d_mesh_mapping)
-        {
-            plog << d_object_name + ": Initializing fe mesh mappings\n";
-            for (const auto& fe_mesh_mapping : d_mesh_mapping->getMeshPartitioners())
-            {
-                fe_mesh_mapping->setPatchHierarchy(d_hierarchy);
-                fe_mesh_mapping->reinitElementMappings();
-            }
-        }
-    }
-    LSAdvDiffIntegrator::initializeCompositeHierarchyDataSpecialized(current_time, initial_time);
-}
-
-void
-SBAdvDiffIntegrator::regridHierarchyEndSpecialized()
-{
-    if (d_mesh_mapping)
-    {
-        for (const auto& mesh_partitioner : d_mesh_mapping->getMeshPartitioners())
-        {
-            mesh_partitioner->reinitElementMappings();
-        }
-    }
-    LSAdvDiffIntegrator::regridHierarchyEndSpecialized();
 }
 
 } // namespace ADS

--- a/tests/examples/disk_2d.output
+++ b/tests/examples/disk_2d.output
@@ -6,7 +6,6 @@ SBAdvDiffIntegrator: initializing level data
 1Setting level set at initial time: 1
 SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Initializing fe mesh mappings
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: initializing level set for: LS_In
 Minimum volume on level:     0 is: 1.19775018947e-06
 Total area found on level:   0 is: 6.2780779643
@@ -341,7 +340,6 @@ Simulation time is 0
 SBAdvDiffIntegrator::advanceHierarchy(): time interval = [0,0.01171875], dt = 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): regridding prior to timestep 0
 SBAdvDiffIntegrator: initializing composite Hierarchy data
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Finished initializing composite data
 SBAdvDiffIntegrator: Initializing fe mesh mappings
 Minimum volume on level:     0 is: 1.19775018947e-06
@@ -396,7 +394,6 @@ At beginning of timestep # 1
 Simulation time is 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): time interval = [0.01171875,0.0234375], dt = 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): regridding prior to timestep 1
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Finished initializing composite data
 SBAdvDiffIntegrator: Initializing fe mesh mappings
@@ -453,7 +450,6 @@ Simulation time is 0.0234375
 SBAdvDiffIntegrator::advanceHierarchy(): time interval = [0.0234375,0.03515625], dt = 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): regridding prior to timestep 2
 SBAdvDiffIntegrator: initializing composite Hierarchy data
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Finished initializing composite data
 SBAdvDiffIntegrator: Initializing fe mesh mappings
 Minimum volume on level:     0 is: 1.19775018947e-06
@@ -508,7 +504,6 @@ At beginning of timestep # 3
 Simulation time is 0.03515625
 SBAdvDiffIntegrator::advanceHierarchy(): time interval = [0.03515625,0.046875], dt = 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): regridding prior to timestep 3
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Finished initializing composite data
 SBAdvDiffIntegrator: Initializing fe mesh mappings
@@ -565,7 +560,6 @@ Simulation time is 0.046875
 SBAdvDiffIntegrator::advanceHierarchy(): time interval = [0.046875,0.05859375], dt = 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): regridding prior to timestep 4
 SBAdvDiffIntegrator: initializing composite Hierarchy data
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Finished initializing composite data
 SBAdvDiffIntegrator: Initializing fe mesh mappings
 Minimum volume on level:     0 is: 1.19775018947e-06
@@ -620,7 +614,6 @@ At beginning of timestep # 5
 Simulation time is 0.05859375
 SBAdvDiffIntegrator::advanceHierarchy(): time interval = [0.05859375,0.0703125], dt = 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): regridding prior to timestep 5
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Finished initializing composite data
 SBAdvDiffIntegrator: Initializing fe mesh mappings
@@ -677,7 +670,6 @@ Simulation time is 0.0703125
 SBAdvDiffIntegrator::advanceHierarchy(): time interval = [0.0703125,0.08203125], dt = 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): regridding prior to timestep 6
 SBAdvDiffIntegrator: initializing composite Hierarchy data
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Finished initializing composite data
 SBAdvDiffIntegrator: Initializing fe mesh mappings
 Minimum volume on level:     0 is: 1.19775018947e-06
@@ -732,7 +724,6 @@ At beginning of timestep # 7
 Simulation time is 0.08203125
 SBAdvDiffIntegrator::advanceHierarchy(): time interval = [0.08203125,0.09375], dt = 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): regridding prior to timestep 7
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Finished initializing composite data
 SBAdvDiffIntegrator: Initializing fe mesh mappings
@@ -789,7 +780,6 @@ Simulation time is 0.09375
 SBAdvDiffIntegrator::advanceHierarchy(): time interval = [0.09375,0.10546875], dt = 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): regridding prior to timestep 8
 SBAdvDiffIntegrator: initializing composite Hierarchy data
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Finished initializing composite data
 SBAdvDiffIntegrator: Initializing fe mesh mappings
 Minimum volume on level:     0 is: 1.19775018947e-06
@@ -844,7 +834,6 @@ At beginning of timestep # 9
 Simulation time is 0.10546875
 SBAdvDiffIntegrator::advanceHierarchy(): time interval = [0.10546875,0.1171875], dt = 0.01171875
 SBAdvDiffIntegrator::advanceHierarchy(): regridding prior to timestep 9
-SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: initializing composite Hierarchy data
 SBAdvDiffIntegrator: Finished initializing composite data
 SBAdvDiffIntegrator: Initializing fe mesh mappings


### PR DESCRIPTION
In some scenarios, we need to initialize boundary meshes in different ways than by calling `updateBoundaryLocation()`. This adds a function to do that.