### PR TITLE
Add compressible semi-Lagrangian method

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 ADD_CUSTOM_TARGET(examples)
-SET(EXAMPLE_DIRECTORIES couette disk pipe_flow_no_ins pipe_flow_no_struct radial reacting_couette rotational solvers operators semi_lagrangian)
+SET(EXAMPLE_DIRECTORIES compressible couette disk pipe_flow_no_ins pipe_flow_no_struct radial reacting_couette rotational solvers operators semi_lagrangian)
 
 MACRO(ADS_ADD_EXAMPLE)
   SET(OPTIONS)

--- a/examples/compressible/CMakeLists.txt
+++ b/examples/compressible/CMakeLists.txt
@@ -1,0 +1,17 @@
+ADS_ADD_EXAMPLE(
+  TARGET_NAME
+    "compressible"
+  OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/examples/compressible"
+  OUTPUT_NAME
+    main2d
+  EXAMPLE_GROUP
+    examples
+  SOURCES
+    main.cpp QFcn.cpp
+  LINK_TARGETS
+    ADS2d
+  INPUT_FILES
+    input2d
+  )
+

--- a/examples/compressible/QFcn.cpp
+++ b/examples/compressible/QFcn.cpp
@@ -1,0 +1,41 @@
+#include "ibamr/config.h"
+
+#include "ADS/app_namespaces.h"
+
+#include "QFcn.h"
+
+#include <SAMRAI_config.h>
+
+#include <array>
+
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+
+QFcn::QFcn(string object_name) : CartGridFunction(std::move(object_name))
+{
+    // intentionally blank
+    return;
+} // QFcn
+
+void
+QFcn::setDataOnPatch(const int data_idx,
+                     Pointer<hier::Variable<NDIM>> var,
+                     Pointer<Patch<NDIM>> patch,
+                     const double t,
+                     const bool initial_time,
+                     Pointer<PatchLevel<NDIM>> level)
+{
+    Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
+    const double* const dx = pgeom->getDx();
+    const double* const xlow = pgeom->getXLower();
+    const hier::Index<NDIM>& idx_low = patch->getBox().lower();
+
+    Pointer<CellData<NDIM, double>> Q_data = patch->getPatchData(data_idx);
+    for (CellIterator<NDIM> ci(patch->getBox()); ci; ci++)
+    {
+        const CellIndex<NDIM>& idx = ci();
+        VectorNd x;
+        for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
+        (*Q_data)(idx) = std::pow(std::cos(M_PI * (x[0])) * std::cos(M_PI * (x[1])), 2.0);
+    }
+    return;
+} // setDataOnPatch

--- a/examples/compressible/QFcn.h
+++ b/examples/compressible/QFcn.h
@@ -1,0 +1,44 @@
+#ifndef included_QFcn
+#define included_QFcn
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibamr/AdvDiffHierarchyIntegrator.h>
+
+#include <ibtk/CartGridFunction.h>
+#include <ibtk/ibtk_utilities.h>
+
+#include <CartesianGridGeometry.h>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+/*!
+ * \brief Method to initialize the value of the advected scalar Q.
+ */
+class QFcn : public IBTK::CartGridFunction
+{
+public:
+    /*!
+     * \brief Constructor.
+     */
+    QFcn(std::string object_name);
+
+    /*!
+     * Indicates whether the concrete CartGridFunction object is time dependent.
+     */
+    bool isTimeDependent() const
+    {
+        return true;
+    }
+
+    /*!
+     * Set the data on the patch interior to the exact answer. Note that we are setting the cell average here.
+     */
+    void setDataOnPatch(int data_idx,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM>> var,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
+                        double data_time,
+                        bool initial_time = false,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>> level =
+                            SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>>(nullptr)) override;
+};
+#endif // #ifndef included_ADS_QFcn

