### PR TITLE
Updates to advection operators

### DIFF
--- a/examples/peristalsis/main.cpp
+++ b/examples/peristalsis/main.cpp
@@ -453,7 +453,8 @@ main(int argc, char* argv[])
             auto adv_op_reconstruct =
                 std::make_shared<LagrangeStructureReconstructions>("RBFReconstruct", input_db->getDatabase("AdvOps"));
             adv_op_reconstruct->setCutCellMapping(cut_cell_mapping);
-            adv_op_reconstruct->setQSystemName(Q_exact_str);
+            adv_op_reconstruct->setInsideQSystemName(Q_exact_str);
+            adv_op_reconstruct->setReconstructionOutside(false);
             adv_diff_integrator->registerAdvectionReconstruction(Q_var, adv_op_reconstruct);
         }
 

--- a/include/ADS/LagrangeStructureReconstructions.h
+++ b/include/ADS/LagrangeStructureReconstructions.h
@@ -67,7 +67,8 @@ public:
     /*!
      * \brief Provide the structural system name for the exact solution.
      */
-    void setQSystemName(std::string Q_sys_name);
+    void setInsideQSystemName(std::string Q_sys_name);
+    void setOutsideQSystemName(std::string Q_sys_name);
 
 private:
     /*!
@@ -88,7 +89,7 @@ private:
     SAMRAI::tbox::Pointer<CutCellVolumeMeshMapping> d_cut_cell_mapping;
 
     // Structural value information
-    std::string d_Q_sys_name;
+    std::string d_Q_in_sys_name, d_Q_out_sys_name;
 
     // Truncation info
     double d_low_cutoff = -std::numeric_limits<double>::max();

--- a/include/ADS/LagrangeStructureReconstructions.h
+++ b/include/ADS/LagrangeStructureReconstructions.h
@@ -18,7 +18,16 @@ namespace ADS
 {
 /*!
  * \brief Class LagrangeStructureReconstructions is a abstract class for an implementation of
- * a convective differencing operator.
+ * a semi-Lagrangian interpolation operator for the advection equation.
+ *
+ * Uses polyharmonic splines near the structure and limited quadratic Lagrange interpolants away from the structure.
+ *
+ * The input database is searched for the following items:
+ * - stencil_size: Total number of points to be used for polyharmonic spline.
+ * - rbf_order: Order for polynomials to be appended to RBF.
+ * - low_cutoff: Minimum allowable reconstructed value (used to limit reconstruction).
+ * - high_cutoff: Largest allowable reconstructed value (used to limit reconstruction).
+ * - default_value: Default value to use for reconstructing in invalid regions.
  */
 class LagrangeStructureReconstructions : public AdvectiveReconstructionOperator
 {
@@ -55,20 +64,31 @@ public:
     void deallocateOperatorState() override;
 
     /*!
-     * \brief Compute N = u * grad Q.
+     * \brief Interpolate Q interpolated to positions stored in path_idx. End result is given in N_idx.
      */
     void applyReconstruction(int Q_idx, int N_idx, int path_idx) override;
 
     /*!
-     * \brief Provide information on the location of the mesh
+     * \brief Provide information on the location of the mesh.
      */
     void setCutCellMapping(SAMRAI::tbox::Pointer<CutCellVolumeMeshMapping> mesh_partitioner);
 
     /*!
-     * \brief Provide the structural system name for the exact solution.
+     * \brief Provide the structural system name for the exact solution on the "interior" side of the object.
      */
     void setInsideQSystemName(std::string Q_sys_name);
+
+    /*!
+     * \brief Provide the structural system name for the exact solution on the "exterior" side of the object.
+     *
+     * \note This is only used if reconstruct_outside is true, see setReconstructionSides.
+     */
     void setOutsideQSystemName(std::string Q_sys_name);
+
+    /*!
+     * Specify whether to reconstruct on the outside the structure.
+     */
+    void setReconstructionOutside(bool reconstruct_outside);
 
 private:
     /*!
@@ -94,6 +114,8 @@ private:
     // Truncation info
     double d_low_cutoff = -std::numeric_limits<double>::max();
     double d_high_cutoff = std::numeric_limits<double>::max();
+    bool d_reconstruct_outside = true;
+    double d_default_value = 0.0;
 };
 } // namespace ADS
 

--- a/include/ADS/LagrangeStructureReconstructions.h
+++ b/include/ADS/LagrangeStructureReconstructions.h
@@ -81,12 +81,15 @@ public:
     /*!
      * \brief Provide the structural system name for the exact solution on the "exterior" side of the object.
      *
-     * \note This is only used if reconstruct_outside is true, see setReconstructionSides.
+     * \note This is only used if reconstruct_outside is true, see setReconstructionOutside.
      */
     void setOutsideQSystemName(std::string Q_sys_name);
 
     /*!
-     * Specify whether to reconstruct on the outside the structure.
+     * Specify whether to reconstruct on the outside the structure. If this is set to false, then the default value is
+     * used in outside grid cells.
+     *
+     * This is by default set to true.
      */
     void setReconstructionOutside(bool reconstruct_outside);
 

--- a/include/ADS/RBFDivergenceReconstructions.h
+++ b/include/ADS/RBFDivergenceReconstructions.h
@@ -68,8 +68,8 @@ private:
     void applyReconstructionLS(int Q_idx, int N_idx, int path_idx);
 
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> d_hierarchy;
-    Reconstruct::RBFPolyOrder d_rbf_order = Reconstruct::RBFPolyOrder::LINEAR;
-    unsigned int d_rbf_stencil_size = 5;
+    Reconstruct::RBFPolyOrder d_rbf_order = Reconstruct::RBFPolyOrder::QUADRATIC;
+    unsigned int d_rbf_stencil_size = 12;
 
     // Scratch data
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_u_scr_var;

--- a/include/ADS/RBFDivergenceReconstructions.h
+++ b/include/ADS/RBFDivergenceReconstructions.h
@@ -11,6 +11,7 @@
 #include "ADS/reconstructions.h"
 
 #include "CellVariable.h"
+#include "SideVariable.h"
 
 /////////////////////////////// CLASS DEFINITION /////////////////////////////
 
@@ -73,6 +74,8 @@ private:
     // Scratch data
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_u_scr_var;
     int d_u_scr_idx = IBTK::invalid_index;
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_div_var;
+    int d_div_idx = IBTK::invalid_index;
 
     // Weight caching
     bool d_weights_cached = false;

--- a/include/ADS/private/ls_functions_inc.h
+++ b/include/ADS/private/ls_functions_inc.h
@@ -357,8 +357,8 @@ node_to_side(const SAMRAI::pdat::SideIndex<NDIM>& idx, const SAMRAI::pdat::NodeD
 #if (NDIM == 2)
     if (idx.getAxis() == 0)
     {
-        SAMRAI::pdat::NodeIndex<NDIM> idx_l(idx.toCell(0), SAMRAI::pdat::NodeIndex<NDIM>::UpperLeft);
-        SAMRAI::pdat::NodeIndex<NDIM> idx_u(idx.toCell(0), SAMRAI::pdat::NodeIndex<NDIM>::LowerLeft);
+        SAMRAI::pdat::NodeIndex<NDIM> idx_l(idx.toCell(0), SAMRAI::pdat::NodeIndex<NDIM>::UpperRight);
+        SAMRAI::pdat::NodeIndex<NDIM> idx_u(idx.toCell(0), SAMRAI::pdat::NodeIndex<NDIM>::LowerRight);
         return 0.5 * (ls_data(idx_l) + ls_data(idx_u));
     }
     else

--- a/include/ADS/private/reconstructions_inc.h
+++ b/include/ADS/private/reconstructions_inc.h
@@ -7,8 +7,57 @@
 
 #include <Eigen/Dense>
 
+#include <exception>
+
 namespace Reconstruct
 {
+inline void
+floodFillForPoints(std::vector<SAMRAI::pdat::CellIndex<NDIM>>& fill_pts,
+                   const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                   const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                   const double ls,
+                   const size_t stencil_size)
+{
+    // Flood fill for Eulerian points
+    std::vector<SAMRAI::pdat::CellIndex<NDIM>> test_idxs = { idx };
+    unsigned int i = 0;
+    while (fill_pts.size() < stencil_size)
+    {
+#ifndef NDEBUG
+        if (i >= test_idxs.size())
+        {
+            std::ostringstream err_msg;
+            err_msg << "Could not find enough cells to fill stencil.\n";
+            err_msg << "  Starting at base point " << idx << "\n";
+            err_msg << "  ls value: " << ls << "\n";
+            err_msg << "  Searched " << i << " indices and found " << fill_pts.size() << " total pts\n";
+            throw std::runtime_error(err_msg.str());
+        }
+#endif
+        const SAMRAI::pdat::CellIndex<NDIM>& new_idx = test_idxs[i];
+        // Add new idx to list of X_vals
+        if (ADS::node_to_cell(new_idx, ls_data) * ls > 0.0) fill_pts.push_back(new_idx);
+
+        // Add neighboring points to new_idxs.
+        SAMRAI::hier::IntVector<NDIM> l(-1, 0), r(1, 0), b(0, -1), u(0, 1);
+        SAMRAI::pdat::CellIndex<NDIM> idx_l(new_idx + l), idx_r(new_idx + r);
+        SAMRAI::pdat::CellIndex<NDIM> idx_u(new_idx + u), idx_b(new_idx + b);
+        if (ADS::node_to_cell(idx_l, ls_data) * ls > 0.0 &&
+            (std::find(test_idxs.begin(), test_idxs.end(), idx_l) == test_idxs.end()))
+            test_idxs.push_back(idx_l);
+        if (ADS::node_to_cell(idx_r, ls_data) * ls > 0.0 &&
+            (std::find(test_idxs.begin(), test_idxs.end(), idx_r) == test_idxs.end()))
+            test_idxs.push_back(idx_r);
+        if (ADS::node_to_cell(idx_u, ls_data) * ls > 0.0 &&
+            (std::find(test_idxs.begin(), test_idxs.end(), idx_u) == test_idxs.end()))
+            test_idxs.push_back(idx_u);
+        if (ADS::node_to_cell(idx_b, ls_data) * ls > 0.0 &&
+            (std::find(test_idxs.begin(), test_idxs.end(), idx_b) == test_idxs.end()))
+            test_idxs.push_back(idx_b);
+        ++i;
+    }
+}
+
 template <class Point>
 void
 RBFFDReconstruct(std::vector<double>& wgts,
@@ -54,6 +103,45 @@ RBFFDReconstruct(std::vector<double>& wgts,
     wgts.resize(stencil_size);
     for (int i = 0; i < stencil_size; ++i) wgts[i] = weights[i];
 }
+
+inline double
+quadraticLagrangeInterpolant(const IBTK::VectorNd& x,
+                             const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                             const SAMRAI::pdat::CellData<NDIM, double>& Q_data)
+{
+    SAMRAI::hier::IntVector<NDIM> one_x(1, 0), one_y(0, 1);
+    return Q_data(idx) * (x[0] - 1.0) * (x[0] + 1.0) * (x[1] - 1.0) * (x[1] + 1.0) -
+           Q_data(idx + one_x) * 0.5 * x[0] * (x[0] + 1.0) * (x[1] - 1.0) * (x[1] + 1.0) -
+           Q_data(idx - one_x) * 0.5 * x[0] * (x[0] - 1.0) * (x[1] - 1.0) * (x[1] + 1.0) -
+           Q_data(idx + one_y) * 0.5 * x[1] * (x[1] + 1.0) * (x[0] - 1.0) * (x[0] + 1.0) -
+           Q_data(idx - one_y) * 0.5 * x[1] * (x[1] - 1.0) * (x[0] - 1.0) * (x[0] + 1.0);
+}
+
+inline double
+quadraticLagrangeInterpolantLimited(IBTK::VectorNd x,
+                                    const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                                    const SAMRAI::pdat::CellData<NDIM, double>& Q_data)
+{
+    double Q = quadraticLagrangeInterpolant(x, idx, Q_data);
+
+    SAMRAI::hier::IntVector<NDIM> one_x(1, 0), one_y(0, 1);
+    SAMRAI::pdat::CellIndex<NDIM> ll;
+    for (int d = 0; d < NDIM; ++d) ll(d) = idx(d) + std::round(x[d]);
+    double q00 = Q_data(ll);
+    double q10 = Q_data(ll + one_x);
+    double q01 = Q_data(ll + one_y);
+    double q11 = Q_data(ll + one_x + one_y);
+    if (Q > std::max({ q00, q10, q01, q11 }) || Q < std::min({ q00, q10, q01, q11 }))
+    {
+        // Need to potentially "reshift" x if it's the below idx.
+        for (int d = 0; d < NDIM; ++d) x[d] = x[d] - (idx(d) - ll(d));
+        Q = Q_data(ll) * (x[0] - 1.0) * (x[1] - 1.0) - Q_data(ll + one_y) * x[1] * (x[0] - 1.0) -
+            Q_data(ll + one_x) * x[0] * (x[1] - 1.0) + Q_data(ll + one_x + one_y) * x[0] * x[1];
+    }
+
+    return Q;
+}
+
 } // namespace Reconstruct
 
 #endif

--- a/include/ADS/reconstructions.h
+++ b/include/ADS/reconstructions.h
@@ -217,9 +217,9 @@ RBFFDReconstruct(std::vector<double>& wgts,
 /*!
  * Compute the quadratic Lagrange interpolant to the location x using an interpolant centered at idx.
  *
- * Note that x must be given in index space, and should be shifted so that idx corresponds to (0,0).
+ * Note that x must be given in index space.
  */
-double quadraticLagrangeInterpolant(const IBTK::VectorNd& x,
+double quadraticLagrangeInterpolant(IBTK::VectorNd x,
                                     const SAMRAI::pdat::CellIndex<NDIM>& idx,
                                     const SAMRAI::pdat::CellData<NDIM, double>& Q_data);
 
@@ -227,7 +227,7 @@ double quadraticLagrangeInterpolant(const IBTK::VectorNd& x,
  * Compute the quadratic Lagrange interpolant to the location x using an interpolant centered at idx. Limit the
  * interpolant if the reconstructed value falls outside the neighboring values.
  *
- * Note that x must be given in index space, and should be shifted so that idx corresponds to (0,0).
+ * Note that x must be given in index space.
  */
 double quadraticLagrangeInterpolantLimited(IBTK::VectorNd x,
                                            const SAMRAI::pdat::CellIndex<NDIM>& idx,

--- a/include/ADS/reconstructions.h
+++ b/include/ADS/reconstructions.h
@@ -40,8 +40,7 @@ string_to_enum(const std::string& /*val*/)
  * \brief Routine for converting enums to strings.
  */
 template <typename T>
-inline std::string
-enum_to_string(T /*val*/)
+inline std::string enum_to_string(T /*val*/)
 {
     TBOX_ERROR("UNSUPPORTED ENUM TYPE\n");
     return "UNKNOWN";
@@ -122,6 +121,22 @@ mls_weight(double r)
 }
 
 /*!
+ * Use a flood filling algorithm to find neighboring points to a given index. Uses the value of the level set to
+ * determine whether indices point to the same size.
+ *
+ * Note that fill_pts does not need to be empty. This function will append fill_pts until it's size is equal to
+ * stencil_size.
+ *
+ * If compiled with debugging flags, throws a runtime_error if the flood filling algorithm could not find the requested
+ * number of points.
+ */
+void floodFillForPoints(std::vector<SAMRAI::pdat::CellIndex<NDIM>>& fill_pts,
+                        const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                        const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                        double ls,
+                        size_t stencil_size);
+
+/*!
  * Reconstruct the data at position x_loc, using a stencil centered at idx. Only uses points that have a non-zero volume
  * fraction in vol_data. The reconstruction uses a polyharmonic spline fit.
  *
@@ -198,6 +213,25 @@ RBFFDReconstruct(std::vector<double>& wgts,
                  void* rbf_ctx,
                  std::function<IBTK::VectorXd(const std::vector<Point>&, int, double, const Point&, void*)> L_polys,
                  void* poly_ctx);
+
+/*!
+ * Compute the quadratic Lagrange interpolant to the location x using an interpolant centered at idx.
+ *
+ * Note that x must be given in index space, and should be shifted so that idx corresponds to (0,0).
+ */
+double quadraticLagrangeInterpolant(const IBTK::VectorNd& x,
+                                    const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                                    const SAMRAI::pdat::CellData<NDIM, double>& Q_data);
+
+/*!
+ * Compute the quadratic Lagrange interpolant to the location x using an interpolant centered at idx. Limit the
+ * interpolant if the reconstructed value falls outside the neighboring values.
+ *
+ * Note that x must be given in index space, and should be shifted so that idx corresponds to (0,0).
+ */
+double quadraticLagrangeInterpolantLimited(IBTK::VectorNd x,
+                                           const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                                           const SAMRAI::pdat::CellData<NDIM, double>& Q_data);
 } // namespace Reconstruct
 
 #include <ADS/private/reconstructions_inc.h>

--- a/src/adv_ops/LagrangeReconstructions.cpp
+++ b/src/adv_ops/LagrangeReconstructions.cpp
@@ -70,7 +70,7 @@ LagrangeReconstructions::applyReconstruction(const int Q_idx, const int N_idx, c
             {
                 const CellIndex<NDIM>& idx = ci();
                 VectorNd x_loc;
-                for (int d = 0; d < NDIM; ++d) x_loc[d] = (*xstar_data)(idx, d) - (static_cast<double>(idx(d)) + 0.5);
+                for (int d = 0; d < NDIM; ++d) x_loc[d] = (*xstar_data)(idx, d);
                 (*Q_new_data)(idx) = Reconstruct::quadraticLagrangeInterpolant(x_loc, idx, *Q_cur_data);
             }
         }

--- a/src/adv_ops/LagrangeReconstructions.cpp
+++ b/src/adv_ops/LagrangeReconstructions.cpp
@@ -71,37 +71,7 @@ LagrangeReconstructions::applyReconstruction(const int Q_idx, const int N_idx, c
                 const CellIndex<NDIM>& idx = ci();
                 VectorNd x_loc;
                 for (int d = 0; d < NDIM; ++d) x_loc[d] = (*xstar_data)(idx, d) - (static_cast<double>(idx(d)) + 0.5);
-                IntVector<NDIM> one_x(1, 0), one_y(0, 1);
-                (*Q_new_data)(idx) =
-                    (*Q_cur_data)(idx) * (x_loc[0] - 1.0) * (x_loc[0] + 1.0) * (x_loc[1] - 1.0) * (x_loc[1] + 1.0) -
-                    (*Q_cur_data)(idx + one_x) * 0.5 * x_loc[0] * (x_loc[0] + 1.0) * (x_loc[1] - 1.0) *
-                        (x_loc[1] + 1.0) -
-                    (*Q_cur_data)(idx - one_x) * 0.5 * x_loc[0] * (x_loc[0] - 1.0) * (x_loc[1] - 1.0) *
-                        (x_loc[1] + 1.0) -
-                    (*Q_cur_data)(idx + one_y) * 0.5 * x_loc[1] * (x_loc[1] + 1.0) * (x_loc[0] - 1.0) *
-                        (x_loc[0] + 1.0) -
-                    (*Q_cur_data)(idx - one_y) * 0.5 * x_loc[1] * (x_loc[1] - 1.0) * (x_loc[0] - 1.0) *
-                        (x_loc[0] + 1.0);
-                // Check if we need to limit.
-                // Grab "lower left" index
-                CellIndex<NDIM> ll;
-                for (int d = 0; d < NDIM; ++d) ll(d) = std::round((*xstar_data)(idx, d)) - 1.0;
-                double q00 = (*Q_cur_data)(ll);
-                double q10 = (*Q_cur_data)(ll + one_x);
-                double q01 = (*Q_cur_data)(ll + one_y);
-                double q11 = (*Q_cur_data)(ll + one_x + one_y);
-                if ((*Q_new_data)(idx) > std::max({ q00, q10, q01, q11 }) ||
-                    (*Q_new_data)(idx) < std::min({ q00, q10, q01, q11 }))
-                {
-                    CellIndex<NDIM> ll;
-                    for (int d = 0; d < NDIM; ++d) ll(d) = std::round((*xstar_data)(idx, d)) - 1;
-                    for (int d = 0; d < NDIM; ++d)
-                        x_loc[d] = (*xstar_data)(idx, d) - (static_cast<double>(ll(d)) + 0.5);
-                    (*Q_new_data)(idx) = (*Q_cur_data)(ll) * (x_loc[0] - 1.0) * (x_loc[1] - 1.0) -
-                                         (*Q_cur_data)(ll + one_y) * x_loc[1] * (x_loc[0] - 1.0) -
-                                         (*Q_cur_data)(ll + one_x) * x_loc[0] * (x_loc[1] - 1.0) +
-                                         (*Q_cur_data)(ll + one_x + one_y) * x_loc[0] * x_loc[1];
-                }
+                (*Q_new_data)(idx) = Reconstruct::quadraticLagrangeInterpolant(x_loc, idx, *Q_cur_data);
             }
         }
     }

--- a/src/adv_ops/LagrangeStructureReconstructions.cpp
+++ b/src/adv_ops/LagrangeStructureReconstructions.cpp
@@ -110,6 +110,12 @@ LagrangeStructureReconstructions::setOutsideQSystemName(std::string Q_sys_name)
 }
 
 void
+LagrangeStructureReconstructions::setReconstructionOutside(const bool reconstruct_outside)
+{
+    d_reconstruct_outside = reconstruct_outside;
+}
+
+void
 LagrangeStructureReconstructions::applyReconstructionLS(const int Q_idx, const int N_idx, const int path_idx)
 {
     int coarsest_ln = 0;
@@ -139,9 +145,12 @@ LagrangeStructureReconstructions::applyReconstructionLS(const int Q_idx, const i
         Q_in_vecs[part] = Q_in_sys.current_local_solution.get();
         Q_in_dof_map_vecs[part] = &Q_in_sys.get_dof_map();
 
-        auto& Q_out_sys = eq_sys->get_system<ExplicitSystem>(d_Q_out_sys_name);
-        Q_out_vecs[part] = Q_out_sys.current_local_solution.get();
-        Q_out_dof_map_vecs[part] = &Q_out_sys.get_dof_map();
+        if (d_reconstruct_outside)
+        {
+            auto& Q_out_sys = eq_sys->get_system<ExplicitSystem>(d_Q_out_sys_name);
+            Q_out_vecs[part] = Q_out_sys.current_local_solution.get();
+            Q_out_dof_map_vecs[part] = &Q_out_sys.get_dof_map();
+        }
     }
 
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
@@ -190,160 +199,103 @@ LagrangeStructureReconstructions::applyReconstructionLS(const int Q_idx, const i
                 IBTK::VectorNd x_loc;
                 for (int d = 0; d < NDIM; ++d) x_loc(d) = (*xstar_data)(idx, d);
 
+                const double ls_val = ADS::node_to_cell(idx, *ls_new_data);
+
                 // If we are in the bulk, we can use a regular polynomial interpolant.
-                if (within_lagrange_interpolant(idx, *ls_data))
+                if (d_reconstruct_outside || ls_val < 0.0)
                 {
-                    for (int d = 0; d < NDIM; ++d)
-                        x_loc[d] = (*xstar_data)(idx, d) - (static_cast<double>(idx(d)) + 0.5);
-                    IntVector<NDIM> one_x(1, 0), one_y(0, 1);
-                    (*Q_new_data)(idx) =
-                        (*Q_cur_data)(idx) * (x_loc[0] - 1.0) * (x_loc[0] + 1.0) * (x_loc[1] - 1.0) * (x_loc[1] + 1.0) -
-                        (*Q_cur_data)(idx + one_x) * 0.5 * x_loc[0] * (x_loc[0] + 1.0) * (x_loc[1] - 1.0) *
-                            (x_loc[1] + 1.0) -
-                        (*Q_cur_data)(idx - one_x) * 0.5 * x_loc[0] * (x_loc[0] - 1.0) * (x_loc[1] - 1.0) *
-                            (x_loc[1] + 1.0) -
-                        (*Q_cur_data)(idx + one_y) * 0.5 * x_loc[1] * (x_loc[1] + 1.0) * (x_loc[0] - 1.0) *
-                            (x_loc[0] + 1.0) -
-                        (*Q_cur_data)(idx - one_y) * 0.5 * x_loc[1] * (x_loc[1] - 1.0) * (x_loc[0] - 1.0) *
-                            (x_loc[0] + 1.0);
-
-                    // Check if we need to limit.
-                    // Grab "lower left" index
-                    CellIndex<NDIM> ll;
-                    for (int d = 0; d < NDIM; ++d) ll(d) = std::round((*xstar_data)(idx, d)) - 1.0;
-                    double q00 = (*Q_cur_data)(ll);
-                    double q10 = (*Q_cur_data)(ll + one_x);
-                    double q01 = (*Q_cur_data)(ll + one_y);
-                    double q11 = (*Q_cur_data)(ll + one_x + one_y);
-                    if ((*Q_new_data)(idx) > std::max({ q00, q10, q01, q11 }) ||
-                        (*Q_new_data)(idx) < std::min({ q00, q10, q01, q11 }))
+                    if (within_lagrange_interpolant(idx, *ls_data))
                     {
-                        CellIndex<NDIM> ll;
-                        for (int d = 0; d < NDIM; ++d) ll(d) = std::round((*xstar_data)(idx, d)) - 1;
                         for (int d = 0; d < NDIM; ++d)
-                            x_loc[d] = (*xstar_data)(idx, d) - (static_cast<double>(ll(d)) + 0.5);
-                        (*Q_new_data)(idx) = (*Q_cur_data)(ll) * (x_loc[0] - 1.0) * (x_loc[1] - 1.0) -
-                                             (*Q_cur_data)(ll + one_y) * x_loc[1] * (x_loc[0] - 1.0) -
-                                             (*Q_cur_data)(ll + one_x) * x_loc[0] * (x_loc[1] - 1.0) +
-                                             (*Q_cur_data)(ll + one_x + one_y) * x_loc[0] * x_loc[1];
+                            x_loc[d] = (*xstar_data)(idx, d) - (static_cast<double>(idx(d)) + 0.5);
+                        (*Q_new_data)(idx) = Reconstruct::quadraticLagrangeInterpolantLimited(x_loc, idx, *Q_cur_data);
                     }
-                }
-                else if (cut_cell_map.count(IndexList(patch, idx)) > 0)
-                {
-                    // Our reconstruction can use boundary data.
-                    // Need to determine closest points. If we are on a cut cell, we use the parent element's nodes
-                    // in the stencil
-                    const double ls_new_val = node_to_cell(idx, *ls_new_data);
-                    // List of points and values
-                    std::vector<VectorNd> X_pts;
-                    std::vector<double> Q_vals;
-
-                    const std::vector<CutCellElems>& cut_cell_elems = cut_cell_map.at(IndexList(patch, idx));
-                    for (const auto& cut_cell_elem : cut_cell_elems)
+                    else if (cut_cell_map.count(IndexList(patch, idx)) > 0 &&
+                             (ls_val < 0.0 || !d_Q_out_sys_name.empty()))
                     {
-                        const Elem* elem = cut_cell_elem.d_parent_elem;
-                        const int part = cut_cell_elem.d_part;
+                        // Our reconstruction can use boundary data.
+                        // Need to determine closest points. If we are on a cut cell, we use the parent element's nodes
+                        // in the stencil
+                        const double ls_new_val = node_to_cell(idx, *ls_new_data);
+                        // List of points and values
+                        std::vector<VectorNd> X_pts;
+                        std::vector<double> Q_vals;
 
-                        // Grab the position of the nodes
-                        for (unsigned int node_num = 0; node_num < elem->n_nodes(); ++node_num)
+                        const std::vector<CutCellElems>& cut_cell_elems = cut_cell_map.at(IndexList(patch, idx));
+                        for (const auto& cut_cell_elem : cut_cell_elems)
                         {
-                            const Node* node = elem->node_ptr(node_num);
-                            VectorNd X_pt;
-                            std::vector<dof_id_type> dofs;
-                            X_dof_map_vecs[part]->dof_indices(node, dofs);
-                            for (int d = 0; d < NDIM; ++d) X_pt[d] = (*X_vecs[part])(dofs[d]);
-                            X_pts.push_back(X_pt);
-                            if (ADS::node_to_cell(idx, *ls_new_data) < 0.0)
+                            const Elem* elem = cut_cell_elem.d_parent_elem;
+                            const int part = cut_cell_elem.d_part;
+
+                            // Grab the position of the nodes
+                            for (unsigned int node_num = 0; node_num < elem->n_nodes(); ++node_num)
                             {
-                                Q_in_dof_map_vecs[part]->dof_indices(node, dofs);
-                                Q_vals.push_back((*Q_in_vecs[part])(dofs[0]));
-                            }
-                            else
-                            {
-                                Q_out_dof_map_vecs[part]->dof_indices(node, dofs);
-                                Q_vals.push_back((*Q_out_vecs[part])(dofs[0]));
+                                const Node* node = elem->node_ptr(node_num);
+                                VectorNd X_pt;
+                                std::vector<dof_id_type> dofs;
+                                X_dof_map_vecs[part]->dof_indices(node, dofs);
+                                for (int d = 0; d < NDIM; ++d) X_pt[d] = (*X_vecs[part])(dofs[d]);
+                                X_pts.push_back(X_pt);
+                                if (ADS::node_to_cell(idx, *ls_new_data) < 0.0)
+                                {
+                                    Q_in_dof_map_vecs[part]->dof_indices(node, dofs);
+                                    Q_vals.push_back((*Q_in_vecs[part])(dofs[0]));
+                                }
+                                else
+                                {
+                                    Q_out_dof_map_vecs[part]->dof_indices(node, dofs);
+                                    Q_vals.push_back((*Q_out_vecs[part])(dofs[0]));
+                                }
                             }
                         }
-                    }
 
-                    // We have the points on the structure that we are using to reconstruct the function. Grab the
-                    // rest from the Cartesian grid.
-                    for (int d = 0; d < NDIM; ++d)
-                        x_loc[d] = xlow[d] + dx[d] * (x_loc[d] - static_cast<double>(idx_low(d)));
+                        // We have the points on the structure that we are using to reconstruct the function. Grab the
+                        // rest from the Cartesian grid.
+                        for (int d = 0; d < NDIM; ++d)
+                            x_loc[d] = xlow[d] + dx[d] * (x_loc[d] - static_cast<double>(idx_low(d)));
 
-                    // Flood fill for Eulerian points
-                    std::vector<CellIndex<NDIM>> new_idxs = { idx };
-                    unsigned int i = 0;
-                    while (X_pts.size() < d_rbf_stencil_size)
-                    {
-#ifndef NDEBUG
-                        if (i >= new_idxs.size())
+                        // Flood fill for Eulerian points
+                        std::vector<CellIndex<NDIM>> idx_vec;
+                        try
                         {
-                            std::ostringstream err_msg;
-                            err_msg
-                                << d_object_name
-                                << "::applyReconstruction(): Could not find enough cells to perform reconstruction.\n";
-                            err_msg << "  Reconstructing on index: " << idx << " and level " << ln << " and patch num "
-                                    << patch->getPatchNumber() << "\n";
-                            err_msg << "  Reconstructing at point: " << x_loc.transpose() << "\n";
-                            err_msg << "  ls value: " << ls_new_val << "\n";
-                            err_msg << "  Searched " << i << " indices and found " << new_idxs.size()
-                                    << " valid indices\n";
-                            err_msg << "  Ls neighbor values: "
-                                    << (*ls_new_data)(NodeIndex<NDIM>(idx, NodeIndex<NDIM>::LowerLeft)) << " "
-                                    << (*ls_new_data)(NodeIndex<NDIM>(idx, NodeIndex<NDIM>::LowerRight)) << " "
-                                    << (*ls_new_data)(NodeIndex<NDIM>(idx, NodeIndex<NDIM>::UpperLeft)) << " "
-                                    << (*ls_new_data)(NodeIndex<NDIM>(idx, NodeIndex<NDIM>::UpperRight)) << "\n";
-                            pout << err_msg.str() << "\n";
-                            TBOX_ERROR(err_msg.str());
+                            Reconstruct::floodFillForPoints(
+                                idx_vec, idx, *ls_new_data, ls_new_val, d_rbf_stencil_size - X_pts.size());
                         }
-#endif
-                        const CellIndex<NDIM>& new_idx = new_idxs[i];
-                        // Add new idx to list of X_vals
-                        if (ADS::node_to_cell(new_idx, *ls_data) * ls_new_val > 0.0)
+                        catch (const std::runtime_error& e)
                         {
-                            Q_vals.push_back((*Q_cur_data)(new_idx));
+                            pout << e.what() << "\n";
+                            TBOX_ERROR(d_object_name + "::applyReconstruction(): Could not perform reconstruction!\n");
+                        }
+                        for (const auto& idx : idx_vec)
+                        {
+                            Q_vals.push_back((*Q_cur_data)(idx));
                             VectorNd x_cent_c;
                             for (int d = 0; d < NDIM; ++d)
-                                x_cent_c[d] = xlow[d] + dx[d] * (static_cast<double>(new_idx(d) - idx_low(d)) + 0.5);
+                                x_cent_c[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
                             X_pts.push_back(x_cent_c);
                         }
 
-                        // Add neighboring points to new_idxs.
-                        IntVector<NDIM> l(-1, 0), r(1, 0), b(0, -1), u(0, 1);
-                        CellIndex<NDIM> idx_l(new_idx + l), idx_r(new_idx + r);
-                        CellIndex<NDIM> idx_u(new_idx + u), idx_b(new_idx + b);
-                        if (ADS::node_to_cell(idx_l, *ls_data) * ls_new_val > 0.0 &&
-                            (std::find(new_idxs.begin(), new_idxs.end(), idx_l) == new_idxs.end()))
-                            new_idxs.push_back(idx_l);
-                        if (ADS::node_to_cell(idx_r, *ls_data) * ls_new_val > 0.0 &&
-                            (std::find(new_idxs.begin(), new_idxs.end(), idx_r) == new_idxs.end()))
-                            new_idxs.push_back(idx_r);
-                        if (ADS::node_to_cell(idx_u, *ls_data) * ls_new_val > 0.0 &&
-                            (std::find(new_idxs.begin(), new_idxs.end(), idx_u) == new_idxs.end()))
-                            new_idxs.push_back(idx_u);
-                        if (ADS::node_to_cell(idx_b, *ls_data) * ls_new_val > 0.0 &&
-                            (std::find(new_idxs.begin(), new_idxs.end(), idx_b) == new_idxs.end()))
-                            new_idxs.push_back(idx_b);
-                        ++i;
+                        // Now reconstruct the function
+                        (*Q_new_data)(idx) =
+                            Reconstruct::radialBasisFunctionReconstruction(x_loc, X_pts, Q_vals, d_rbf_order);
                     }
-
-                    // Now reconstruct the function
-                    (*Q_new_data)(idx) =
-                        Reconstruct::radialBasisFunctionReconstruction(x_loc, X_pts, Q_vals, d_rbf_order);
+                    else
+                    {
+                        // A node doesn't touch this cell. Just use normal interpolation.
+                        (*Q_new_data)(idx) =
+                            Reconstruct::radialBasisFunctionReconstruction(x_loc,
+                                                                           ADS::node_to_cell(idx, *ls_new_data),
+                                                                           idx,
+                                                                           *Q_cur_data,
+                                                                           *ls_data,
+                                                                           patch,
+                                                                           d_rbf_order,
+                                                                           d_rbf_stencil_size);
+                    }
                 }
                 else
                 {
-                    // A node doesn't touch this cell. Just use normal interpolation.
-                    (*Q_new_data)(idx) =
-                        Reconstruct::radialBasisFunctionReconstruction(x_loc,
-                                                                       ADS::node_to_cell(idx, *ls_new_data),
-                                                                       idx,
-                                                                       *Q_cur_data,
-                                                                       *ls_data,
-                                                                       patch,
-                                                                       d_rbf_order,
-                                                                       d_rbf_stencil_size);
+                    (*Q_new_data)(idx) = d_default_value;
                 }
 
                 // Cutoff solution if applicable

--- a/src/adv_ops/RBFDivergenceReconstructions.cpp
+++ b/src/adv_ops/RBFDivergenceReconstructions.cpp
@@ -172,38 +172,7 @@ RBFDivergenceReconstructions::applyReconstructionLS(const int u_idx, const int d
                     // Interpolate fd_div_data to x_loc.
                     for (int d = 0; d < NDIM; ++d)
                         x_loc[d] = (*xstar_data)(idx, d) - (static_cast<double>(idx(d)) + 0.5);
-                    IntVector<NDIM> one_x(1, 0), one_y(0, 1);
-                    (*div_data)(idx) = (*fd_div_data)(idx) * (x_loc[0] - 1.0) * (x_loc[0] + 1.0) * (x_loc[1] - 1.0) *
-                                           (x_loc[1] + 1.0) -
-                                       (*fd_div_data)(idx + one_x) * 0.5 * x_loc[0] * (x_loc[0] + 1.0) *
-                                           (x_loc[1] - 1.0) * (x_loc[1] + 1.0) -
-                                       (*fd_div_data)(idx - one_x) * 0.5 * x_loc[0] * (x_loc[0] - 1.0) *
-                                           (x_loc[1] - 1.0) * (x_loc[1] + 1.0) -
-                                       (*fd_div_data)(idx + one_y) * 0.5 * x_loc[1] * (x_loc[1] + 1.0) *
-                                           (x_loc[0] - 1.0) * (x_loc[0] + 1.0) -
-                                       (*fd_div_data)(idx - one_y) * 0.5 * x_loc[1] * (x_loc[1] - 1.0) *
-                                           (x_loc[0] - 1.0) * (x_loc[0] + 1.0);
-
-                    // Check if we need to limit.
-                    // Grab "lower left" index
-                    CellIndex<NDIM> ll;
-                    for (int d = 0; d < NDIM; ++d) ll(d) = std::round((*xstar_data)(idx, d)) - 1.0;
-                    double q00 = (*fd_div_data)(ll);
-                    double q10 = (*fd_div_data)(ll + one_x);
-                    double q01 = (*fd_div_data)(ll + one_y);
-                    double q11 = (*fd_div_data)(ll + one_x + one_y);
-                    if ((*div_data)(idx) > std::max({ q00, q10, q01, q11 }) ||
-                        (*div_data)(idx) < std::min({ q00, q10, q01, q11 }))
-                    {
-                        CellIndex<NDIM> ll;
-                        for (int d = 0; d < NDIM; ++d) ll(d) = std::round((*xstar_data)(idx, d)) - 1;
-                        for (int d = 0; d < NDIM; ++d)
-                            x_loc[d] = (*xstar_data)(idx, d) - (static_cast<double>(ll(d)) + 0.5);
-                        (*div_data)(idx) = (*fd_div_data)(ll) * (x_loc[0] - 1.0) * (x_loc[1] - 1.0) -
-                                           (*fd_div_data)(ll + one_y) * x_loc[1] * (x_loc[0] - 1.0) -
-                                           (*fd_div_data)(ll + one_x) * x_loc[0] * (x_loc[1] - 1.0) +
-                                           (*fd_div_data)(ll + one_x + one_y) * x_loc[0] * x_loc[1];
-                    }
+                    (*div_data)(idx) = Reconstruct::quadraticLagrangeInterpolantLimited(x_loc, idx, *fd_div_data);
                 }
                 else
                 {

--- a/tests/adv_ops/divergence.cpp
+++ b/tests/adv_ops/divergence.cpp
@@ -137,7 +137,7 @@ main(int argc, char* argv[])
                 for (CellIterator<NDIM> ci(patch->getBox()); ci; ci++)
                 {
                     const CellIndex<NDIM>& idx = ci();
-                    for (int d = 0; d < NDIM; ++d) (*path_data)(idx, d) = static_cast<double>(idx(d)) + 0.5;
+                    for (int d = 0; d < NDIM; ++d) (*path_data)(idx, d) = static_cast<double>(idx(d)) + 0.25;
                 }
             }
         }

--- a/tests/adv_ops/divergence.cpp
+++ b/tests/adv_ops/divergence.cpp
@@ -100,6 +100,8 @@ main(int argc, char* argv[])
         comps.setFlag(div_err_idx);
         comps.setFlag(path_idx);
 
+        RBFDivergenceReconstructions div_ops("div_ops", input_db->getDatabase("div_ops"));
+
         gridding_algorithm->makeCoarsestLevel(patch_hierarchy, 0.0);
         int tag_buffer = 1;
         int ln = 0;
@@ -137,7 +139,7 @@ main(int argc, char* argv[])
                 for (CellIterator<NDIM> ci(patch->getBox()); ci; ci++)
                 {
                     const CellIndex<NDIM>& idx = ci();
-                    for (int d = 0; d < NDIM; ++d) (*path_data)(idx, d) = static_cast<double>(idx(d)) + 0.25;
+                    for (int d = 0; d < NDIM; ++d) (*path_data)(idx, d) = static_cast<double>(idx(d)) + 0.5;
                 }
             }
         }
@@ -159,7 +161,6 @@ main(int argc, char* argv[])
 
         u_fcn.setDataOnPatchHierarchy(u_idx, u_var, patch_hierarchy, 0.0);
 
-        RBFDivergenceReconstructions div_ops("div_ops", input_db->getDatabase("div_ops"));
         div_ops.setLSData(ls_idx, vol_idx, ls_idx, vol_idx);
         div_ops.allocateOperatorState(patch_hierarchy, 0.0, 0.0);
         div_ops.applyReconstruction(u_idx, div_idx, path_idx);

--- a/tests/adv_ops/divergence_2d.input
+++ b/tests/adv_ops/divergence_2d.input
@@ -1,12 +1,12 @@
 // grid spacing parameters
-MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
 REF_RATIO  = 4                            // refinement ratio between levels
-N = 8                                    // coarsest grid spacing
+N = 64                                    // coarsest grid spacing
 NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
 DX = 1.0/NFINEST
 
 ls_fcn {
-  function = "-1.0"
+  function = "0.5-sqrt(X_0*X_0 + X_1*X_1)"
 }
 
 u {
@@ -47,8 +47,8 @@ Main {
 
 CartesianGeometry {
    domain_boxes = [ (0,0),(N - 1,N - 1) ]
-   x_lo = 0,0
-   x_up = 1,1
+   x_lo = -2,-2
+   x_up = 2,2
    periodic_dimension = 1,1
 }
 
@@ -70,6 +70,11 @@ GriddingAlgorithm {
 }
 
 StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+//      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,3*N/4 - 1 )]
+      level_0 = [( 2,2 ),( N - 1,N - 1 )]
+   }
 }
 
 LoadBalancer {

--- a/tests/adv_ops/divergence_2d.input
+++ b/tests/adv_ops/divergence_2d.input
@@ -1,0 +1,78 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 8                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX = 1.0/NFINEST
+
+ls_fcn {
+  function = "-1.0"
+}
+
+u {
+  function_0 = "sin(2*PI*X_0)*sin(2*PI*X_1)"
+  function_1 = "cos(2*PI*X_0)*cos(2*PI*X_1)"
+}
+
+div {
+  function = "0.0"
+}
+
+div_ops {
+  stencil_size = 12
+  rbf_order = "QUADRATIC"
+}
+
+Main {
+
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt", "ExodusII"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "new_viz_adv_diff2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_adv_diff2d"
+
+   data_dump_interval          = 0
+   data_dump_dirname           = "hier_data_IB2d"
+
+   timer_dump_interval = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = 0,0
+   x_up = 1,1
+   periodic_dimension = 1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.9e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.9e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/adv_ops/divergence_2d.output
+++ b/tests/adv_ops/divergence_2d.output
@@ -1,8 +1,11 @@
 Setting Level set at time 0
-Minimum volume on level:     0 is: 0.015625
+Minimum volume on level:     0 is: 1.90906107369e-05
 Total area found on level:   0 is: 0
-Total volume found on level: 0 is: 1
+Total volume found on level: 0 is: 15.2166879665
+Minimum volume on level:     1 is: 6.18370098313e-08
+Total area found on level:   1 is: 0
+Total volume found on level: 1 is: 14.2303557991
 Computing error in divergence interpolation:
- L1-norm:  8.10373e-16
- L2-norm:  1.16325e-15
- max-norm: 3.46077e-15
+ L1-norm:  0.0361951
+ L2-norm:  0.0471447
+ max-norm: 0.0943753

--- a/tests/adv_ops/divergence_2d.output
+++ b/tests/adv_ops/divergence_2d.output
@@ -3,6 +3,6 @@ Minimum volume on level:     0 is: 0.015625
 Total area found on level:   0 is: 0
 Total volume found on level: 0 is: 1
 Computing error in divergence interpolation:
- L1-norm:  0.024628
- L2-norm:  0.0278146
- max-norm: 0.0442169
+ L1-norm:  8.10373e-16
+ L2-norm:  1.16325e-15
+ max-norm: 3.46077e-15

--- a/tests/adv_ops/divergence_2d.output
+++ b/tests/adv_ops/divergence_2d.output
@@ -1,8 +1,8 @@
 Setting Level set at time 0
-Minimum volume on level:     0 is: 0.00390625
+Minimum volume on level:     0 is: 0.015625
 Total area found on level:   0 is: 0
 Total volume found on level: 0 is: 1
 Computing error in divergence interpolation:
- L1-norm:  0.00381976
- L2-norm:  0.00441658
- max-norm: 0.00813532
+ L1-norm:  0.024628
+ L2-norm:  0.0278146
+ max-norm: 0.0442169

--- a/tests/examples/peristalsis.cpp
+++ b/tests/examples/peristalsis.cpp
@@ -410,7 +410,7 @@ main(int argc, char* argv[])
             auto adv_op_reconstruct =
                 std::make_shared<LagrangeStructureReconstructions>("RBFReconstruct", input_db->getDatabase("AdvOps"));
             adv_op_reconstruct->setCutCellMapping(cut_cell_mapping);
-            adv_op_reconstruct->setQSystemName(Q_exact_str);
+            adv_op_reconstruct->setInsideQSystemName(Q_exact_str);
             adv_diff_integrator->registerAdvectionReconstruction(Q_var, adv_op_reconstruct);
         }
 

--- a/tests/examples/peristalsis.cpp
+++ b/tests/examples/peristalsis.cpp
@@ -411,6 +411,7 @@ main(int argc, char* argv[])
                 std::make_shared<LagrangeStructureReconstructions>("RBFReconstruct", input_db->getDatabase("AdvOps"));
             adv_op_reconstruct->setCutCellMapping(cut_cell_mapping);
             adv_op_reconstruct->setInsideQSystemName(Q_exact_str);
+            adv_op_reconstruct->setReconstructionOutside(false);
             adv_diff_integrator->registerAdvectionReconstruction(Q_var, adv_op_reconstruct);
         }
 

--- a/tests/examples/peristalsis_2d.lagrange.output
+++ b/tests/examples/peristalsis_2d.lagrange.output
@@ -87,10 +87,11 @@ input_db {
    BDRY_INTERP_TYPE            = "LINEAR"                   // input not used
    LS                          = "1.0 + sin(2.0*PI*X_0)*cos(2.0*PI*X_1)" // input used
    AdvOps {
-      stencil_size = 12                                     // input used
-      rbf_order    = "QUADRATIC"                            // input used
-      low_cutoff   = 0                                      // input used
-      high_cutoff  = 1.79769e+308                           // from default
+      stencil_size  = 12                                    // input used
+      rbf_order     = "QUADRATIC"                           // input used
+      low_cutoff    = 0                                     // input used
+      high_cutoff   = 1.79769e+308                          // from default
+      default_value = 0                                     // from default
    }
    MeshMapping {
       alpha     = 1.25664                                   // input used


### PR DESCRIPTION
This updates some semi-Lagrangian advection operators. In particular:

-  consolidates some common reconstruction functionality outside the classes
- let `RBFDivergenceReconstructions` use standard finite differences away from structure
- let `LagrangeStructureReconstructions` to optionally reconstruct on the outside.