### PR TITLE
Add routines for cell centered level sets

### DIFF
--- a/include/ADS/LSFindCellVolume.h
+++ b/include/ADS/LSFindCellVolume.h
@@ -16,16 +16,16 @@ public:
 
     virtual ~LSFindCellVolume() = default;
 
-    virtual void updateVolumeAreaSideLS(int vol_idx,
-                                        SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> vol_var,
-                                        int area_idx,
-                                        SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> area_var,
-                                        int side_idx,
-                                        SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> side_var,
-                                        int phi_idx,
-                                        SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> phi_var,
-                                        double data_time,
-                                        bool extended_box = false) = 0;
+    void updateVolumeAreaSideLS(int vol_idx,
+                                SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> vol_var,
+                                int area_idx,
+                                SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> area_var,
+                                int side_idx,
+                                SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> side_var,
+                                int phi_idx,
+                                SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM>> phi_var,
+                                double data_time,
+                                bool extended_box = false);
 
     inline void setLS(bool set_ls)
     {
@@ -36,6 +36,18 @@ protected:
     std::string d_object_name;
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> d_hierarchy;
     bool d_set_ls = true;
+
+private:
+    virtual void doUpdateVolumeAreaSideLS(int vol_idx,
+                                          SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> vol_var,
+                                          int area_idx,
+                                          SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> area_var,
+                                          int side_idx,
+                                          SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> side_var,
+                                          int phi_idx,
+                                          SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM>> phi_var,
+                                          double data_time,
+                                          bool extended_box = false) = 0;
 };
 } // namespace ADS
 

--- a/include/ADS/LSFromLevelSet.h
+++ b/include/ADS/LSFromLevelSet.h
@@ -27,18 +27,18 @@ public:
 
     void registerLSFcn(SAMRAI::tbox::Pointer<IBTK::CartGridFunction> ls_fcn);
 
-    void updateVolumeAreaSideLS(int vol_idx,
-                                SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> vol_var,
-                                int area_idx,
-                                SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> area_var,
-                                int side_idx,
-                                SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> side_var,
-                                int phi_idx,
-                                SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> phi_var,
-                                double data_time,
-                                bool extended_box = false) override;
-
 private:
+    void doUpdateVolumeAreaSideLS(int vol_idx,
+                                  SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> vol_var,
+                                  int area_idx,
+                                  SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> area_var,
+                                  int side_idx,
+                                  SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> side_var,
+                                  int phi_idx,
+                                  SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM>> phi_var,
+                                  double data_time,
+                                  bool extended_box = false) override;
+
     SAMRAI::tbox::Pointer<IBTK::CartGridFunction> d_ls_fcn;
 };
 } // namespace ADS

--- a/include/ADS/LSFromMesh.h
+++ b/include/ADS/LSFromMesh.h
@@ -51,17 +51,6 @@ public:
 
     virtual ~LSFromMesh() = default;
 
-    void updateVolumeAreaSideLS(int vol_idx,
-                                SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> vol_var,
-                                int area_idx,
-                                SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> area_var,
-                                int side_idx,
-                                SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> side_var,
-                                int phi_idx,
-                                SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> phi_var,
-                                double data_time,
-                                bool extended_box = false) override;
-
     inline void registerNormalReverseDomainId(unsigned int bdry_id, unsigned int part = 0)
     {
         d_norm_reverse_domain_ids[part].insert(bdry_id);
@@ -95,13 +84,36 @@ public:
     }
 
 private:
-    void commonConstructor();
+    void doUpdateVolumeAreaSideLS(int vol_idx,
+                                  SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> vol_var,
+                                  int area_idx,
+                                  SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> area_var,
+                                  int side_idx,
+                                  SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> side_var,
+                                  int phi_idx,
+                                  SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM>> phi_var,
+                                  double data_time,
+                                  bool extended_box = false) override;
 
-    void updateLSAwayFromInterface(int phi_idx);
-    // This does a flood filling algorithm for d_sgn_idx.
-    // We assume that any value less than eps on the given level is correctly set.
-    // NOTE: eps must be positive.
-    void floodFillForLS(int ln, double eps);
+    void doUpdateVolumeAreaSideLSNode(int vol_idx,
+                                      SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> vol_var,
+                                      int area_idx,
+                                      SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> area_var,
+                                      int side_idx,
+                                      SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> side_var,
+                                      int phi_idx,
+                                      SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> phi_var,
+                                      double data_time,
+                                      bool extended_box = false);
+
+    void doUpdateLSCell(int phi_idx,
+                        SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> phi_var,
+                        double data_time,
+                        bool extended_box = false);
+
+    void updateLSAwayFromInterfaceNode(int phi_idx);
+
+    void updateLSAwayFromInterfaceCell(int phi_idx);
 
     bool d_use_inside = true;
 
@@ -112,8 +124,11 @@ private:
 
     BdryFcn d_bdry_fcn;
 
-    SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> d_sgn_var;
-    int d_sgn_idx = IBTK::invalid_index;
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> d_sgn_nc_var;
+    int d_sgn_nc_idx = IBTK::invalid_index;
+
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_sgn_cc_var;
+    int d_sgn_cc_idx = IBTK::invalid_index;
 };
 } // namespace ADS
 

--- a/include/ADS/RBFReconstructions.h
+++ b/include/ADS/RBFReconstructions.h
@@ -25,7 +25,10 @@ public:
     /*!
      * \brief Class constructor.
      */
-    RBFReconstructions(std::string object_name, Reconstruct::RBFPolyOrder rbf_poly_order, int stencil_size);
+    RBFReconstructions(std::string object_name,
+                       Reconstruct::RBFPolyOrder rbf_poly_order,
+                       int stencil_size,
+                       bool use_cut_cells = true);
 
     /*!
      * \brief Destructor.
@@ -59,9 +62,22 @@ public:
     void applyReconstruction(int Q_idx, int N_idx, int path_idx) override;
 
 private:
+    /*!
+     * \brief Compute the reconstruction using cut cells and cell centroids. This method assumes ghost cells are present
+     * and filled for Q_idx.
+     */
+    void applyReconstructionCutCell(int Q_idx, int N_idx, int path_idx);
+
+    /*!
+     * \brief Compute the reconstruction using only the level set to determine sides. This method assumes ghost cells
+     * are present and filled for Q_idx.
+     */
+    void applyReconstructionLS(int Q_idx, int N_idx, int path_idx);
+
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> d_hierarchy;
     Reconstruct::RBFPolyOrder d_rbf_order = Reconstruct::RBFPolyOrder::LINEAR;
     unsigned int d_rbf_stencil_size = 5;
+    bool d_use_cut_cells = true;
 
     // Scratch data
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_Q_scr_var;

--- a/include/ADS/ls_functions.h
+++ b/include/ADS/ls_functions.h
@@ -47,7 +47,7 @@ IBTK::VectorNd find_cell_centroid(const SAMRAI::pdat::CellIndex<NDIM>& idx,
                                   const SAMRAI::pdat::NodeData<NDIM, double>& ls_data);
 #endif
 