--- a/examples/compressible/input2d
+++ b/examples/compressible/input2d
@@ -1,0 +1,140 @@
+// physical parameters
+PI = 3.14159265359
+L = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+H = L/NFINEST
+CFL_MAX = 0.5
+U_MAX = 2.0
+DT_MIN = H * CFL_MAX 
+DT_MAX = DT_MIN
+END_TIME = 2.0
+REGRID_INTERVAL = 1
+TAG_BUFFER = 1
+
+MIN_REFINE_FACTOR = -4.0
+MAX_REFINE_FACTOR = 2.0
+LEAST_SQUARES_ORDER = "QUADRATIC"
+USE_STRANG_SPLITTING = TRUE
+USE_OUTSIDE_LS_FOR_TAGGING = TRUE
+ADV_INT_METHOD = "MIDPOINT_RULE"
+DIF_INT_METHOD = "TRAPEZOIDAL_RULE"
+USE_RBFS =  TRUE
+RBF_STENCIL_SIZE = 12
+RBF_POLY_ORDER = "QUADRATIC"
+
+UFunction {
+   function_0 = "sin(2*PI*t)*cos(PI*X_0)*cos(PI*X_1)"
+   function_1 = "sin(2*PI*t)*cos(PI*X_1)*cos(PI*X_0)"
+}
+
+Q_bcs {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+
+    gcoef_function_0 = "0.0"
+    gcoef_function_1 = "0.0"
+    gcoef_function_2 = "0.0"
+    gcoef_function_3 = "0.0"
+}
+
+Main {
+
+// log file parameters
+   log_file_name               = "test.log"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 8
+   viz_dump_dirname            = "viz_adv_diff2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_adv_diff2d"
+
+   data_dump_interval          = NFINEST/8
+   data_dump_dirname           = "hier_data_IB2d"
+
+   timer_dump_interval = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = -L,-L
+   x_up = L,L
+   periodic_dimension = 1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.9e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.9e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "GRADIENT_DETECTOR"
+   RefineBoxes {
+      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = TRUE
+   print_total     = TRUE
+   print_threshold = 0.0
+   timer_list      = "LS::*::*","IBAMR::*::*","IBTK::*::*"
+}
+
+
+SLAdvIntegrator {
+    start_time           = 0.0e0  // initial simulation time
+    end_time             = END_TIME    // final simulation time
+    grow_dt              = 2.0e0  // growth factor for timesteps
+    regrid_interval      = REGRID_INTERVAL  // effectively disable regridding
+    cfl                  = CFL_MAX
+    dt_max               = DT_MAX
+    dt_min               = DT_MIN
+    enable_logging       = TRUE
+
+    min_ls_refine_factor = MIN_REFINE_FACTOR
+    max_ls_refine_factor = MAX_REFINE_FACTOR
+    least_squares_order = LEAST_SQUARES_ORDER
+    advection_ts_type = ADV_INT_METHOD
+    use_rbfs = USE_RBFS
+    rbf_stencil_size = RBF_STENCIL_SIZE
+    rbf_poly_order = RBF_POLY_ORDER
+    default_adv_reconstruct_type = "RBF"
+
+    tag_buffer = TAG_BUFFER
+    
+    num_cycles = 1
+}

--- a/examples/compressible/main.cpp
+++ b/examples/compressible/main.cpp
@@ -1,0 +1,263 @@
+#include "ibamr/config.h"
+
+#include "ADS/SLAdvIntegrator.h"
+#include <ADS/LSFromLevelSet.h>
+#include <ADS/PointwiseFunction.h>
+#include <ADS/app_namespaces.h>
+
+#include "ibtk/CartGridFunctionSet.h"
+#include "ibtk/PETScKrylovPoissonSolver.h"
+#include "ibtk/muParserCartGridFunction.h"
+#include "ibtk/muParserRobinBcCoefs.h"
+#include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+
+#include "BergerRigoutsos.h"
+#include "CartesianGridGeometry.h"
+#include "LoadBalancer.h"
+#include "SAMRAI_config.h"
+#include "StandardTagAndInitialize.h"
+#include "tbox/Pointer.h"
+
+#include <petscsys.h>
+
+#include <memory>
+#include <utility>
+
+// Local includes
+#include "QFcn.h"
+
+/*******************************************************************************
+ * For each run, the input filename and restart information (if needed) must   *
+ * be given on the command line.  For non-restarted case, command line is:     *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ * For restarted run, command line is:                                         *
+ *                                                                             *
+ *    executable <input file name> <restart directory> <restart number>        *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize PETSc, MPI, and SAMRAI.
+    IBTK::IBTKInit init(argc, argv, MPI_COMM_WORLD);
+
+    { // cleanup dynamically allocated objects prior to shutdown
+
+        // Parse command line options, set some standard options from the input
+        // file, initialize the restart database (if this is a restarted run),
+        // and enable file logging.
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "adv_diff.log");
+        Pointer<Database> input_db = app_initializer->getInputDatabase();
+        Pointer<Database> main_db = app_initializer->getComponentDatabase("Main");
+
+        // Get various standard options set in the input file.
+        const bool dump_viz_data = app_initializer->dumpVizData();
+        const int viz_dump_interval = app_initializer->getVizDumpInterval();
+        const bool uses_visit = dump_viz_data && app_initializer->getVisItDataWriter();
+
+        const bool dump_restart_data = app_initializer->dumpRestartData();
+        const int restart_dump_interval = app_initializer->getRestartDumpInterval();
+        const std::string restart_dump_dirname = app_initializer->getRestartDumpDirectory();
+
+        const bool dump_timer_data = app_initializer->dumpTimerData();
+        const int timer_dump_interval = app_initializer->getTimerDumpInterval();
+
+        const bool dump_postproc_data = app_initializer->dumpPostProcessingData();
+        const int dump_postproc_interval = app_initializer->getPostProcessingDataDumpInterval();
+        const std::string postproc_data_dump_dirname = app_initializer->getPostProcessingDataDumpDirectory();
+        if (dump_postproc_data && !postproc_data_dump_dirname.empty())
+        {
+            Utilities::recursiveMkdir(postproc_data_dump_dirname);
+        }
+
+        // Create major algorithm and data objects that comprise the
+        // application.  These objects are configured from the input database
+        // and, if this is a restarted run, from the restart database.
+        Pointer<CartesianGridGeometry<NDIM>> grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<SLAdvIntegrator> time_integrator =
+            new SLAdvIntegrator("SLAdvIntegrator", app_initializer->getComponentDatabase("SLAdvIntegrator"), false);
+
+        Pointer<PatchHierarchy<NDIM>> patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<StandardTagAndInitialize<NDIM>> error_detector =
+            new StandardTagAndInitialize<NDIM>("StandardTagAndInitialize",
+                                               time_integrator,
+                                               app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<BergerRigoutsos<NDIM>> box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM>> load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM>> gridding_algorithm =
+            new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                        app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                        error_detector,
+                                        box_generator,
+                                        load_balancer);
+
+        // Setup the advection velocity.
+        Pointer<FaceVariable<NDIM, double>> u_var = new FaceVariable<NDIM, double>("u");
+        Pointer<CartGridFunction> u_fcn;
+        Pointer<CartGridFunction> u_adv_fcn;
+        time_integrator->registerAdvectionVelocity(u_var);
+        time_integrator->setAdvectionVelocityIsDivergenceFree(u_var, false);
+        u_fcn = new muParserCartGridFunction(
+            "UFunction", app_initializer->getComponentDatabase("UFunction"), grid_geometry);
+        time_integrator->setAdvectionVelocityFunction(u_var, u_fcn);
+
+        // Setup level set
+        Pointer<NodeVariable<NDIM, double>> ls_var = new NodeVariable<NDIM, double>("ls");
+        PointwiseFunctions::ScalarFcn ls_fcn = [](double, const VectorNd&, double) -> double { return -1.0; };
+        Pointer<ADS::PointwiseFunction<PointwiseFunctions::ScalarFcn>> ls_hier_fcn =
+            new ADS::PointwiseFunction("ls_fcn", ls_fcn);
+        Pointer<LSFromLevelSet> ls_vol_fcn = new LSFromLevelSet("ls_fcn", patch_hierarchy);
+        ls_vol_fcn->registerLSFcn(ls_hier_fcn);
+        time_integrator->registerLevelSetVariable(ls_var);
+        time_integrator->registerLevelSetVolFunction(ls_var, ls_vol_fcn);
+
+        // Setup advected quantity
+        Pointer<CellVariable<NDIM, double>> Q_var = new CellVariable<NDIM, double>("Q");
+        Pointer<CartGridFunction> Q_init = new QFcn("QInit");
+        const bool periodic_domain = grid_geometry->getPeriodicShift().min() > 0;
+        std::vector<RobinBcCoefStrategy<NDIM>*> Q_bcs(1);
+        if (!periodic_domain)
+        {
+            const std::string Q_bcs_name = "Q_bcs";
+            Q_bcs[0] =
+                new muParserRobinBcCoefs(Q_bcs_name, app_initializer->getComponentDatabase(Q_bcs_name), grid_geometry);
+        }
+
+        time_integrator->registerTransportedQuantity(Q_var);
+        time_integrator->restrictToLevelSet(Q_var, ls_var);
+        time_integrator->setAdvectionVelocity(Q_var, u_var);
+        time_integrator->setInitialConditions(Q_var, Q_init);
+        time_integrator->setPhysicalBcCoef(Q_var, Q_bcs[0]);
+
+        // Set up visualization plot file writer.
+        Pointer<VisItDataWriter<NDIM>> visit_data_writer = app_initializer->getVisItDataWriter();
+        if (uses_visit)
+        {
+            time_integrator->registerVisItDataWriter(visit_data_writer);
+        }
+
+        // Register a drawing variable with the data writer
+        auto var_db = VariableDatabase<NDIM>::getDatabase();
+        Pointer<CellVariable<NDIM, double>> u_draw_var = new CellVariable<NDIM, double>("U", NDIM);
+        const int u_draw_idx = var_db->registerVariableAndContext(u_draw_var, var_db->getContext("Draw"));
+        visit_data_writer->registerPlotQuantity("U", "VECTOR", u_draw_idx);
+        for (int d = 0; d < NDIM; ++d)
+            visit_data_writer->registerPlotQuantity("U_" + std::to_string(d), "SCALAR", u_draw_idx, d);
+
+        // Initialize hierarchy configuration and data on all patches.
+        time_integrator->initializePatchHierarchy(patch_hierarchy, gridding_algorithm);
+
+        // Close the restart manager.
+        RestartManager::getManager()->closeRestartFile();
+
+        // Print the input database contents to the log file.
+        plog << "Input database:\n";
+        input_db->printClassData(plog);
+
+        double dt = time_integrator->getMaximumTimeStepSize();
+
+        // Write out initial visualization data.
+        int iteration_num = time_integrator->getIntegratorStep();
+        double loop_time = time_integrator->getIntegratorTime();
+        if (dump_viz_data && uses_visit)
+        {
+            pout << "\n\nWriting visualization files...\n\n";
+            time_integrator->setupPlotData();
+            time_integrator->allocatePatchData(u_draw_idx, loop_time);
+            u_fcn->setDataOnPatchHierarchy(u_draw_idx, u_draw_var, patch_hierarchy, loop_time);
+            visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+            time_integrator->deallocatePatchData(u_draw_idx);
+        }
+
+        // Main time step loop.
+        double loop_time_end = time_integrator->getEndTime();
+        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        {
+            iteration_num = time_integrator->getIntegratorStep();
+            loop_time = time_integrator->getIntegratorTime();
+
+            pout << "\n";
+            pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+            pout << "At beginning of timestep # " << iteration_num << "\n";
+            pout << "Simulation time is " << loop_time << "\n";
+
+            dt = time_integrator->getMaximumTimeStepSize();
+            time_integrator->advanceHierarchy(dt);
+            loop_time += dt;
+
+            pout << "\n";
+            pout << "At end       of timestep # " << iteration_num << "\n";
+            pout << "Simulation time is " << loop_time << "\n";
+            pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+            pout << "\n";
+
+            // At specified intervals, write visualization and restart files,
+            // and print out timer data.
+            iteration_num += 1;
+            const bool last_step = !time_integrator->stepsRemaining();
+            if (dump_viz_data && uses_visit && (iteration_num % viz_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting visualization files...\n\n";
+                time_integrator->setupPlotData();
+                time_integrator->allocatePatchData(u_draw_idx, loop_time);
+                u_fcn->setDataOnPatchHierarchy(u_draw_idx, u_draw_var, patch_hierarchy, loop_time);
+                visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+                time_integrator->deallocatePatchData(u_draw_idx);
+            }
+            if (dump_restart_data && (iteration_num % restart_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting restart files...\n\n";
+                RestartManager::getManager()->writeRestartFile(restart_dump_dirname, iteration_num);
+            }
+            if (dump_timer_data && (iteration_num % timer_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting timer data...\n\n";
+                TimerManager::getManager()->print(plog);
+                TimerManager::getManager()->resetAllTimers();
+            }
+        }
+
+        // Compute errors
+        const int Q_cur_idx = var_db->mapVariableAndContextToIndex(Q_var, time_integrator->getCurrentContext());
+        const int Q_err_idx = var_db->registerClonedPatchDataIndex(Q_var, Q_cur_idx);
+        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->allocatePatchData(Q_err_idx);
+        }
+
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(patch_hierarchy);
+        HierarchyMathOps hier_math_ops("hier_math_ops", patch_hierarchy);
+        const int wgt_cc_idx = hier_math_ops.getCellWeightPatchDescriptorIndex();
+
+        Q_init->setDataOnPatchHierarchy(Q_err_idx, Q_var, patch_hierarchy, loop_time);
+        hier_cc_data_ops.subtract(Q_cur_idx, Q_cur_idx, Q_err_idx);
+        pout << "Computing error norms:\n";
+        pout << "  L1-norm:  " << hier_cc_data_ops.L1Norm(Q_cur_idx, wgt_cc_idx) << "\n";
+        pout << "  L2-norm:  " << hier_cc_data_ops.L2Norm(Q_cur_idx, wgt_cc_idx) << "\n";
+        pout << "  max-norm: " << hier_cc_data_ops.maxNorm(Q_cur_idx, wgt_cc_idx) << "\n";
+
+        time_integrator->setupPlotData();
+        time_integrator->allocatePatchData(u_draw_idx, loop_time);
+        u_fcn->setDataOnPatchHierarchy(u_draw_idx, u_draw_var, patch_hierarchy, loop_time);
+        visit_data_writer->writePlotData(patch_hierarchy, iteration_num + 1, loop_time);
+        time_integrator->deallocatePatchData(u_draw_idx);
+
+        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->deallocatePatchData(Q_err_idx);
+        }
+
+        if (!periodic_domain) delete Q_bcs[0];
+    } // cleanup dynamically allocated objects prior to shutdown
+
+    SAMRAIManager::shutdown();
+    PetscFinalize();
+    return 0;
+} // main

--- a/include/ADS/SLAdvIntegrator.h
+++ b/include/ADS/SLAdvIntegrator.h
@@ -189,9 +189,10 @@ protected:
                                  double new_time);
 
     /*!
-     * Integrates the paths backward in time using the provided velocity patch indices.
+     * Integrates the paths backward in time using the provided velocity patch indices. If half_path_idx is a valid
+     * patch index, then the departure points are computed at half time points as well.
      */
-    virtual void integratePaths(int path_idx, int u_new_idx, int u_half_idx, double dt);
+    virtual void integratePaths(int path_idx, int half_path_idx, int u_new_idx, int u_half_idx, double dt);
 
     void setDefaultReconstructionOperator(SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> Q_var);
 
@@ -199,7 +200,7 @@ protected:
 
     // Level set information
     std::vector<SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>>> d_ls_vars;
-    std::vector<SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>>> d_vol_vars, d_vol_wgt_vars;
+    std::vector<SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>>> d_vol_vars;
     std::map<SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>>, bool> d_ls_use_ls_for_tagging;
     std::map<SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>>,
              SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>>>
@@ -217,9 +218,14 @@ protected:
 
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_u_s_var;
 
+    // Divergence variable for compressible velocity fields
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_u_div_var;
+
     // patch data for particle trajectories
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_path_var;
     int d_path_idx = IBTK::invalid_index;
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_half_path_var;
+    int d_half_path_idx = IBTK::invalid_index;
     // Scratch data for when we need more ghost cells.
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_Q_big_scr_var;
     int d_Q_big_scr_idx = IBTK::invalid_index;

--- a/src/integrators/SLAdvIntegrator.cpp
+++ b/src/integrators/SLAdvIntegrator.cpp
@@ -726,6 +726,9 @@ SLAdvIntegrator::advectionUpdate(Pointer<CellVariable<NDIM, double>> Q_var,
 
     // If the velocity field is not divergence free, we need to reconstruct J*q where J = exp(-dt*div(u)) evaluated at
     // half point departure points.
+    // TODO: Currently, we compute J = exp(-dt*div(u)) at half point departures and separately compute q at full point
+    // departures. We should investigate if we can compute these at the same departure ponts while maintaining second
+    // order accuracy.
     if (!d_u_is_div_free[u_var])
     {
         // Need to integrate the half path back as well

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,7 @@ MACRO(SETUP_3D _dir _src)
   ADD_DEPENDENCIES(tests-${_dir} ${_target})
 ENDMACRO()
 
+SETUP_2D(examples compressible.cpp)
 SETUP_2D(examples disk.cpp)
 SETUP_2D(examples radial.cpp)
 SETUP_2D(examples semi_lagrangian_01.cpp)

--- a/tests/examples/compressible.cpp
+++ b/tests/examples/compressible.cpp
@@ -1,0 +1,265 @@
+#include "ibamr/config.h"
+
+#include "ADS/SLAdvIntegrator.h"
+#include <ADS/LSFromLevelSet.h>
+#include <ADS/PointwiseFunction.h>
+#include <ADS/app_namespaces.h>
+
+#include "ibtk/CartGridFunctionSet.h"
+#include "ibtk/PETScKrylovPoissonSolver.h"
+#include "ibtk/muParserCartGridFunction.h"
+#include "ibtk/muParserRobinBcCoefs.h"
+#include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+
+#include "BergerRigoutsos.h"
+#include "CartesianGridGeometry.h"
+#include "LoadBalancer.h"
+#include "SAMRAI_config.h"
+#include "StandardTagAndInitialize.h"
+#include "tbox/Pointer.h"
+
+#include <petscsys.h>
+
+#include <memory>
+#include <utility>
+
+// Local includes
+#include "compressible/QFcn.h"
+
+#include "compressible/QFcn.cpp"
+
+/*******************************************************************************
+ * For each run, the input filename and restart information (if needed) must   *
+ * be given on the command line.  For non-restarted case, command line is:     *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ * For restarted run, command line is:                                         *
+ *                                                                             *
+ *    executable <input file name> <restart directory> <restart number>        *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize PETSc, MPI, and SAMRAI.
+    IBTK::IBTKInit init(argc, argv, MPI_COMM_WORLD);
+
+    { // cleanup dynamically allocated objects prior to shutdown
+
+        // Parse command line options, set some standard options from the input
+        // file, initialize the restart database (if this is a restarted run),
+        // and enable file logging.
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "adv_diff.log");
+        Pointer<Database> input_db = app_initializer->getInputDatabase();
+        Pointer<Database> main_db = app_initializer->getComponentDatabase("Main");
+
+        // Get various standard options set in the input file.
+        const bool dump_viz_data = app_initializer->dumpVizData();
+        const int viz_dump_interval = app_initializer->getVizDumpInterval();
+        const bool uses_visit = dump_viz_data && app_initializer->getVisItDataWriter();
+
+        const bool dump_restart_data = app_initializer->dumpRestartData();
+        const int restart_dump_interval = app_initializer->getRestartDumpInterval();
+        const std::string restart_dump_dirname = app_initializer->getRestartDumpDirectory();
+
+        const bool dump_timer_data = app_initializer->dumpTimerData();
+        const int timer_dump_interval = app_initializer->getTimerDumpInterval();
+
+        // Create major algorithm and data objects that comprise the
+        // application.  These objects are configured from the input database
+        // and, if this is a restarted run, from the restart database.
+        Pointer<CartesianGridGeometry<NDIM>> grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<SLAdvIntegrator> time_integrator =
+            new SLAdvIntegrator("SLAdvIntegrator", app_initializer->getComponentDatabase("SLAdvIntegrator"), false);
+
+        Pointer<PatchHierarchy<NDIM>> patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<StandardTagAndInitialize<NDIM>> error_detector =
+            new StandardTagAndInitialize<NDIM>("StandardTagAndInitialize",
+                                               time_integrator,
+                                               app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<BergerRigoutsos<NDIM>> box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM>> load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM>> gridding_algorithm =
+            new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                        app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                        error_detector,
+                                        box_generator,
+                                        load_balancer);
+
+        // Setup the advection velocity.
+        Pointer<FaceVariable<NDIM, double>> u_var = new FaceVariable<NDIM, double>("u");
+        Pointer<CartGridFunction> u_fcn;
+        Pointer<CartGridFunction> u_adv_fcn;
+        time_integrator->registerAdvectionVelocity(u_var);
+        time_integrator->setAdvectionVelocityIsDivergenceFree(u_var, false);
+        u_fcn = new muParserCartGridFunction(
+            "UFunction", app_initializer->getComponentDatabase("UFunction"), grid_geometry);
+        time_integrator->setAdvectionVelocityFunction(u_var, u_fcn);
+
+        // Setup level set
+        Pointer<NodeVariable<NDIM, double>> ls_var = new NodeVariable<NDIM, double>("ls");
+        PointwiseFunctions::ScalarFcn ls_fcn = [](double, const VectorNd&, double) -> double { return -1.0; };
+        Pointer<ADS::PointwiseFunction<PointwiseFunctions::ScalarFcn>> ls_hier_fcn =
+            new ADS::PointwiseFunction("ls_fcn", ls_fcn);
+        Pointer<LSFromLevelSet> ls_vol_fcn = new LSFromLevelSet("ls_fcn", patch_hierarchy);
+        ls_vol_fcn->registerLSFcn(ls_hier_fcn);
+        time_integrator->registerLevelSetVariable(ls_var);
+        time_integrator->registerLevelSetVolFunction(ls_var, ls_vol_fcn);
+
+        // Setup advected quantity
+        Pointer<CellVariable<NDIM, double>> Q_var = new CellVariable<NDIM, double>("Q");
+        Pointer<CartGridFunction> Q_init = new QFcn("QInit");
+        const bool periodic_domain = grid_geometry->getPeriodicShift().min() > 0;
+        std::vector<RobinBcCoefStrategy<NDIM>*> Q_bcs(1);
+        if (!periodic_domain)
+        {
+            const std::string Q_bcs_name = "Q_bcs";
+            Q_bcs[0] =
+                new muParserRobinBcCoefs(Q_bcs_name, app_initializer->getComponentDatabase(Q_bcs_name), grid_geometry);
+        }
+
+        time_integrator->registerTransportedQuantity(Q_var);
+        time_integrator->restrictToLevelSet(Q_var, ls_var);
+        time_integrator->setAdvectionVelocity(Q_var, u_var);
+        time_integrator->setInitialConditions(Q_var, Q_init);
+        time_integrator->setPhysicalBcCoef(Q_var, Q_bcs[0]);
+
+        // Set up visualization plot file writer.
+        Pointer<VisItDataWriter<NDIM>> visit_data_writer = app_initializer->getVisItDataWriter();
+        if (uses_visit)
+        {
+            time_integrator->registerVisItDataWriter(visit_data_writer);
+        }
+
+        // Register a drawing variable with the data writer
+        auto var_db = VariableDatabase<NDIM>::getDatabase();
+        Pointer<CellVariable<NDIM, double>> u_draw_var = new CellVariable<NDIM, double>("U", NDIM);
+        const int u_draw_idx = var_db->registerVariableAndContext(u_draw_var, var_db->getContext("Draw"));
+        visit_data_writer->registerPlotQuantity("U", "VECTOR", u_draw_idx);
+        for (int d = 0; d < NDIM; ++d)
+            visit_data_writer->registerPlotQuantity("U_" + std::to_string(d), "SCALAR", u_draw_idx, d);
+
+        // Initialize hierarchy configuration and data on all patches.
+        time_integrator->initializePatchHierarchy(patch_hierarchy, gridding_algorithm);
+
+        // Close the restart manager.
+        RestartManager::getManager()->closeRestartFile();
+
+        // Print the input database contents to the log file.
+        plog << "Input database:\n";
+        input_db->printClassData(plog);
+
+        double dt = time_integrator->getMaximumTimeStepSize();
+
+        // Write out initial visualization data.
+        int iteration_num = time_integrator->getIntegratorStep();
+        double loop_time = time_integrator->getIntegratorTime();
+        // Uncomment to write viz files
+        // #define WRITE_VIZ_FILES
+        if (dump_viz_data && uses_visit)
+        {
+            pout << "\n\nWriting visualization files...\n\n";
+            time_integrator->setupPlotData();
+            time_integrator->allocatePatchData(u_draw_idx, loop_time);
+            u_fcn->setDataOnPatchHierarchy(u_draw_idx, u_draw_var, patch_hierarchy, loop_time);
+#ifdef WRITE_VIZ_FILES
+            visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+#endif
+            time_integrator->deallocatePatchData(u_draw_idx);
+        }
+
+        // Main time step loop.
+        double loop_time_end = time_integrator->getEndTime();
+        while (!MathUtilities<double>::equalEps(loop_time, loop_time_end) && time_integrator->stepsRemaining())
+        {
+            iteration_num = time_integrator->getIntegratorStep();
+            loop_time = time_integrator->getIntegratorTime();
+
+            pout << "\n";
+            pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+            pout << "At beginning of timestep # " << iteration_num << "\n";
+            pout << "Simulation time is " << loop_time << "\n";
+
+            dt = time_integrator->getMaximumTimeStepSize();
+            time_integrator->advanceHierarchy(dt);
+            loop_time += dt;
+
+            pout << "\n";
+            pout << "At end       of timestep # " << iteration_num << "\n";
+            pout << "Simulation time is " << loop_time << "\n";
+            pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+            pout << "\n";
+
+            // At specified intervals, write visualization and restart files,
+            // and print out timer data.
+            iteration_num += 1;
+            const bool last_step = !time_integrator->stepsRemaining();
+            if (dump_viz_data && uses_visit && (iteration_num % viz_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting visualization files...\n\n";
+                time_integrator->setupPlotData();
+                time_integrator->allocatePatchData(u_draw_idx, loop_time);
+                u_fcn->setDataOnPatchHierarchy(u_draw_idx, u_draw_var, patch_hierarchy, loop_time);
+#ifdef WRITE_VIZ_FILES
+                visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+#endif
+                time_integrator->deallocatePatchData(u_draw_idx);
+            }
+            if (dump_restart_data && (iteration_num % restart_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting restart files...\n\n";
+                RestartManager::getManager()->writeRestartFile(restart_dump_dirname, iteration_num);
+            }
+            if (dump_timer_data && (iteration_num % timer_dump_interval == 0 || last_step))
+            {
+                pout << "\nWriting timer data...\n\n";
+                TimerManager::getManager()->print(plog);
+                TimerManager::getManager()->resetAllTimers();
+            }
+        }
+
+        // Compute errors
+        const int Q_cur_idx = var_db->mapVariableAndContextToIndex(Q_var, time_integrator->getCurrentContext());
+        const int Q_err_idx = var_db->registerClonedPatchDataIndex(Q_var, Q_cur_idx);
+        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->allocatePatchData(Q_err_idx);
+        }
+
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(patch_hierarchy);
+        HierarchyMathOps hier_math_ops("hier_math_ops", patch_hierarchy);
+        const int wgt_cc_idx = hier_math_ops.getCellWeightPatchDescriptorIndex();
+
+        Q_init->setDataOnPatchHierarchy(Q_err_idx, Q_var, patch_hierarchy, loop_time);
+        hier_cc_data_ops.subtract(Q_cur_idx, Q_cur_idx, Q_err_idx);
+        pout << "Computing error norms:\n";
+        pout << "  L1-norm:  " << hier_cc_data_ops.L1Norm(Q_cur_idx, wgt_cc_idx) << "\n";
+        pout << "  L2-norm:  " << hier_cc_data_ops.L2Norm(Q_cur_idx, wgt_cc_idx) << "\n";
+        pout << "  max-norm: " << hier_cc_data_ops.maxNorm(Q_cur_idx, wgt_cc_idx) << "\n";
+
+        time_integrator->setupPlotData();
+        time_integrator->allocatePatchData(u_draw_idx, loop_time);
+        u_fcn->setDataOnPatchHierarchy(u_draw_idx, u_draw_var, patch_hierarchy, loop_time);
+#ifdef WRITE_VIZ_FILES
+        visit_data_writer->writePlotData(patch_hierarchy, iteration_num + 1, loop_time);
+#endif
+        time_integrator->deallocatePatchData(u_draw_idx);
+
+        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->deallocatePatchData(Q_err_idx);
+        }
+
+        if (!periodic_domain) delete Q_bcs[0];
+    } // cleanup dynamically allocated objects prior to shutdown
+
+    SAMRAIManager::shutdown();
+    PetscFinalize();
+    return 0;
+} // main

--- a/tests/examples/compressible/QFcn.cpp
+++ b/tests/examples/compressible/QFcn.cpp
@@ -1,0 +1,41 @@
+#include "ibamr/config.h"
+
+#include "ADS/app_namespaces.h"
+
+#include "QFcn.h"
+
+#include <SAMRAI_config.h>
+
+#include <array>
+
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+
+QFcn::QFcn(string object_name) : CartGridFunction(std::move(object_name))
+{
+    // intentionally blank
+    return;
+} // QFcn
+
+void
+QFcn::setDataOnPatch(const int data_idx,
+                     Pointer<hier::Variable<NDIM>> var,
+                     Pointer<Patch<NDIM>> patch,
+                     const double t,
+                     const bool initial_time,
+                     Pointer<PatchLevel<NDIM>> level)
+{
+    Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
+    const double* const dx = pgeom->getDx();
+    const double* const xlow = pgeom->getXLower();
+    const hier::Index<NDIM>& idx_low = patch->getBox().lower();
+
+    Pointer<CellData<NDIM, double>> Q_data = patch->getPatchData(data_idx);
+    for (CellIterator<NDIM> ci(patch->getBox()); ci; ci++)
+    {
+        const CellIndex<NDIM>& idx = ci();
+        VectorNd x;
+        for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
+        (*Q_data)(idx) = std::pow(std::cos(M_PI * (x[0])) * std::cos(M_PI * (x[1])), 2.0);
+    }
+    return;
+} // setDataOnPatch

--- a/tests/examples/compressible/QFcn.h
+++ b/tests/examples/compressible/QFcn.h
@@ -1,0 +1,44 @@
+#ifndef included_QFcn
+#define included_QFcn
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibamr/AdvDiffHierarchyIntegrator.h>
+
+#include <ibtk/CartGridFunction.h>
+#include <ibtk/ibtk_utilities.h>
+
+#include <CartesianGridGeometry.h>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+/*!
+ * \brief Method to initialize the value of the advected scalar Q.
+ */
+class QFcn : public IBTK::CartGridFunction
+{
+public:
+    /*!
+     * \brief Constructor.
+     */
+    QFcn(std::string object_name);
+
+    /*!
+     * Indicates whether the concrete CartGridFunction object is time dependent.
+     */
+    bool isTimeDependent() const
+    {
+        return true;
+    }
+
+    /*!
+     * Set the data on the patch interior to the exact answer. Note that we are setting the cell average here.
+     */
+    void setDataOnPatch(int data_idx,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM>> var,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch,
+                        double data_time,
+                        bool initial_time = false,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>> level =
+                            SAMRAI::tbox::Pointer<SAMRAI::hier::PatchLevel<NDIM>>(nullptr)) override;
+};
+#endif // #ifndef included_ADS_QFcn

--- a/tests/examples/compressible_2d.input
+++ b/tests/examples/compressible_2d.input
@@ -1,0 +1,140 @@
+// physical parameters
+PI = 3.14159265359
+L = 1.0
+
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 16                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+H = L/NFINEST
+CFL_MAX = 0.5
+U_MAX = 2.0
+DT_MIN = H * CFL_MAX 
+DT_MAX = DT_MIN
+END_TIME = 1.0
+REGRID_INTERVAL = 1
+TAG_BUFFER = 1
+
+MIN_REFINE_FACTOR = -4.0
+MAX_REFINE_FACTOR = 2.0
+LEAST_SQUARES_ORDER = "QUADRATIC"
+USE_STRANG_SPLITTING = TRUE
+USE_OUTSIDE_LS_FOR_TAGGING = TRUE
+ADV_INT_METHOD = "MIDPOINT_RULE"
+DIF_INT_METHOD = "TRAPEZOIDAL_RULE"
+USE_RBFS =  TRUE
+RBF_STENCIL_SIZE = 12
+RBF_POLY_ORDER = "QUADRATIC"
+
+UFunction {
+   function_0 = "sin(2*PI*t)*cos(PI*X_0)*cos(PI*X_1)"
+   function_1 = "sin(2*PI*t)*cos(PI*X_1)*cos(PI*X_0)"
+}
+
+Q_bcs {
+    acoef_function_0 = "0.0"
+    acoef_function_1 = "0.0"
+    acoef_function_2 = "0.0"
+    acoef_function_3 = "0.0"
+
+    bcoef_function_0 = "1.0"
+    bcoef_function_1 = "1.0"
+    bcoef_function_2 = "1.0"
+    bcoef_function_3 = "1.0"
+
+    gcoef_function_0 = "0.0"
+    gcoef_function_1 = "0.0"
+    gcoef_function_2 = "0.0"
+    gcoef_function_3 = "0.0"
+}
+
+Main {
+
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt"
+   viz_dump_interval           = 8
+   viz_dump_dirname            = "viz_adv_diff2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_adv_diff2d"
+
+   data_dump_interval          = NFINEST/8
+   data_dump_dirname           = "hier_data_IB2d"
+
+   timer_dump_interval = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = -L,-L
+   x_up = L,L
+   periodic_dimension = 1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.9e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.9e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "GRADIENT_DETECTOR"
+   RefineBoxes {
+      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = TRUE
+   print_total     = TRUE
+   print_threshold = 0.0
+   timer_list      = "LS::*::*","IBAMR::*::*","IBTK::*::*"
+}
+
+
+SLAdvIntegrator {
+    start_time           = 0.0e0  // initial simulation time
+    end_time             = END_TIME    // final simulation time
+    grow_dt              = 2.0e0  // growth factor for timesteps
+    regrid_interval      = REGRID_INTERVAL  // effectively disable regridding
+    cfl                  = CFL_MAX
+    dt_max               = DT_MAX
+    dt_min               = DT_MIN
+    enable_logging       = TRUE
+
+    min_ls_refine_factor = MIN_REFINE_FACTOR
+    max_ls_refine_factor = MAX_REFINE_FACTOR
+    least_squares_order = LEAST_SQUARES_ORDER
+    advection_ts_type = ADV_INT_METHOD
+    use_rbfs = USE_RBFS
+    rbf_stencil_size = RBF_STENCIL_SIZE
+    rbf_poly_order = RBF_POLY_ORDER
+    default_adv_reconstruct_type = "RBF"
+
+    tag_buffer = TAG_BUFFER
+    
+    num_cycles = 1
+}

--- a/tests/examples/compressible_2d.output
+++ b/tests/examples/compressible_2d.output
@@ -1,0 +1,1058 @@
+SLAdvIntegrator: initializing Hierarchy integrator.
+SLAdvIntegrator::initializePatchHierarchy(): tag_buffer = 0
+SLAdvIntegrator: initializing level data
+Setting level set at initial time: 1
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: initializing level set for: ls
+Setting Level set at time 0
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: Initializing data for variable: Q
+SLAdvIntegrator: Finished initializing composite data
+Input database:
+input_db {
+   PI                         = 3.14159                     // input not used
+   L                          = 1                           // input used
+   MAX_LEVELS                 = 1                           // input used
+   REF_RATIO                  = 4                           // input used
+   N                          = 16                          // input used
+   NFINEST                    = 16                          // input used
+   H                          = 0.0625                      // input used
+   CFL_MAX                    = 0.5                         // input used
+   U_MAX                      = 2                           // input not used
+   DT_MIN                     = 0.03125                     // input used
+   DT_MAX                     = 0.03125                     // input used
+   END_TIME                   = 1                           // input used
+   REGRID_INTERVAL            = 1                           // input used
+   TAG_BUFFER                 = 1                           // input used
+   MIN_REFINE_FACTOR          = -4                          // input used
+   MAX_REFINE_FACTOR          = 2                           // input used
+   LEAST_SQUARES_ORDER        = "QUADRATIC"                 // input used
+   USE_STRANG_SPLITTING       = TRUE                        // input not used
+   USE_OUTSIDE_LS_FOR_TAGGING = TRUE                        // input not used
+   ADV_INT_METHOD             = "MIDPOINT_RULE"             // input used
+   DIF_INT_METHOD             = "TRAPEZOIDAL_RULE"          // input not used
+   USE_RBFS                   = TRUE                        // input used
+   RBF_STENCIL_SIZE           = 12                          // input used
+   RBF_POLY_ORDER             = "QUADRATIC"                 // input used
+   UFunction {
+      function_0 = "sin(2*PI*t)*cos(PI*X_0)*cos(PI*X_1)"    // input used
+      function_1 = "sin(2*PI*t)*cos(PI*X_1)*cos(PI*X_0)"    // input used
+   }
+   Q_bcs {
+      acoef_function_0 = "0.0"                              // input not used
+      acoef_function_1 = "0.0"                              // input not used
+      acoef_function_2 = "0.0"                              // input not used
+      acoef_function_3 = "0.0"                              // input not used
+      bcoef_function_0 = "1.0"                              // input not used
+      bcoef_function_1 = "1.0"                              // input not used
+      bcoef_function_2 = "1.0"                              // input not used
+      bcoef_function_3 = "1.0"                              // input not used
+      gcoef_function_0 = "0.0"                              // input not used
+      gcoef_function_1 = "0.0"                              // input not used
+      gcoef_function_2 = "0.0"                              // input not used
+      gcoef_function_3 = "0.0"                              // input not used
+   }
+   Main {
+      log_file_name               = "output"                // input used
+      log_all_nodes               = FALSE                   // input used
+      viz_writer                  = "VisIt"                 // input used
+      viz_dump_interval           = 8                       // input used
+      viz_dump_dirname            = "viz_adv_diff2d"        // input used
+      visit_number_procs_per_file = 1                       // input used
+      restart_dump_interval       = 0                       // input used
+      restart_dump_dirname        = "restart_adv_diff2d"    // input used
+      data_dump_interval          = 2                       // input used
+      data_dump_dirname           = "hier_data_IB2d"        // input used
+      timer_dump_interval         = 0                       // input used
+   }
+   CartesianGeometry {
+      domain_boxes       = [(0,0),(15,15)]                  // input used
+      x_lo               = -1, -1                           // input used
+      x_up               = 1, 1                             // input used
+      periodic_dimension = 1, 1                             // input used
+   }
+   GriddingAlgorithm {
+      max_levels                = 1                         // input used
+      efficiency_tolerance      = 0.9                       // input used
+      combine_efficiency        = 0.9                       // input used
+      check_nonrefined_tags     = 'w'                       // from default
+      check_overlapping_patches = 'i'                       // from default
+      extend_tags_to_bdry       = FALSE                     // from default
+      ratio_to_coarser {
+         level_1 = 4, 4                                     // input not used
+         level_2 = 4, 4                                     // input not used
+         level_3 = 4, 4                                     // input not used
+      }
+      largest_patch_size {
+         level_0 = 512, 512                                 // input used
+      }
+      smallest_patch_size {
+         level_0 = 4, 4                                     // input used
+      }
+   }
+   StandardTagAndInitialize {
+      tagging_method = "GRADIENT_DETECTOR"                  // input used
+      RefineBoxes {
+         level_0 = [(4,4),(11,7)], [(4,8),(7,11)]           // input not used
+      }
+   }
+   LoadBalancer {
+      bin_pack_method                      = "SPATIAL"      // input used
+      max_workload_factor                  = 1              // input used
+      ignore_level_box_union_is_single_box = FALSE          // from default
+   }
+   TimerManager {
+      print_exclusive      = TRUE                           // input used
+      print_total          = TRUE                           // input used
+      print_threshold      = 0                              // input used
+      timer_list           = "LS::*::*", "IBAMR::*::*", "IBTK::*::*" // input used
+      print_processor      = TRUE                           // from default
+      print_max            = FALSE                          // from default
+      print_summed         = FALSE                          // from default
+      print_user           = FALSE                          // from default
+      print_sys            = FALSE                          // from default
+      print_wall           = TRUE                           // from default
+      print_percentage     = TRUE                           // from default
+      print_concurrent     = FALSE                          // from default
+      print_timer_overhead = FALSE                          // from default
+   }
+   SLAdvIntegrator {
+      start_time                   = 0                      // input used
+      end_time                     = 1                      // input used
+      grow_dt                      = 2                      // input used
+      regrid_interval              = 1                      // input used
+      cfl                          = 0.5                    // input used
+      dt_max                       = 0.03125                // input used
+      dt_min                       = 0.03125                // input used
+      enable_logging               = TRUE                   // input used
+      min_ls_refine_factor         = -4                     // input used
+      max_ls_refine_factor         = 2                      // input used
+      least_squares_order          = "QUADRATIC"            // input used
+      advection_ts_type            = "MIDPOINT_RULE"        // input used
+      use_rbfs                     = TRUE                   // input used
+      rbf_stencil_size             = 12                     // input used
+      rbf_poly_order               = "QUADRATIC"            // input used
+      default_adv_reconstruct_type = "RBF"                  // input used
+      tag_buffer                   = 1                      // input used
+      num_cycles                   = 1                      // input used
+      mls_stencil_size             = 8                      // from default
+   }
+}
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 0
+Simulation time is 0
+SLAdvIntegrator::advanceHierarchy(): time interval = [0,0.03125], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 0
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.03125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 0
+Simulation time is 0.03125
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 1
+Simulation time is 0.03125
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.03125,0.0625], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 1
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.03125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.0625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 1
+Simulation time is 0.0625
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 2
+Simulation time is 0.0625
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.0625,0.09375], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 2
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.0625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.09375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 2
+Simulation time is 0.09375
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 3
+Simulation time is 0.09375
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.09375,0.125], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 3
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.09375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 3
+Simulation time is 0.125
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 4
+Simulation time is 0.125
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.125,0.15625], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 4
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.15625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 4
+Simulation time is 0.15625
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 5
+Simulation time is 0.15625
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.15625,0.1875], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 5
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.15625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.1875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 5
+Simulation time is 0.1875
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 6
+Simulation time is 0.1875
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.1875,0.21875], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 6
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.1875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.21875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 6
+Simulation time is 0.21875
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 7
+Simulation time is 0.21875
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.21875,0.25], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 7
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.21875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.25
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 7
+Simulation time is 0.25
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 8
+Simulation time is 0.25
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.25,0.28125], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 8
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.25
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.28125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 8
+Simulation time is 0.28125
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 9
+Simulation time is 0.28125
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.28125,0.3125], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 9
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.28125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.3125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 9
+Simulation time is 0.3125
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 10
+Simulation time is 0.3125
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.3125,0.34375], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 10
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.3125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.34375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 10
+Simulation time is 0.34375
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 11
+Simulation time is 0.34375
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.34375,0.375], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 11
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.34375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 11
+Simulation time is 0.375
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 12
+Simulation time is 0.375
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.375,0.40625], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 12
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.40625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 12
+Simulation time is 0.40625
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 13
+Simulation time is 0.40625
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.40625,0.4375], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 13
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.40625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.4375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 13
+Simulation time is 0.4375
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 14
+Simulation time is 0.4375
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.4375,0.46875], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 14
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.4375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.46875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 14
+Simulation time is 0.46875
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 15
+Simulation time is 0.46875
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.46875,0.5], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 15
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.46875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.5
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 15
+Simulation time is 0.5
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 16
+Simulation time is 0.5
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.5,0.53125], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 16
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.5
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.53125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 16
+Simulation time is 0.53125
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 17
+Simulation time is 0.53125
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.53125,0.5625], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 17
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.53125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.5625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 17
+Simulation time is 0.5625
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 18
+Simulation time is 0.5625
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.5625,0.59375], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 18
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.5625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.59375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 18
+Simulation time is 0.59375
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 19
+Simulation time is 0.59375
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.59375,0.625], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 19
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.59375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 19
+Simulation time is 0.625
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 20
+Simulation time is 0.625
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.625,0.65625], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 20
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.65625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 20
+Simulation time is 0.65625
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 21
+Simulation time is 0.65625
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.65625,0.6875], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 21
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.65625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.6875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 21
+Simulation time is 0.6875
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 22
+Simulation time is 0.6875
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.6875,0.71875], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 22
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.6875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.71875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 22
+Simulation time is 0.71875
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 23
+Simulation time is 0.71875
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.71875,0.75], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 23
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.71875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.75
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 23
+Simulation time is 0.75
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 24
+Simulation time is 0.75
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.75,0.78125], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 24
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.75
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.78125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 24
+Simulation time is 0.78125
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 25
+Simulation time is 0.78125
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.78125,0.8125], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 25
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.78125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.8125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 25
+Simulation time is 0.8125
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 26
+Simulation time is 0.8125
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.8125,0.84375], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 26
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.8125
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.84375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 26
+Simulation time is 0.84375
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 27
+Simulation time is 0.84375
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.84375,0.875], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 27
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.84375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 27
+Simulation time is 0.875
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 28
+Simulation time is 0.875
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.875,0.90625], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 28
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.90625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 28
+Simulation time is 0.90625
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 29
+Simulation time is 0.90625
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.90625,0.9375], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 29
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.90625
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.9375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 29
+Simulation time is 0.9375
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 30
+Simulation time is 0.9375
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.9375,0.96875], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 30
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.9375
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 0.96875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 30
+Simulation time is 0.96875
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
++++++++++++++++++++++++++++++++++++++++++++++++++++
+At beginning of timestep # 31
+Simulation time is 0.96875
+SLAdvIntegrator::advanceHierarchy(): time interval = [0.96875,1], dt = 0.03125
+SLAdvIntegrator::advanceHierarchy(): regridding prior to timestep 31
+SLAdvIntegrator: initializing composite Hierarchy data
+SLAdvIntegrator: Finished initializing composite data
+Setting Level set at time 0.96875
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator::advanceHierarchy(): integrating hierarchy
+SLAdvIntegrator::advanceHierarchy(): executing cycle 1 of 2
+SLAdvIntegrator::advanceHierarchy(): executing cycle 2 of 2
+Setting Level set at time 1
+Minimum volume on level:     0 is: 0.015625
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 4
+SLAdvIntegrator: advecting Q
+SLAdvIntegrator::integrateHierarchy() finished advection update for variable: Q
+SLAdvIntegrator::advanceHierarchy(): synchronizing updated data
+SLAdvIntegrator::advanceHierarchy(): resetting time dependent data
+
+At end       of timestep # 31
+Simulation time is 1
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+Writing visualization files...
+
+Computing error norms:
+  L1-norm:  0.273944
+  L2-norm:  0.210785
+  max-norm: 0.340455


### PR DESCRIPTION
This adds an option to `SLAdvIntegrator` to advect quantities in a compressible velocity field. Instead of advecting `q`, we advect `J*q` in which `J` is the Jacobian of the deformation map. Effectively, this means we reconstruct $J_{n+1/2} = e^{-\Delta t \nabla\cdot\mathbf{u}}$ at half interval departure points.

This gives second order accuracy.