-double node_to_cell(const SAMRAI::pdat::CellIndex<NDIM>& idx, SAMRAI::pdat::NodeData<NDIM, double>& ls_data);
+double node_to_cell(const SAMRAI::pdat::CellIndex<NDIM>& idx, const SAMRAI::pdat::NodeData<NDIM, double>& ls_data);
 
 void copy_face_to_side(const int u_s_idx,
                        const int u_f_idx,

--- a/include/ADS/ls_functions.h
+++ b/include/ADS/ls_functions.h
@@ -91,6 +91,32 @@ double findVolume(const std::vector<Simplex>& simplices);
  * Find the surface area of a vector of simplices (tri in 2D, tet in 3D)
  */
 double findArea(const std::vector<Simplex>& simplices);
+
+/*!
+ * Use a flood filling algorithm to compute the correct sign for the node centered level set on the provided patch
+ * level. We assume that the sign of any values that are exactly equal to eps might need adjusting.
+ *
+ * This function requires that sgn_idx have at least one layer of ghost cells.
+ *
+ * Note: This function remains untested for levels that are not simply connected.
+ */
+void flood_fill_for_LS(int sgn_idx,
+                       SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> sgn_var,
+                       double eps,
+                       SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>> level);
+
+/*!
+ * Use a flood filling algorithm to compute the correct sign for the cell centered level set on the provided patch
+ * level. We assume that the sign of any values that are exactly equal to eps might need adjusting.
+ *
+ * This function requires that sgn_idx have at least one layer of ghost cells.
+ *
+ * Note: This function remains untested for levels that are not simply connected.
+ */
+void flood_fill_for_LS(int sgn_idx,
+                       SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> sgn_var,
+                       double eps,
+                       SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>> level);
 } // namespace ADS
 
 #include <ADS/private/ls_functions_inc.h>

--- a/include/ADS/private/ls_functions_inc.h
+++ b/include/ADS/private/ls_functions_inc.h
@@ -323,7 +323,7 @@ find_cell_centroid(const SAMRAI::pdat::CellIndex<NDIM>& idx, const SAMRAI::pdat:
 #endif
 
 inline double
-node_to_cell(const SAMRAI::pdat::CellIndex<NDIM>& idx, SAMRAI::pdat::NodeData<NDIM, double>& ls_data)
+node_to_cell(const SAMRAI::pdat::CellIndex<NDIM>& idx, const SAMRAI::pdat::NodeData<NDIM, double>& ls_data)
 {
 #if (NDIM == 2)
     SAMRAI::pdat::NodeIndex<NDIM> idx_ll(idx, SAMRAI::hier::IntVector<NDIM>(0, 0));

--- a/include/ADS/reconstructions.h
+++ b/include/ADS/reconstructions.h
@@ -102,18 +102,28 @@ enum_to_string<RBFPolyOrder>(RBFPolyOrder val)
     return "UNKNOWN_ORDER";
 }
 
+/*!
+ * \brief Polyharmonic rbf.
+ */
 static inline double
 rbf(double r)
 {
     return r;
 }
 
+/*!
+ * \brief MLS weight function: Gaussian-like kernel.
+ */
 static inline double
 mls_weight(double r)
 {
     return std::exp(-r * r);
 }
 
+/*!
+ * Reconstruct the data at position x_loc, using a stencil centered at idx. Only uses points that have a non-zero volume
+ * fraction in vol_data. The reconstruction uses a polyharmonic spline fit.
+ */
 double radialBasisFunctionReconstruction(IBTK::VectorNd x_loc,
                                          const SAMRAI::pdat::CellIndex<NDIM>& idx,
                                          const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
@@ -123,6 +133,10 @@ double radialBasisFunctionReconstruction(IBTK::VectorNd x_loc,
                                          const RBFPolyOrder order,
                                          const unsigned int stencil_size);
 
+/*!
+ * Reconstruct the data at position x_loc, using a stencil centered at idx. Only uses points that have a non-zero volume
+ * fraction in vol_data. The reconstruction uses a least squares polynomial fit.
+ */
 double leastSquaresReconstruction(IBTK::VectorNd x_loc,
                                   const SAMRAI::pdat::CellIndex<NDIM>& idx,
                                   const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
@@ -131,12 +145,32 @@ double leastSquaresReconstruction(IBTK::VectorNd x_loc,
                                   const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch,
                                   LeastSquaresOrder order);
 
+/*!
+ * Reconstruct data at position x_loc given the lower cell index idx_ll using bilinear interpolation.
+ */
 double bilinearReconstruction(const IBTK::VectorNd& x_loc,
                               const IBTK::VectorNd& x_ll,
                               const SAMRAI::pdat::CellIndex<NDIM>& idx_ll,
                               const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
                               const double* const dx);
 
+/*!
+ * Reconstruct the data at position x_loc, using a stencil centered at idx. Only uses points that share the same sign of
+ * the level set. The reconstruction uses a polyharmonic spline fit.
+ */
+double radialBasisFunctionReconstruction(IBTK::VectorNd x_loc,
+                                         double ls_val,
+                                         const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                                         const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
+                                         const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                                         const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch,
+                                         const RBFPolyOrder order,
+                                         const unsigned int stencil_size);
+
+/*!
+ * Compute finite-difference weights using the points in fd_pts evaluated at the point base_pt. The action of the
+ * operator needs to be supplied to both the radial basis function and the polynomials.
+ */
 template <class Point>
 void
 RBFFDReconstruct(std::vector<double>& wgts,

--- a/src/adv_ops/RBFReconstructions.cpp
+++ b/src/adv_ops/RBFReconstructions.cpp
@@ -12,11 +12,15 @@
 
 namespace ADS
 {
-RBFReconstructions::RBFReconstructions(std::string object_name, Reconstruct::RBFPolyOrder rbf_order, int stencil_size)
+RBFReconstructions::RBFReconstructions(std::string object_name,
+                                       Reconstruct::RBFPolyOrder rbf_order,
+                                       int stencil_size,
+                                       bool use_cut_cells)
     : AdvectiveReconstructionOperator(std::move(object_name)),
       d_rbf_order(rbf_order),
       d_rbf_stencil_size(stencil_size),
-      d_Q_scr_var(new CellVariable<NDIM, double>(d_object_name + "::Q_scratch"))
+      d_Q_scr_var(new CellVariable<NDIM, double>(d_object_name + "::Q_scratch")),
+      d_use_cut_cells(use_cut_cells)
 {
     auto var_db = VariableDatabase<NDIM>::getDatabase();
     d_Q_scr_idx = var_db->registerVariableAndContext(
@@ -35,11 +39,6 @@ RBFReconstructions::applyReconstruction(const int Q_idx, const int N_idx, const 
 {
     int coarsest_ln = 0;
     int finest_ln = d_hierarchy->getFinestLevelNumber();
-#ifndef NDEBUG
-    TBOX_ASSERT(d_cur_vol_idx > 0);
-    TBOX_ASSERT(d_new_vol_idx > 0);
-#endif
-
     // TODO: What kind of physical boundary conditions should we use for advection?
     using ITC = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
     std::vector<ITC> ghost_cell_comps(2);
@@ -50,41 +49,10 @@ RBFReconstructions::applyReconstruction(const int Q_idx, const int N_idx, const 
     hier_ghost_cells.initializeOperatorState(ghost_cell_comps, d_hierarchy, coarsest_ln, finest_ln);
     hier_ghost_cells.fillData(d_current_time);
 
-    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
-    {
-        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
-        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
-        {
-            Pointer<Patch<NDIM>> patch = level->getPatch(p());
-
-            const Box<NDIM>& box = patch->getBox();
-
-            Pointer<CellData<NDIM, double>> xstar_data = patch->getPatchData(path_idx);
-            Pointer<CellData<NDIM, double>> Q_cur_data = patch->getPatchData(d_Q_scr_idx);
-            Pointer<CellData<NDIM, double>> vol_cur_data = patch->getPatchData(d_cur_vol_idx);
-            Pointer<CellData<NDIM, double>> Q_new_data = patch->getPatchData(N_idx);
-            Pointer<CellData<NDIM, double>> vol_new_data = patch->getPatchData(d_new_vol_idx);
-            Pointer<NodeData<NDIM, double>> ls_data = patch->getPatchData(d_cur_ls_idx);
-
-            Q_new_data->fillAll(0.0);
-
-            for (CellIterator<NDIM> ci(box); ci; ci++)
-            {
-                const CellIndex<NDIM>& idx = ci();
-                if ((*vol_new_data)(idx) > 0.0)
-                {
-                    IBTK::VectorNd x_loc;
-                    for (int d = 0; d < NDIM; ++d) x_loc(d) = (*xstar_data)(idx, d);
-                    (*Q_new_data)(idx) = Reconstruct::radialBasisFunctionReconstruction(
-                        x_loc, idx, *Q_cur_data, *vol_cur_data, *ls_data, patch, d_rbf_order, d_rbf_stencil_size);
-                }
-                else
-                {
-                    (*Q_new_data)(idx) = 0.0;
-                }
-            }
-        }
-    }
+    if (d_use_cut_cells)
+        applyReconstructionCutCell(d_Q_scr_idx, N_idx, path_idx);
+    else
+        applyReconstructionLS(d_Q_scr_idx, N_idx, path_idx);
 }
 
 void
@@ -113,6 +81,106 @@ RBFReconstructions::deallocateOperatorState()
         if (level->checkAllocated(d_Q_scr_idx)) level->deallocatePatchData(d_Q_scr_idx);
     }
     d_is_allocated = false;
+}
+
+void
+RBFReconstructions::applyReconstructionCutCell(const int Q_idx, const int N_idx, const int path_idx)
+{
+    int coarsest_ln = 0;
+    int finest_ln = d_hierarchy->getFinestLevelNumber();
+#ifndef NDEBUG
+    TBOX_ASSERT(d_cur_vol_idx > 0);
+    TBOX_ASSERT(d_new_vol_idx > 0);
+#endif
+
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+
+            const Box<NDIM>& box = patch->getBox();
+
+            Pointer<CellData<NDIM, double>> xstar_data = patch->getPatchData(path_idx);
+            Pointer<CellData<NDIM, double>> Q_cur_data = patch->getPatchData(Q_idx);
+            Pointer<CellData<NDIM, double>> vol_cur_data = patch->getPatchData(d_cur_vol_idx);
+            Pointer<CellData<NDIM, double>> Q_new_data = patch->getPatchData(N_idx);
+            Pointer<CellData<NDIM, double>> vol_new_data = patch->getPatchData(d_new_vol_idx);
+            Pointer<NodeData<NDIM, double>> ls_data = patch->getPatchData(d_cur_ls_idx);
+
+            Q_new_data->fillAll(0.0);
+
+            for (CellIterator<NDIM> ci(box); ci; ci++)
+            {
+                const CellIndex<NDIM>& idx = ci();
+                if ((*vol_new_data)(idx) > 0.0)
+                {
+                    IBTK::VectorNd x_loc;
+                    for (int d = 0; d < NDIM; ++d) x_loc(d) = (*xstar_data)(idx, d);
+                    (*Q_new_data)(idx) = Reconstruct::radialBasisFunctionReconstruction(
+                        x_loc, idx, *Q_cur_data, *vol_cur_data, *ls_data, patch, d_rbf_order, d_rbf_stencil_size);
+                }
+                else
+                {
+                    (*Q_new_data)(idx) = 0.0;
+                }
+            }
+        }
+    }
+}
+
+void
+RBFReconstructions::applyReconstructionLS(const int Q_idx, const int N_idx, const int path_idx)
+{
+    int coarsest_ln = 0;
+    int finest_ln = d_hierarchy->getFinestLevelNumber();
+#ifndef NDEBUG
+    TBOX_ASSERT(d_cur_ls_idx > 0);
+    TBOX_ASSERT(d_new_ls_idx > 0);
+#endif
+
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+
+            const Box<NDIM>& box = patch->getBox();
+
+            Pointer<CellData<NDIM, double>> xstar_data = patch->getPatchData(path_idx);
+            Pointer<CellData<NDIM, double>> Q_cur_data = patch->getPatchData(Q_idx);
+            Pointer<CellData<NDIM, double>> Q_new_data = patch->getPatchData(N_idx);
+            Pointer<NodeData<NDIM, double>> ls_data = patch->getPatchData(d_cur_ls_idx);
+            Pointer<NodeData<NDIM, double>> ls_new_data = patch->getPatchData(d_new_ls_idx);
+
+            Q_new_data->fillAll(0.0);
+
+            for (CellIterator<NDIM> ci(box); ci; ci++)
+            {
+                const CellIndex<NDIM>& idx = ci();
+                if (ADS::node_to_cell(idx, *ls_data) < 0.0)
+                {
+                    IBTK::VectorNd x_loc;
+                    for (int d = 0; d < NDIM; ++d) x_loc(d) = (*xstar_data)(idx, d);
+                    (*Q_new_data)(idx) =
+                        Reconstruct::radialBasisFunctionReconstruction(x_loc,
+                                                                       ADS::node_to_cell(idx, *ls_data),
+                                                                       idx,
+                                                                       *Q_cur_data,
+                                                                       *ls_new_data,
+                                                                       patch,
+                                                                       d_rbf_order,
+                                                                       d_rbf_stencil_size);
+                }
+                else
+                {
+                    (*Q_new_data)(idx) = 0.0;
+                }
+            }
+        }
+    }
 }
 } // namespace ADS
 

--- a/src/adv_ops/RBFReconstructions.cpp
+++ b/src/adv_ops/RBFReconstructions.cpp
@@ -133,6 +133,7 @@ RBFReconstructions::applyReconstructionCutCell(const int Q_idx, const int N_idx,
 void
 RBFReconstructions::applyReconstructionLS(const int Q_idx, const int N_idx, const int path_idx)
 {
+    pout << "Reconstructing using level set only.\n";
     int coarsest_ln = 0;
     int finest_ln = d_hierarchy->getFinestLevelNumber();
 #ifndef NDEBUG
@@ -160,16 +161,16 @@ RBFReconstructions::applyReconstructionLS(const int Q_idx, const int N_idx, cons
             for (CellIterator<NDIM> ci(box); ci; ci++)
             {
                 const CellIndex<NDIM>& idx = ci();
-                if (ADS::node_to_cell(idx, *ls_data) < 0.0)
+                if (ADS::node_to_cell(idx, *ls_new_data) < 0.0)
                 {
                     IBTK::VectorNd x_loc;
                     for (int d = 0; d < NDIM; ++d) x_loc(d) = (*xstar_data)(idx, d);
                     (*Q_new_data)(idx) =
                         Reconstruct::radialBasisFunctionReconstruction(x_loc,
-                                                                       ADS::node_to_cell(idx, *ls_data),
+                                                                       ADS::node_to_cell(idx, *ls_new_data),
                                                                        idx,
                                                                        *Q_cur_data,
-                                                                       *ls_new_data,
+                                                                       *ls_data,
                                                                        patch,
                                                                        d_rbf_order,
                                                                        d_rbf_stencil_size);

--- a/src/adv_ops/RBFReconstructions.cpp
+++ b/src/adv_ops/RBFReconstructions.cpp
@@ -133,7 +133,6 @@ RBFReconstructions::applyReconstructionCutCell(const int Q_idx, const int N_idx,
 void
 RBFReconstructions::applyReconstructionLS(const int Q_idx, const int N_idx, const int path_idx)
 {
-    pout << "Reconstructing using level set only.\n";
     int coarsest_ln = 0;
     int finest_ln = d_hierarchy->getFinestLevelNumber();
 #ifndef NDEBUG

--- a/src/integrators/SLAdvIntegrator.cpp
+++ b/src/integrators/SLAdvIntegrator.cpp
@@ -790,8 +790,11 @@ SLAdvIntegrator::setDefaultReconstructionOperator(Pointer<CellVariable<NDIM, dou
                 std::make_shared<ZSplineReconstructions>(Q_var->getName() + "::DefaultReconstruct", 2);
             break;
         case AdvReconstructType::RBF:
-            d_Q_adv_reconstruct_map[Q_var] = std::make_shared<RBFReconstructions>(
-                Q_var->getName() + "::DefaultReconstruct", d_rbf_poly_order, d_rbf_stencil_size);
+            d_Q_adv_reconstruct_map[Q_var] =
+                std::make_shared<RBFReconstructions>(Q_var->getName() + "::DefaultReconstruct",
+                                                     d_rbf_poly_order,
+                                                     d_rbf_stencil_size,
+                                                     false /*use_cut_cells*/);
             break;
         case AdvReconstructType::LINEAR:
             d_Q_adv_reconstruct_map[Q_var] =

--- a/src/integrators/SLAdvIntegrator.cpp
+++ b/src/integrators/SLAdvIntegrator.cpp
@@ -428,57 +428,12 @@ SLAdvIntegrator::preprocessIntegrateHierarchy(const double current_time, const d
 void
 SLAdvIntegrator::integrateHierarchy(const double current_time, const double new_time, const int cycle_num)
 {
-    AdvDiffHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
+    if (cycle_num != 100) AdvDiffHierarchyIntegrator::integrateHierarchy(current_time, new_time, cycle_num);
     ADS_TIMER_START(t_integrate_hierarchy);
-    auto var_db = VariableDatabase<NDIM>::getDatabase();
 
-    // We only do something if this is the last cycle
-    if (cycle_num == getNumberOfCycles() - 1)
-    {
-        // We need to set velocity at final time...
-        for (const auto& u_var : d_u_var)
-        {
-            const int u_new_idx = var_db->mapVariableAndContextToIndex(u_var, getNewContext());
-            if (d_u_fcn.at(u_var))
-            {
-                d_u_fcn.at(u_var)->setDataOnPatchHierarchy(
-                    u_new_idx, u_var, d_hierarchy, new_time, false, 0, d_hierarchy->getFinestLevelNumber());
-            }
-        }
-        // Update Level sets
-        for (size_t l = 0; l < d_ls_vars.size(); ++l)
-        {
-            const Pointer<NodeVariable<NDIM, double>>& ls_var = d_ls_vars[l];
-            const Pointer<CellVariable<NDIM, double>>& vol_var = d_vol_vars[l];
-
-            const int ls_new_idx = var_db->mapVariableAndContextToIndex(ls_var, getNewContext());
-            const int vol_new_idx = var_db->mapVariableAndContextToIndex(vol_var, getNewContext());
-
-            const Pointer<LSFindCellVolume>& ls_fcn = d_ls_vol_fcn_map[ls_var];
-            // Update boundary mesh if necessary.
-            if (d_mesh_mapping) d_mesh_mapping->updateBoundaryLocation(new_time, true);
-            ls_fcn->updateVolumeAreaSideLS(vol_new_idx,
-                                           vol_var,
-                                           IBTK::invalid_index,
-                                           nullptr,
-                                           IBTK::invalid_index,
-                                           nullptr,
-                                           ls_new_idx,
-                                           ls_var,
-                                           new_time,
-                                           true);
-        }
-
-        // Now do advective update for each variable
-        for (const auto& Q_var : d_Q_var)
-        {
-            // Now update advection.
-            advectionUpdate(Q_var, current_time, new_time);
-
-            plog << d_object_name + "::integrateHierarchy() finished advection update for variable: "
-                 << Q_var->getName() << "\n";
-        }
-    }
+    // Intentionally blank. Semi-Lagrangian methods require everything at the END of the timestep.
+    // TODO: We need to be more careful about this. In particular, we should double check that "current" and "new" data
+    // is still present at the end of posprocessIntegrateHierarchy().
 
     executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     ADS_TIMER_STOP(t_integrate_hierarchy);
@@ -491,6 +446,51 @@ SLAdvIntegrator::postprocessIntegrateHierarchy(const double current_time,
                                                const int num_cycles)
 {
     ADS_TIMER_START(t_postprocess);
+    // We need to set velocity at final time...
+    auto var_db = VariableDatabase<NDIM>::getDatabase();
+    for (const auto& u_var : d_u_var)
+    {
+        const int u_new_idx = var_db->mapVariableAndContextToIndex(u_var, getNewContext());
+        if (d_u_fcn.at(u_var))
+        {
+            d_u_fcn.at(u_var)->setDataOnPatchHierarchy(
+                u_new_idx, u_var, d_hierarchy, new_time, false, 0, d_hierarchy->getFinestLevelNumber());
+        }
+    }
+    // Update Level sets
+    for (size_t l = 0; l < d_ls_vars.size(); ++l)
+    {
+        const Pointer<NodeVariable<NDIM, double>>& ls_var = d_ls_vars[l];
+        const Pointer<CellVariable<NDIM, double>>& vol_var = d_vol_vars[l];
+
+        const int ls_new_idx = var_db->mapVariableAndContextToIndex(ls_var, getNewContext());
+        const int vol_new_idx = var_db->mapVariableAndContextToIndex(vol_var, getNewContext());
+
+        const Pointer<LSFindCellVolume>& ls_fcn = d_ls_vol_fcn_map[ls_var];
+        // Update boundary mesh if necessary.
+        if (d_mesh_mapping) d_mesh_mapping->updateBoundaryLocation(new_time, true);
+        ls_fcn->updateVolumeAreaSideLS(vol_new_idx,
+                                       vol_var,
+                                       IBTK::invalid_index,
+                                       nullptr,
+                                       IBTK::invalid_index,
+                                       nullptr,
+                                       ls_new_idx,
+                                       ls_var,
+                                       new_time,
+                                       true);
+    }
+
+    // Now do advective update for each variable
+    for (const auto& Q_var : d_Q_var)
+    {
+        // Now update advection.
+        advectionUpdate(Q_var, current_time, new_time);
+
+        plog << d_object_name + "::integrateHierarchy() finished advection update for variable: " << Q_var->getName()
+             << "\n";
+    }
+
     for (int ln = 0; ln <= d_hierarchy->getFinestLevelNumber(); ++ln)
         d_hierarchy->getPatchLevel(ln)->deallocatePatchData(d_adv_data);
 

--- a/src/level_set/LSFindCellVolume.cpp
+++ b/src/level_set/LSFindCellVolume.cpp
@@ -11,4 +11,20 @@ LSFindCellVolume::LSFindCellVolume(std::string object_name, Pointer<PatchHierarc
     // intentionally blank
     return;
 } // Constructor
+
+void
+LSFindCellVolume::updateVolumeAreaSideLS(const int vol_idx,
+                                         Pointer<CellVariable<NDIM, double>> vol_var,
+                                         const int area_idx,
+                                         Pointer<CellVariable<NDIM, double>> area_var,
+                                         const int side_idx,
+                                         Pointer<SideVariable<NDIM, double>> side_var,
+                                         const int phi_idx,
+                                         Pointer<Variable<NDIM>> phi_var,
+                                         const double data_time,
+                                         const bool extended_box)
+{
+    doUpdateVolumeAreaSideLS(
+        vol_idx, vol_var, area_idx, area_var, side_idx, side_var, phi_idx, phi_var, data_time, extended_box);
+}
 } // namespace ADS

--- a/src/level_set/LSFromLevelSet.cpp
+++ b/src/level_set/LSFromLevelSet.cpp
@@ -24,16 +24,16 @@ LSFromLevelSet::registerLSFcn(Pointer<CartGridFunction> ls_fcn)
 }
 
 void
-LSFromLevelSet::updateVolumeAreaSideLS(int vol_idx,
-                                       Pointer<CellVariable<NDIM, double>> /*vol_var*/,
-                                       int area_idx,
-                                       Pointer<CellVariable<NDIM, double>> /*area_var*/,
-                                       int side_idx,
-                                       Pointer<SideVariable<NDIM, double>> /*side_var*/,
-                                       int phi_idx,
-                                       Pointer<NodeVariable<NDIM, double>> phi_var,
-                                       double data_time,
-                                       bool extended_box)
+LSFromLevelSet::doUpdateVolumeAreaSideLS(int vol_idx,
+                                         Pointer<CellVariable<NDIM, double>> /*vol_var*/,
+                                         int area_idx,
+                                         Pointer<CellVariable<NDIM, double>> /*area_var*/,
+                                         int side_idx,
+                                         Pointer<SideVariable<NDIM, double>> /*side_var*/,
+                                         int phi_idx,
+                                         Pointer<Variable<NDIM>> phi_var,
+                                         double data_time,
+                                         bool extended_box)
 {
     int coarsest_ln = 0, finest_ln = d_hierarchy->getFinestLevelNumber();
 
@@ -69,6 +69,13 @@ LSFromLevelSet::updateVolumeAreaSideLS(int vol_idx,
             if (vol_idx != IBTK::invalid_index) vol_data = patch->getPatchData(vol_idx);
             Pointer<SideData<NDIM, double>> side_data;
             if (side_idx != IBTK::invalid_index) side_data = patch->getPatchData(side_idx);
+
+            // Skip this code if we aren't computing area, volume, or cell side lengths
+            if (area_idx == IBTK::invalid_index && vol_idx == IBTK::invalid_index && side_idx == IBTK::invalid_index)
+                continue;
+
+            // This code only works if phi is node centered
+            TBOX_ASSERT(phi_data);
 
             const Box<NDIM>& box = extended_box ? phi_data->getGhostBox() : patch->getBox();
             const hier::Index<NDIM>& patch_lower = box.lower();

--- a/src/level_set/LSFromLevelSet.cpp
+++ b/src/level_set/LSFromLevelSet.cpp
@@ -74,7 +74,8 @@ LSFromLevelSet::doUpdateVolumeAreaSideLS(int vol_idx,
             if (area_idx == IBTK::invalid_index && vol_idx == IBTK::invalid_index && side_idx == IBTK::invalid_index)
                 continue;
 
-            // This code only works if phi is node centered
+            // This code only works if phi is node centered. Since we are evaluating a prescribed level set function, we
+            // should be able to create a scratch node centered level set for volume, area, and side computations.
             TBOX_ASSERT(phi_data);
 
             const Box<NDIM>& box = extended_box ? phi_data->getGhostBox() : patch->getBox();

--- a/src/level_set/LSFromMesh.cpp
+++ b/src/level_set/LSFromMesh.cpp
@@ -23,27 +23,59 @@ LSFromMesh::LSFromMesh(std::string object_name,
     : LSFindCellVolume(std::move(object_name), hierarchy),
       d_use_inside(use_inside),
       d_cut_cell_mesh_mapping(cut_cell_mesh_mapping),
-      d_sgn_var(new NodeVariable<NDIM, double>(d_object_name + "::SGN_VAR"))
+      d_sgn_nc_var(new NodeVariable<NDIM, double>(d_object_name + "::SGN_NC_VAR")),
+      d_sgn_cc_var(new CellVariable<NDIM, double>(d_object_name + "::SGN_CC_VAR"))
 {
-    commonConstructor();
+    IBAMR_DO_ONCE(t_updateVolumeAreaSideLS =
+                      TimerManager::getManager()->getTimer("ADS::LSFromMesH::updateVolumeAreaSideLS()"););
+    const unsigned int num_parts = d_cut_cell_mesh_mapping->getNumParts();
+    d_norm_reverse_domain_ids.resize(num_parts);
+    d_norm_reverse_elem_ids.resize(num_parts);
+    d_reverse_normal.resize(num_parts, 0);
+
+    auto var_db = VariableDatabase<NDIM>::getDatabase();
+    d_sgn_nc_idx = var_db->registerVariableAndContext(d_sgn_nc_var, var_db->getContext(d_object_name + "::Context"), 1);
+    d_sgn_cc_idx = var_db->registerVariableAndContext(d_sgn_cc_var, var_db->getContext(d_object_name + "::Context"), 1);
     return;
 } // Constructor
 
 void
-LSFromMesh::updateVolumeAreaSideLS(int vol_idx,
-                                   Pointer<CellVariable<NDIM, double>> /*vol_var*/,
-                                   int area_idx,
-                                   Pointer<CellVariable<NDIM, double>> /*area_var*/,
-                                   int side_idx,
-                                   Pointer<SideVariable<NDIM, double>> /*side_var*/,
-                                   int phi_idx,
-                                   Pointer<NodeVariable<NDIM, double>> phi_var,
-                                   double data_time,
-                                   bool extended_box)
+LSFromMesh::doUpdateVolumeAreaSideLS(int vol_idx,
+                                     Pointer<CellVariable<NDIM, double>> vol_var,
+                                     int area_idx,
+                                     Pointer<CellVariable<NDIM, double>> area_var,
+                                     int side_idx,
+                                     Pointer<SideVariable<NDIM, double>> side_var,
+                                     int phi_idx,
+                                     Pointer<hier::Variable<NDIM>> phi_var,
+                                     double data_time,
+                                     bool extended_box)
 {
     ADS_TIMER_START(t_updateVolumeAreaSideLS);
-    TBOX_ASSERT(phi_idx != IBTK::invalid_index);
-    TBOX_ASSERT(phi_var);
+    Pointer<NodeVariable<NDIM, double>> phi_nc_var = phi_var;
+    Pointer<CellVariable<NDIM, double>> phi_cc_var = phi_var;
+    if (phi_nc_var)
+        doUpdateVolumeAreaSideLSNode(
+            vol_idx, vol_var, area_idx, area_var, side_idx, side_var, phi_idx, phi_nc_var, data_time, extended_box);
+    else if (phi_cc_var)
+        doUpdateLSCell(phi_idx, phi_cc_var, data_time, extended_box);
+    else
+        TBOX_ERROR(d_object_name + "::doUpdateVolumeAreaSideLS(): Not a valid data centering\n");
+    ADS_TIMER_STOP(t_updateVolumeAreaSideLS);
+}
+
+void
+LSFromMesh::doUpdateVolumeAreaSideLSNode(int vol_idx,
+                                         Pointer<CellVariable<NDIM, double>> vol_var,
+                                         int area_idx,
+                                         Pointer<CellVariable<NDIM, double>> area_var,
+                                         int side_idx,
+                                         Pointer<SideVariable<NDIM, double>> side_var,
+                                         int phi_idx,
+                                         Pointer<NodeVariable<NDIM, double>> phi_var,
+                                         double data_time,
+                                         bool extended_box)
+{
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
     for (int ln = 0; ln <= finest_ln; ++ln)
     {
@@ -243,7 +275,7 @@ LSFromMesh::updateVolumeAreaSideLS(int vol_idx,
     }
 
     // Now update the LS away from the interface using a flood filling algorithm.
-    updateLSAwayFromInterface(phi_idx);
+    updateLSAwayFromInterfaceNode(phi_idx);
 
     // Synchronize the hierarchy.
     {
@@ -349,37 +381,232 @@ LSFromMesh::updateVolumeAreaSideLS(int vol_idx,
 }
 
 void
-LSFromMesh::commonConstructor()
+LSFromMesh::doUpdateLSCell(const int phi_idx,
+                           Pointer<CellVariable<NDIM, double>> phi_var,
+                           const double data_time,
+                           const bool extended_box)
 {
-    IBAMR_DO_ONCE(t_updateVolumeAreaSideLS =
-                      TimerManager::getManager()->getTimer("ADS::LSFromMesH::updateVolumeAreaSideLS()"););
-    const unsigned int num_parts = d_cut_cell_mesh_mapping->getNumParts();
-    d_norm_reverse_domain_ids.resize(num_parts);
-    d_norm_reverse_elem_ids.resize(num_parts);
-    d_reverse_normal.resize(num_parts, 0);
+    const int finest_ln = d_hierarchy->getFinestLevelNumber();
+    for (int ln = 0; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            const Pointer<Patch<NDIM>>& patch = level->getPatch(p());
+            Pointer<CellData<NDIM, double>> phi_data = patch->getPatchData(phi_idx);
+            phi_data->fillAll(static_cast<double>(ln + 2));
+        }
+    }
 
-    auto var_db = VariableDatabase<NDIM>::getDatabase();
-    d_sgn_idx = var_db->registerVariableAndContext(d_sgn_var, var_db->getContext(d_object_name + "::Context"), 1);
+    d_cut_cell_mesh_mapping->initializeObjectState(d_hierarchy);
+    d_cut_cell_mesh_mapping->generateCutCellMappings();
+    for (int ln = 0; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
+        const std::vector<std::map<IndexList, std::vector<CutCellElems>>>& idx_cut_cell_map_vec =
+            d_cut_cell_mesh_mapping->getIdxCutCellElemsMap(ln);
+
+        unsigned int local_patch_num = 0;
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++local_patch_num)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            if (idx_cut_cell_map_vec.size() > local_patch_num)
+            {
+                const std::map<IndexList, std::vector<CutCellElems>>& idx_cut_cell_map =
+                    idx_cut_cell_map_vec[local_patch_num];
+                Pointer<CellData<NDIM, double>> phi_data = patch->getPatchData(phi_idx);
+
+                Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
+                const double* const x_low = pgeom->getXLower();
+                const double* const dx = pgeom->getDx();
+                const hier::Index<NDIM>& idx_low = patch->getBox().lower();
+
+                // Loop through all cut cells in map
+                for (const auto& idx_elem_vec_pair : idx_cut_cell_map)
+                {
+                    const CellIndex<NDIM>& idx = idx_elem_vec_pair.first.d_idx;
+                    const std::vector<CutCellElems>& cut_cell_elem_vec = idx_elem_vec_pair.second;
+
+                    // Let's find distances from background cell nodes to structure
+                    // Determine normal for elements
+                    // Warning, we need the normal to be consistent between parent and child elements.
+                    std::vector<IBTK::Vector3d> elem_normals;
+                    for (const auto& cut_cell_elem : cut_cell_elem_vec)
+                    {
+                        // Note we use the parent element to calculate normals to preserve directions
+                        Vector3d v, w;
+                        const std::array<libMesh::Point, 2>& parent_pts = cut_cell_elem.d_parent_cur_pts;
+                        const unsigned int part = cut_cell_elem.d_part;
+                        v << parent_pts[0](0), parent_pts[0](1), parent_pts[0](2);
+                        w << parent_pts[1](0), parent_pts[1](1), parent_pts[1](2);
+                        const unsigned int domain_id = cut_cell_elem.d_parent_elem->subdomain_id();
+                        Vector3d e3 = Vector3d::UnitZ();
+                        if (!d_use_inside) e3 *= -1.0;
+                        if (d_norm_reverse_domain_ids[part].find(domain_id) != d_norm_reverse_domain_ids[part].end() ||
+                            d_norm_reverse_elem_ids[part].find(cut_cell_elem.d_parent_elem->id()) !=
+                                d_norm_reverse_elem_ids[part].end() ||
+                            d_reverse_normal[part])
+                        {
+                            e3 *= -1.0;
+                        }
+                        Vector3d n = (w - v).cross(e3);
+                        elem_normals.push_back(n);
+                    }
+
+                    Box<NDIM> cc_box(idx, idx);
+                    cc_box.grow(1);
+                    for (CellIterator<NDIM> ci(cc_box); ci; ci++)
+                    {
+                        const CellIndex<NDIM>& new_idx = ci();
+                        Vector3d P = Vector3d::Zero();
+                        for (int d = 0; d < NDIM; ++d) P(d) = static_cast<double>(new_idx(d) - idx_low(d)) + 0.5;
+                        // Project P onto element
+                        Vector3d avg_proj, avg_unit_normal;
+                        avg_proj.setZero();
+                        avg_unit_normal.setZero();
+                        double min_dist = std::numeric_limits<double>::max();
+                        int num_min = 0;
+                        // Loop through all elements and calculate the smallest distance
+                        for (unsigned int i = 0; i < elem_normals.size(); ++i)
+                        {
+                            const std::unique_ptr<Elem>& elem = cut_cell_elem_vec[i].d_elem;
+                            const Vector3d& n = elem_normals[i];
+                            Vector3d v, w;
+                            v << (elem->point(0)(0) - x_low[0]) / dx[0], (elem->point(0)(1) - x_low[1]) / dx[1], 0.0;
+                            w << (elem->point(1)(0) - x_low[0]) / dx[0], (elem->point(1)(1) - x_low[1]) / dx[1], 0.0;
+                            const double t = std::max(0.0, std::min(1.0, (P - v).dot(w - v) / (v - w).squaredNorm()));
+                            const Vector3d proj = v + t * (w - v);
+                            VectorNd x_proj;
+                            for (int d = 0; d < NDIM; ++d) x_proj[d] = x_low[d] + dx[d] * (proj(d) - idx_low(d));
+                            const double dist = (proj - P).norm();
+                            if (dist < min_dist)
+                            {
+                                min_dist = dist;
+                                avg_proj = proj;
+                                avg_unit_normal = n;
+                                num_min = 1;
+                            }
+                            else if (MathUtilities<double>::equalEps(dist, min_dist))
+                            {
+                                avg_proj += proj;
+                                avg_unit_normal += n;
+                                ++num_min;
+                            }
+                        }
+                        avg_proj /= static_cast<double>(num_min);
+                        avg_unit_normal /= static_cast<double>(num_min);
+                        avg_unit_normal.normalize();
+
+                        Vector3d phys_vec = Vector3d::Zero();
+                        for (unsigned int d = 0; d < NDIM; ++d) phys_vec(d) = dx[d] * (P - avg_proj)[d];
+                        double dist_phys = phys_vec.norm();
+                        double sgn = (avg_unit_normal.dot(P - avg_proj) <= 0.0 ? -1.0 : 1.0);
+                        (*phi_data)(new_idx) =
+                            dist_phys < std::abs((*phi_data)(new_idx)) ? (dist_phys * sgn) : (*phi_data)(new_idx);
+                        // Truncate distances that are too small
+                        // TODO: find a better way to do this.
+                        if ((*phi_data)(new_idx) < 0.0 && (*phi_data)(new_idx) > -1.0e-6) (*phi_data)(new_idx) = 0.0;
+                    }
+                }
+            }
+        }
+
+        // Fill in physical boundary cells
+        if (d_bdry_fcn)
+        {
+            for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+            {
+                Pointer<Patch<NDIM>> patch = level->getPatch(p());
+                Pointer<CellData<NDIM, double>> ls_data = patch->getPatchData(phi_idx);
+
+                // Loop over boundary boxes
+                Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
+                const double* const xlow = pgeom->getXLower();
+                const double* const dx = pgeom->getDx();
+                const hier::Index<NDIM>& idx_low = patch->getBox().lower();
+                std::vector<Box<NDIM>> fill_boxes;
+                for (int d = 1; d <= NDIM; ++d)
+                {
+                    const tbox::Array<BoundaryBox<NDIM>>& bdry_boxes = pgeom->getCodimensionBoundaries(d);
+                    for (int i = 0; i < bdry_boxes.size(); ++i)
+                    {
+                        const BoundaryBox<NDIM>& bdry_box = bdry_boxes[i];
+                        const int location_index = bdry_box.getLocationIndex();
+                        const int axis = location_index % 2;
+                        const int upper_lower = location_index / 2;
+                        if (pgeom->getTouchesRegularBoundary(axis, upper_lower))
+                        {
+                            fill_boxes.push_back(
+                                pgeom->getBoundaryFillBox(bdry_box, patch->getBox(), ls_data->getGhostCellWidth()));
+                        }
+                    }
+                }
+
+                for (const auto& box : fill_boxes)
+                {
+                    for (CellIterator<NDIM> ni(box); ni; ni++)
+                    {
+                        const CellIndex<NDIM>& idx = ni();
+                        if ((*ls_data)(idx) == static_cast<double>(ln + 2))
+                        {
+                            // Change this value
+                            VectorNd X_loc;
+                            for (int d = 0; d < NDIM; ++d)
+                                X_loc[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
+                            double ls_val = (*ls_data)(idx);
+                            d_bdry_fcn(X_loc, ls_val);
+                            (*ls_data)(idx) = ls_val;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Fill in level set ghost cells to get the periodic boundary conditions correctly. Note we do not coarsen because
+    // that will affect the flood filling algorithm.
+    {
+        using ITC = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
+        std::vector<ITC> ghost_cell_comp(1);
+        ghost_cell_comp[0] = ITC(phi_idx, "CONSERVATIVE_LINEAR_REFINE", false, "NONE");
+        HierarchyGhostCellInterpolation ghost_cells;
+        ghost_cells.initializeOperatorState(ghost_cell_comp, d_hierarchy, 0, finest_ln);
+        ghost_cells.fillData(data_time);
+    }
+
+    // Now update the LS away from the interface using a flood filling algorithm.
+    updateLSAwayFromInterfaceCell(phi_idx);
+
+    // Synchronize the hierarchy.
+    {
+        using ITC = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
+        std::vector<ITC> ghost_cell_comp(1);
+        ghost_cell_comp[0] = ITC(phi_idx, "CONSERVATIVE_LINEAR_REFINE", false, "CONSERVATIVE_COARSEN");
+        HierarchyGhostCellInterpolation ghost_cells;
+        ghost_cells.initializeOperatorState(ghost_cell_comp, d_hierarchy, 0, finest_ln);
+        ghost_cells.fillData(data_time);
+    }
+    return;
 }
 
 void
-LSFromMesh::updateLSAwayFromInterface(const int phi_idx)
+LSFromMesh::updateLSAwayFromInterfaceNode(const int phi_idx)
 {
     const int finest_ln = d_hierarchy->getFinestLevelNumber();
     HierarchyNodeDataOpsReal<NDIM, double> hier_nc_data_ops(d_hierarchy, 0, finest_ln);
-    Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(finest_ln);
+    Pointer<PatchLevel<NDIM>> finest_level = d_hierarchy->getPatchLevel(finest_ln);
     // Now we need to update the sign of phi_data.
     for (int ln = 0; ln <= finest_ln; ++ln)
     {
-        d_hierarchy->getPatchLevel(ln)->allocatePatchData(d_sgn_idx);
+        d_hierarchy->getPatchLevel(ln)->allocatePatchData(d_sgn_nc_idx);
     }
-    hier_nc_data_ops.copyData(d_sgn_idx, phi_idx, false);
-    floodFillForLS(finest_ln, static_cast<double>(finest_ln + 2));
+    hier_nc_data_ops.copyData(d_sgn_nc_idx, phi_idx, false);
+    flood_fill_for_LS(d_sgn_nc_idx, d_sgn_nc_var, static_cast<double>(finest_ln + 2), finest_level);
     // At this point, the finest level has been filled in. We now need to fill in coarser levels
     Pointer<CartesianGridGeometry<NDIM>> grid_geom = d_hierarchy->getGridGeometry();
-    Pointer<CoarsenOperator<NDIM>> coarsen_op = grid_geom->lookupCoarsenOperator(d_sgn_var, "CONSTANT_COARSEN");
+    Pointer<CoarsenOperator<NDIM>> coarsen_op = grid_geom->lookupCoarsenOperator(d_sgn_nc_var, "CONSTANT_COARSEN");
     Pointer<CoarsenAlgorithm<NDIM>> coarsen_alg = new CoarsenAlgorithm<NDIM>();
-    coarsen_alg->registerCoarsen(d_sgn_idx, d_sgn_idx, coarsen_op);
+    coarsen_alg->registerCoarsen(d_sgn_nc_idx, d_sgn_nc_idx, coarsen_op);
     std::vector<Pointer<CoarsenSchedule<NDIM>>> coarsen_scheds(finest_ln + 1);
     for (int ln = finest_ln; ln > 0; --ln)
     {
@@ -387,114 +614,43 @@ LSFromMesh::updateLSAwayFromInterface(const int phi_idx)
         Pointer<PatchLevel<NDIM>> coarser_level = d_hierarchy->getPatchLevel(ln - 1);
         coarsen_scheds[ln] = coarsen_alg->createSchedule(coarser_level, level);
         coarsen_scheds[ln]->coarsenData();
-        floodFillForLS(ln - 1, static_cast<double>(ln + 1));
+        flood_fill_for_LS(d_sgn_nc_idx, d_sgn_nc_var, static_cast<double>(ln + 1), coarser_level);
     }
 
-    hier_nc_data_ops.copyData(phi_idx, d_sgn_idx, false);
+    hier_nc_data_ops.copyData(phi_idx, d_sgn_nc_idx, false);
     for (int ln = 0; ln <= finest_ln; ++ln)
     {
-        d_hierarchy->getPatchLevel(ln)->deallocatePatchData(d_sgn_idx);
+        d_hierarchy->getPatchLevel(ln)->deallocatePatchData(d_sgn_nc_idx);
     }
 }
 
 void
-LSFromMesh::floodFillForLS(const int ln, const double eps)
+LSFromMesh::updateLSAwayFromInterfaceCell(const int phi_idx)
 {
-    TBOX_ASSERT(eps > 0.0);
-    Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
-    RefineAlgorithm<NDIM> ghost_fill_alg;
-    ghost_fill_alg.registerRefine(d_sgn_idx, d_sgn_idx, d_sgn_idx, nullptr);
-    Pointer<RefineSchedule<NDIM>> ghost_fill_sched = ghost_fill_alg.createSchedule(level);
-    // Do a flood fill algorithm
-    std::vector<int> patch_filled_vec(level->getNumberOfPatches());
-    unsigned int patch_num = 0;
-    for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++patch_num)
+    const int finest_ln = d_hierarchy->getFinestLevelNumber();
+    HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(d_hierarchy, 0, finest_ln);
+    Pointer<PatchLevel<NDIM>> finest_level = d_hierarchy->getPatchLevel(finest_ln);
+    // Now we need to update the sign of phi_data.
+    for (int ln = 0; ln <= finest_ln; ++ln) d_hierarchy->getPatchLevel(ln)->allocatePatchData(d_sgn_cc_idx);
+    hier_cc_data_ops.copyData(d_sgn_cc_idx, phi_idx, false);
+    flood_fill_for_LS(d_sgn_cc_idx, d_sgn_cc_var, static_cast<double>(finest_ln + 2), finest_level);
+    // At this point, the finest level has been filled in. We now need to fill in coarser levels
+    Pointer<CartesianGridGeometry<NDIM>> grid_geom = d_hierarchy->getGridGeometry();
+    Pointer<CoarsenOperator<NDIM>> coarsen_op = grid_geom->lookupCoarsenOperator(d_sgn_cc_var, "CONSERVATIVE_COARSEN");
+    Pointer<CoarsenAlgorithm<NDIM>> coarsen_alg = new CoarsenAlgorithm<NDIM>();
+    coarsen_alg->registerCoarsen(d_sgn_cc_idx, d_sgn_cc_idx, coarsen_op);
+    std::vector<Pointer<CoarsenSchedule<NDIM>>> coarsen_scheds(finest_ln + 1);
+    for (int ln = finest_ln; ln > 0; --ln)
     {
-        Pointer<Patch<NDIM>> patch = level->getPatch(p());
-        const Box<NDIM>& box = patch->getBox();
-        Box<NDIM> n_box(box);
-        n_box.growUpper(1);
-        Pointer<NodeData<NDIM, double>> phi_data = patch->getPatchData(d_sgn_idx);
-        NodeData<NDIM, int> idx_touched(box, 1, phi_data->getGhostCellWidth());
-        idx_touched.fillAll(0);
-        std::queue<NodeIndex<NDIM>> idx_queue;
-        bool found_pt = false;
-        for (NodeIterator<NDIM> ni(box); ni; ni++)
-        {
-            const NodeIndex<NDIM>& idx = ni();
-            if ((*phi_data)(idx) <= 0.0)
-            {
-                idx_queue.push(idx);
-                found_pt = true;
-            }
-        }
-        patch_filled_vec[patch_num] = found_pt ? 1 : 0;
-        // We have our starting point. Now, loop through queue
-        while (idx_queue.size() > 0)
-        {
-            const NodeIndex<NDIM>& idx = idx_queue.front();
-            // If this point is uninitialized, it is interior
-            if (idx_touched(idx) == 0 && ((*phi_data)(idx) == eps || (*phi_data)(idx) <= 0.0))
-            {
-                // Insert the point into touched list
-                idx_touched(idx) = 1;
-                if ((*phi_data)(idx) == eps) (*phi_data)(idx) = -eps;
-                // Add neighboring points if they haven't been touched yet
-                NodeIndex<NDIM> idx_s = idx + IntVector<NDIM>(0, -1);
-                NodeIndex<NDIM> idx_n = idx + IntVector<NDIM>(0, 1);
-                NodeIndex<NDIM> idx_e = idx + IntVector<NDIM>(1, 0);
-                NodeIndex<NDIM> idx_w = idx + IntVector<NDIM>(-1, 0);
-                if (n_box.contains(idx_s) && ((*phi_data)(idx_s) == eps || (*phi_data)(idx_s) < 0.0) &&
-                    idx_touched(idx_s) == 0)
-                    idx_queue.push(idx_s);
-                if (n_box.contains(idx_n) && ((*phi_data)(idx_n) == eps || (*phi_data)(idx_n) < 0.0) &&
-                    idx_touched(idx_n) == 0)
-                    idx_queue.push(idx_n);
-                if (n_box.contains(idx_e) && ((*phi_data)(idx_e) == eps || (*phi_data)(idx_e) < 0.0) &&
-                    idx_touched(idx_e) == 0)
-                    idx_queue.push(idx_e);
-                if (n_box.contains(idx_w) && ((*phi_data)(idx_w) == eps || (*phi_data)(idx_w) < 0.0) &&
-                    idx_touched(idx_w) == 0)
-                    idx_queue.push(idx_w);
-            }
-            idx_queue.pop();
-        }
+        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
+        Pointer<PatchLevel<NDIM>> coarser_level = d_hierarchy->getPatchLevel(ln - 1);
+        coarsen_scheds[ln] = coarsen_alg->createSchedule(coarser_level, level);
+        coarsen_scheds[ln]->coarsenData();
+        flood_fill_for_LS(d_sgn_cc_idx, d_sgn_cc_var, static_cast<double>(ln + 1), coarser_level);
     }
 
-    // At this point if there's any box that hasn't been filled, then it's either entirely inside or outside.
-    // We'll fill ghost cells, then check the ghost boxes. If there is any negative in the ghost box, then the entire
-    // patch is inside
-    int num_negative_found = 1;
-    while (num_negative_found > 0)
-    {
-        num_negative_found = 0;
-        ghost_fill_sched->fillData(0.0);
-        patch_num = 0;
-        for (PatchLevel<NDIM>::Iterator p(level); p; p++, ++patch_num)
-        {
-            bool found_negative = false;
-            if (patch_filled_vec[patch_num] == 1) continue;
-            Pointer<Patch<NDIM>> patch = level->getPatch(p());
-            // Loop through ghost cells
-            Pointer<NodeData<NDIM, double>> phi_data = patch->getPatchData(d_sgn_idx);
-            for (NodeIterator<NDIM> ni(phi_data->getGhostBox()); ni; ni++)
-            {
-                const NodeIndex<NDIM>& idx = ni();
-                if (patch->getBox().contains(idx)) continue;
-                if ((*phi_data)(idx) == -eps)
-                {
-                    found_negative = true;
-                    break;
-                }
-            }
-            if (found_negative)
-            {
-                phi_data->fillAll(-eps, phi_data->getGhostBox());
-                num_negative_found++;
-                patch_filled_vec[patch_num] = 1;
-            }
-        }
-        num_negative_found = IBTK_MPI::sumReduction(num_negative_found);
-    }
+    hier_cc_data_ops.copyData(phi_idx, d_sgn_cc_idx, false);
+    for (int ln = 0; ln <= finest_ln; ++ln) d_hierarchy->getPatchLevel(ln)->deallocatePatchData(d_sgn_cc_idx);
 }
+
 } // namespace ADS

--- a/tests/find_vol/find_vol_2d.output
+++ b/tests/find_vol/find_vol_2d.output
@@ -19,3 +19,6 @@ Total volume found on level: 0 is: 3.13571828361
   Exact vol:   3.14159265359
   Approx area: 6.27895484798
   Exact area:  6.28318530718
+
+Computing difference between cell and node centered variable:
+ Average difference: 0.0804029739075


### PR DESCRIPTION
In some cases, e.g. near wall transport for IB, we should use a collocated level set representation for advecting quantities, instead of an interpolated level set. This sets up routines for finding cell centered level sets from a mesh.