### PR TITLE
Generalize divergence

### DIFF
--- a/examples/disk/main.cpp
+++ b/examples/disk/main.cpp
@@ -320,8 +320,8 @@ main(int argc, char* argv[])
         {
             adv_diff_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> reaction_exodus_io(uses_exodus ? new ExodusII_IO(*meshes[REACTION_MESH_ID]) :
-                                                                         NULL);
+        std::unique_ptr<ExodusII_IO> reaction_exodus_io(uses_exodus ? new ExodusII_IO(*meshes[REACTION_MESH_ID]) :
+                                                                      NULL);
 
         auto var_db = VariableDatabase<NDIM>::getDatabase();
         Pointer<CellVariable<NDIM, double>> dist_var = new CellVariable<NDIM, double>("distance");

--- a/examples/pipe_flow_no_ins/main.cpp
+++ b/examples/pipe_flow_no_ins/main.cpp
@@ -331,11 +331,11 @@ main(int argc, char* argv[])
         {
             adv_diff_integrator->registerVisItDataWriter(visit_data_writer);
         }
-        libMesh::UniquePtr<ExodusII_IO> lower_exodus_io(
+        std::unique_ptr<ExodusII_IO> lower_exodus_io(
             uses_exodus ? new ExodusII_IO(*mesh_mapping->getBoundaryMesh(LOWER_MESH_ID)) : NULL);
-        libMesh::UniquePtr<ExodusII_IO> upper_exodus_io(
+        std::unique_ptr<ExodusII_IO> upper_exodus_io(
             uses_exodus ? new ExodusII_IO(*mesh_mapping->getBoundaryMesh(UPPER_MESH_ID)) : NULL);
-        libMesh::UniquePtr<ExodusII_IO> reaction_exodus_io(
+        std::unique_ptr<ExodusII_IO> reaction_exodus_io(
             uses_exodus ? new ExodusII_IO(*mesh_mapping->getBoundaryMesh(REACTION_MESH_ID)) : NULL);
         mesh_mapping->initializeFEData();
         // Initialize hierarchy configuration and data on all patches.

--- a/include/ADS/SLAdvIntegrator.h
+++ b/include/ADS/SLAdvIntegrator.h
@@ -191,6 +191,13 @@ public:
                                        bool skip_synchronize_new_state_data,
                                        int num_cycles = 1) override;
 
+    /*!
+     * Register a function that executes any steps needed after computing the new level set, but before doing the
+     * advection update.
+     */
+    using PreAdvectionCallbackFcnPtr = std::function<void(double, double, void*)>;
+    void registerPreAdvectionUpdateFcnCallback(PreAdvectionCallbackFcnPtr fcn, void* ctx);
+
 protected:
     void initializeCompositeHierarchyDataSpecialized(double current_time, bool initial_time) override;
     void regridHierarchyEndSpecialized() override;
@@ -265,12 +272,17 @@ protected:
     SAMRAI::tbox::Pointer<SAMRAI::math::HierarchyFaceDataOpsReal<NDIM, double>> d_hier_fc_data_ops;
 
 private:
+    void executePreAdvectionCallbacks(double current_time, double new_time);
+
     // Two is a good number for the current default INSStaggeredHierarchyIntegrator.
     int d_num_cycles = 2;
     bool d_use_rbfs = false;
     unsigned int d_rbf_stencil_size = 8;
     unsigned int d_mls_stencil_size = 8;
     Reconstruct::RBFPolyOrder d_rbf_poly_order = Reconstruct::RBFPolyOrder::UNKNOWN_ORDER;
+
+    std::vector<PreAdvectionCallbackFcnPtr> d_preadvection_callback_fcns;
+    std::vector<void*> d_preadvection_callback_ctxs;
 }; // Class SLAdvIntegrator
 } // namespace ADS
 

--- a/include/ADS/ls_functions.h
+++ b/include/ADS/ls_functions.h
@@ -55,10 +55,10 @@ void copy_face_to_side(const int u_s_idx,
                        const int u_f_idx,
                        SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy);
 
-bool findIntersection(libMesh::Point& p,
-                      libMesh::Elem* elem,
-                      const libMesh::Point& r,
-                      const libMesh::VectorValue<double>& q);
+bool find_intersection(libMesh::Point& p,
+                       libMesh::Elem* elem,
+                       const libMesh::Point& r,
+                       const libMesh::VectorValue<double>& q);
 
 std::string get_libmesh_restart_file_name(const std::string& restart_dump_dirname,
                                           const std::string& base_filename,
@@ -79,20 +79,20 @@ std::string get_libmesh_restart_file_name(const std::string& restart_dump_dirnam
  * Returns:
  * pair consisting of the volume (first) and the area (second)
  */
-std::pair<double, double> findVolumeAndArea(const IBTK::VectorNd& xlow,
-                                            const double* const dx,
-                                            SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeData<NDIM, double>> phi,
-                                            const SAMRAI::pdat::CellIndex<NDIM>& idx);
+std::pair<double, double> find_volume_and_area(const IBTK::VectorNd& xlow,
+                                               const double* const dx,
+                                               SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeData<NDIM, double>> phi,
+                                               const SAMRAI::pdat::CellIndex<NDIM>& idx);
 
 /*!
  * Find the volume of a vector of simplices (tri in 2D, tet in 3D)
  */
-double findVolume(const std::vector<Simplex>& simplices);
+double find_volume(const std::vector<Simplex>& simplices);
 
 /*!
  * Find the surface area of a vector of simplices (tri in 2D, tet in 3D)
  */
-double findArea(const std::vector<Simplex>& simplices);
+double find_area(const std::vector<Simplex>& simplices);
 
 /*!
  * Use a flood filling algorithm to compute the correct sign for the node centered level set on the provided patch

--- a/include/ADS/private/reconstructions_inc.h
+++ b/include/ADS/private/reconstructions_inc.h
@@ -9,6 +9,8 @@
 
 #include <exception>
 
+namespace ADS
+{
 namespace Reconstruct
 {
 inline void
@@ -54,6 +56,76 @@ floodFillForPoints(std::vector<SAMRAI::pdat::CellIndex<NDIM>>& fill_pts,
         if (ADS::node_to_cell(idx_b, ls_data) * ls > 0.0 &&
             (std::find(test_idxs.begin(), test_idxs.end(), idx_b) == test_idxs.end()))
             test_idxs.push_back(idx_b);
+        ++i;
+    }
+}
+
+inline void
+floodFillForPoints(std::vector<SAMRAI::pdat::SideIndex<NDIM>>& fill_pts,
+                   const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                   const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                   const double ls,
+                   const int axis,
+                   const size_t stencil_size)
+{
+    // Flood fill for Eulerian points
+    std::vector<SAMRAI::pdat::SideIndex<NDIM>> test_idxs = { SAMRAI::pdat::SideIndex<NDIM>(idx, axis, 0),
+                                                             SAMRAI::pdat::SideIndex<NDIM>(idx, axis, 1) };
+    unsigned int i = 0;
+    while (fill_pts.size() < stencil_size)
+    {
+#ifndef NDEBUG
+        if (i >= test_idxs.size())
+        {
+            std::ostringstream err_msg;
+            err_msg << "Could not find enough cells to fill stencil.\n";
+            err_msg << "  Starting at base point " << idx << "\n";
+            err_msg << "  ls value: " << ls << "\n";
+            err_msg << "  Searched " << i << " indices and found " << fill_pts.size() << " total pts\n";
+            throw std::runtime_error(err_msg.str());
+        }
+#endif
+        const SAMRAI::pdat::SideIndex<NDIM>& new_idx = test_idxs[i];
+        // Add new idx to list of X_vals
+        if (ADS::node_to_side(new_idx, ls_data) * ls > 0.0) fill_pts.push_back(new_idx);
+
+        // Add neighboring points to new_idxs.
+        // Prefer to add points preferentially depending on the axis
+        SAMRAI::hier::IntVector<NDIM> l(-1, 0), r(1, 0), b(0, -1), u(0, 1);
+        SAMRAI::pdat::SideIndex<NDIM> idx_l(new_idx + l), idx_r(new_idx + r);
+        SAMRAI::pdat::SideIndex<NDIM> idx_u(new_idx + u), idx_b(new_idx + b);
+        if (axis == 0)
+        {
+            // Add x points first
+            if (ADS::node_to_side(idx_l, ls_data) * ls > 0.0 &&
+                (std::find(test_idxs.begin(), test_idxs.end(), idx_l) == test_idxs.end()))
+                test_idxs.push_back(idx_l);
+            if (ADS::node_to_side(idx_r, ls_data) * ls > 0.0 &&
+                (std::find(test_idxs.begin(), test_idxs.end(), idx_r) == test_idxs.end()))
+                test_idxs.push_back(idx_r);
+            if (ADS::node_to_side(idx_u, ls_data) * ls > 0.0 &&
+                (std::find(test_idxs.begin(), test_idxs.end(), idx_u) == test_idxs.end()))
+                test_idxs.push_back(idx_u);
+            if (ADS::node_to_side(idx_b, ls_data) * ls > 0.0 &&
+                (std::find(test_idxs.begin(), test_idxs.end(), idx_b) == test_idxs.end()))
+                test_idxs.push_back(idx_b);
+        }
+        else
+        {
+            // Add y points first.
+            if (ADS::node_to_side(idx_u, ls_data) * ls > 0.0 &&
+                (std::find(test_idxs.begin(), test_idxs.end(), idx_u) == test_idxs.end()))
+                test_idxs.push_back(idx_u);
+            if (ADS::node_to_side(idx_b, ls_data) * ls > 0.0 &&
+                (std::find(test_idxs.begin(), test_idxs.end(), idx_b) == test_idxs.end()))
+                test_idxs.push_back(idx_b);
+            if (ADS::node_to_side(idx_l, ls_data) * ls > 0.0 &&
+                (std::find(test_idxs.begin(), test_idxs.end(), idx_l) == test_idxs.end()))
+                test_idxs.push_back(idx_l);
+            if (ADS::node_to_side(idx_r, ls_data) * ls > 0.0 &&
+                (std::find(test_idxs.begin(), test_idxs.end(), idx_r) == test_idxs.end()))
+                test_idxs.push_back(idx_r);
+        }
         ++i;
     }
 }
@@ -143,6 +215,74 @@ quadraticLagrangeInterpolantLimited(IBTK::VectorNd x,
     return Q;
 }
 
-} // namespace Reconstruct
+inline double
+divergence(const IBTK::VectorNd& x,
+           const SAMRAI::pdat::CellIndex<NDIM>& idx,
+           const double ls,
+           const SAMRAI::pdat::SideData<NDIM, double>& u_data,
+           const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+           const RBFPolyOrder poly_order,
+           const int stencil_size,
+           const double* const dx)
+{
+    double div = 0.0;
+    for (int d = 0; d < NDIM; ++d)
+    {
+        // Need to grab indices, use flood filling
+        std::vector<SAMRAI::pdat::SideIndex<NDIM>> idxs;
+        floodFillForPoints(idxs, idx, ls_data, ls, d, stencil_size);
 
+        std::vector<IBTK::VectorNd> X_pts;
+        std::vector<double> u_vals;
+        for (const auto& si : idxs)
+        {
+            u_vals.push_back(u_data(si));
+            IBTK::VectorNd xpt;
+            for (int i = 0; i < NDIM; ++i) xpt[i] = static_cast<double>(si(i)) + (d == i ? 0.0 : 0.5);
+            X_pts.push_back(xpt);
+        }
+
+        // We have all the points. Now determine weights.
+        auto rbf = [](const double r) -> double { return r * r * r * r * r; };
+        auto L_rbf = [](const IBTK::VectorNd& xi, const IBTK::VectorNd& xj, void* ctx) -> double
+        {
+            int d = *static_cast<int*>(ctx);
+            double r = (xi - xj).norm();
+            return 5.0 * (xi[d] - xj[d]) * r * r * r;
+        };
+
+        auto L_polys = [](const std::vector<IBTK::VectorNd>& xpts,
+                          int poly_degree,
+                          double dx,
+                          IBTK::VectorNd base_pt,
+                          void* ctx) -> IBTK::VectorXd
+        {
+            int d = *static_cast<int*>(ctx);
+            if (d == 0)
+                return PolynomialBasis::dPdxMonomials(xpts, poly_degree, dx, base_pt).transpose();
+            else
+                return PolynomialBasis::dPdyMonomials(xpts, poly_degree, dx, base_pt).transpose();
+        };
+
+        // Need to shift x_loc by idx_low
+        std::vector<double> wgts;
+        std::vector<double> dummy_dx = { 1.0, 1.0 };
+        Reconstruct::RBFFDReconstruct<IBTK::VectorNd>(wgts,
+                                                      x,
+                                                      X_pts,
+                                                      poly_order == Reconstruct::RBFPolyOrder::LINEAR ? 1 : 2,
+                                                      dummy_dx.data(),
+                                                      rbf,
+                                                      L_rbf,
+                                                      static_cast<void*>(&d),
+                                                      L_polys,
+                                                      static_cast<void*>(&d));
+        // Now perform reconstruction.
+        for (size_t i = 0; i < u_vals.size(); ++i) div += u_vals[i] * wgts[i] / dx[d];
+    }
+    return div;
+}
+
+} // namespace Reconstruct
+} // namespace ADS
 #endif

--- a/include/ADS/reconstructions.h
+++ b/include/ADS/reconstructions.h
@@ -9,6 +9,8 @@
 #include "CellIndex.h"
 #include "NodeData.h"
 
+namespace ADS
+{
 namespace Reconstruct
 {
 double sumOverZSplines(const IBTK::VectorNd& x_loc,
@@ -122,7 +124,7 @@ mls_weight(double r)
 
 /*!
  * Use a flood filling algorithm to find neighboring points to a given index. Uses the value of the level set to
- * determine whether indices point to the same size.
+ * determine whether indices point to the same side.
  *
  * Note that fill_pts does not need to be empty. This function will append fill_pts until it's size is equal to
  * stencil_size.
@@ -134,6 +136,25 @@ void floodFillForPoints(std::vector<SAMRAI::pdat::CellIndex<NDIM>>& fill_pts,
                         const SAMRAI::pdat::CellIndex<NDIM>& idx,
                         const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
                         double ls,
+                        size_t stencil_size);
+
+/*!
+ * Use a flood filling algorithm to find neighboring points to a given side index. Uses the value of the level set to
+ * determine whether indices point to same side.
+ *
+ * The cell index idx must contain sides on each axis that match the sign of ls.
+ *
+ * Note that fill_pts does not need to be empty. This function will append fill_pts until it's size is equal to
+ * stencil_size.
+ *
+ * If compiled with debugging flags, throws a runtime_error if the flood filling algorithm could not find the requested
+ * number of points.
+ */
+void floodFillForPoints(std::vector<SAMRAI::pdat::SideIndex<NDIM>>& fill_pts,
+                        const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                        const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                        double ls,
+                        const int axis,
                         size_t stencil_size);
 
 /*!
@@ -232,7 +253,27 @@ double quadraticLagrangeInterpolant(IBTK::VectorNd x,
 double quadraticLagrangeInterpolantLimited(IBTK::VectorNd x,
                                            const SAMRAI::pdat::CellIndex<NDIM>& idx,
                                            const SAMRAI::pdat::CellData<NDIM, double>& Q_data);
-} // namespace Reconstruct
 
+/*!
+ * Compute the divergence of a side centered velocity field using a finite difference stencil centered at idx.
+ *
+ * Note that x must be given in index space.
+ *
+ * The sign of ls determines the side from which we grab points.
+ *
+ * The cell index idx must contain sides on each axis that match the sign of ls.
+ *
+ * Uses the RBF r^5 with polynomials appended up to order RBFPolyOrder.
+ */
+double divergence(const IBTK::VectorNd& x,
+                  const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                  double ls,
+                  const SAMRAI::pdat::SideData<NDIM, double>& u_data,
+                  const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                  RBFPolyOrder poly_order,
+                  int stencil_size,
+                  const double* const dx);
+} // namespace Reconstruct
+} // namespace ADS
 #include <ADS/private/reconstructions_inc.h>
 #endif

--- a/include/ADS/reconstructions.h
+++ b/include/ADS/reconstructions.h
@@ -13,19 +13,19 @@ namespace ADS
 {
 namespace Reconstruct
 {
-double sumOverZSplines(const IBTK::VectorNd& x_loc,
-                       const SAMRAI::pdat::CellIndex<NDIM>& idx,
-                       const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
-                       const int order);
+double sum_over_z_splines(const IBTK::VectorNd& x_loc,
+                          const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                          const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
+                          const int order);
 
-bool indexWithinWidth(int stencil_width,
-                      const SAMRAI::pdat::CellIndex<NDIM>& idx,
-                      const SAMRAI::pdat::CellData<NDIM, double>& vol_data);
+bool index_within_width(int stencil_width,
+                        const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                        const SAMRAI::pdat::CellData<NDIM, double>& vol_data);
 
-double evaluateZSpline(const IBTK::VectorNd x, const int order);
+double evaluate_z_spline(const IBTK::VectorNd x, const int order);
 
-int getSplineWidth(int order);
-double ZSpline(double x, int order);
+int get_spline_width(int order);
+double z_spline(double x, int order);
 
 /*!
  * \brief Routine for converting strings to enums.
@@ -132,11 +132,11 @@ mls_weight(double r)
  * If compiled with debugging flags, throws a runtime_error if the flood filling algorithm could not find the requested
  * number of points.
  */
-void floodFillForPoints(std::vector<SAMRAI::pdat::CellIndex<NDIM>>& fill_pts,
-                        const SAMRAI::pdat::CellIndex<NDIM>& idx,
-                        const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
-                        double ls,
-                        size_t stencil_size);
+void flood_fill_for_points(std::vector<SAMRAI::pdat::CellIndex<NDIM>>& fill_pts,
+                           const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                           const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                           double ls,
+                           size_t stencil_size);
 
 /*!
  * Use a flood filling algorithm to find neighboring points to a given side index. Uses the value of the level set to
@@ -150,12 +150,12 @@ void floodFillForPoints(std::vector<SAMRAI::pdat::CellIndex<NDIM>>& fill_pts,
  * If compiled with debugging flags, throws a runtime_error if the flood filling algorithm could not find the requested
  * number of points.
  */
-void floodFillForPoints(std::vector<SAMRAI::pdat::SideIndex<NDIM>>& fill_pts,
-                        const SAMRAI::pdat::CellIndex<NDIM>& idx,
-                        const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
-                        double ls,
-                        const int axis,
-                        size_t stencil_size);
+void flood_fill_for_points(std::vector<SAMRAI::pdat::SideIndex<NDIM>>& fill_pts,
+                           const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                           const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                           double ls,
+                           const int axis,
+                           size_t stencil_size);
 
 /*!
  * Reconstruct the data at position x_loc, using a stencil centered at idx. Only uses points that have a non-zero volume
@@ -163,35 +163,35 @@ void floodFillForPoints(std::vector<SAMRAI::pdat::SideIndex<NDIM>>& fill_pts,
  *
  * x_loc must be given in index space.
  */
-double radialBasisFunctionReconstruction(IBTK::VectorNd x_loc,
-                                         const SAMRAI::pdat::CellIndex<NDIM>& idx,
-                                         const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
-                                         const SAMRAI::pdat::CellData<NDIM, double>& vol_data,
-                                         const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
-                                         const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch,
-                                         const RBFPolyOrder order,
-                                         const unsigned int stencil_size);
+double radial_basis_function_reconstruction(IBTK::VectorNd x_loc,
+                                            const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                                            const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
+                                            const SAMRAI::pdat::CellData<NDIM, double>& vol_data,
+                                            const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                                            const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch,
+                                            const RBFPolyOrder order,
+                                            const unsigned int stencil_size);
 
 /*!
  * Reconstruct the data at position x_loc, using a stencil centered at idx. Only uses points that have a non-zero volume
  * fraction in vol_data. The reconstruction uses a least squares polynomial fit.
  */
-double leastSquaresReconstruction(IBTK::VectorNd x_loc,
-                                  const SAMRAI::pdat::CellIndex<NDIM>& idx,
-                                  const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
-                                  const SAMRAI::pdat::CellData<NDIM, double>& vol_data,
-                                  const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
-                                  const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch,
-                                  LeastSquaresOrder order);
+double least_squares_reconstruction(IBTK::VectorNd x_loc,
+                                    const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                                    const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
+                                    const SAMRAI::pdat::CellData<NDIM, double>& vol_data,
+                                    const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                                    const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch,
+                                    LeastSquaresOrder order);
 
 /*!
  * Reconstruct data at position x_loc given the lower cell index idx_ll using bilinear interpolation.
  */
-double bilinearReconstruction(const IBTK::VectorNd& x_loc,
-                              const IBTK::VectorNd& x_ll,
-                              const SAMRAI::pdat::CellIndex<NDIM>& idx_ll,
-                              const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
-                              const double* const dx);
+double bilinear_reconstruction(const IBTK::VectorNd& x_loc,
+                               const IBTK::VectorNd& x_ll,
+                               const SAMRAI::pdat::CellIndex<NDIM>& idx_ll,
+                               const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
+                               const double* const dx);
 
 /*!
  * Reconstruct the data at position x_loc, using a stencil centered at idx. Only uses points that share the same sign of
@@ -199,24 +199,24 @@ double bilinearReconstruction(const IBTK::VectorNd& x_loc,
  *
  * x_loc must be given in index space.
  */
-double radialBasisFunctionReconstruction(IBTK::VectorNd x_loc,
-                                         double ls_val,
-                                         const SAMRAI::pdat::CellIndex<NDIM>& idx,
-                                         const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
-                                         const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
-                                         const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch,
-                                         const RBFPolyOrder order,
-                                         const unsigned int stencil_size);
+double radial_basis_function_reconstruction(IBTK::VectorNd x_loc,
+                                            double ls_val,
+                                            const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                                            const SAMRAI::pdat::CellData<NDIM, double>& Q_data,
+                                            const SAMRAI::pdat::NodeData<NDIM, double>& ls_data,
+                                            const SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>>& patch,
+                                            const RBFPolyOrder order,
+                                            const unsigned int stencil_size);
 
 /*!
  * Reconstruct the data at position x_loc, using a stencil centered at x_loc. Uses the provided positions and values.
  *
  * x_loc must be given in physical space.
  */
-double radialBasisFunctionReconstruction(const IBTK::VectorNd& x_loc,
-                                         const std::vector<IBTK::VectorNd>& X_pts,
-                                         const std::vector<double>& Q_vals,
-                                         const RBFPolyOrder order);
+double radial_basis_function_reconstruction(const IBTK::VectorNd& x_loc,
+                                            const std::vector<IBTK::VectorNd>& X_pts,
+                                            const std::vector<double>& Q_vals,
+                                            const RBFPolyOrder order);
 
 /*!
  * Compute finite-difference weights using the points in fd_pts evaluated at the point base_pt. The action of the
@@ -224,25 +224,25 @@ double radialBasisFunctionReconstruction(const IBTK::VectorNd& x_loc,
  */
 template <class Point>
 void
-RBFFDReconstruct(std::vector<double>& wgts,
-                 const Point& base_pt,
-                 const std::vector<Point>& fd_pts,
-                 const int poly_degree,
-                 const double* const dx,
-                 std::function<double(double)> rbf,
-                 std::function<double(const Point&, const Point&, void*)> L_rbf,
-                 void* rbf_ctx,
-                 std::function<IBTK::VectorXd(const std::vector<Point>&, int, double, const Point&, void*)> L_polys,
-                 void* poly_ctx);
+RBFFD_reconstruct(std::vector<double>& wgts,
+                  const Point& base_pt,
+                  const std::vector<Point>& fd_pts,
+                  const int poly_degree,
+                  const double* const dx,
+                  std::function<double(double)> rbf,
+                  std::function<double(const Point&, const Point&, void*)> L_rbf,
+                  void* rbf_ctx,
+                  std::function<IBTK::VectorXd(const std::vector<Point>&, int, double, const Point&, void*)> L_polys,
+                  void* poly_ctx);
 
 /*!
  * Compute the quadratic Lagrange interpolant to the location x using an interpolant centered at idx.
  *
  * Note that x must be given in index space.
  */
-double quadraticLagrangeInterpolant(IBTK::VectorNd x,
-                                    const SAMRAI::pdat::CellIndex<NDIM>& idx,
-                                    const SAMRAI::pdat::CellData<NDIM, double>& Q_data);
+double quadratic_lagrange_interpolant(IBTK::VectorNd x,
+                                      const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                                      const SAMRAI::pdat::CellData<NDIM, double>& Q_data);
 
 /*!
  * Compute the quadratic Lagrange interpolant to the location x using an interpolant centered at idx. Limit the
@@ -250,9 +250,9 @@ double quadraticLagrangeInterpolant(IBTK::VectorNd x,
  *
  * Note that x must be given in index space.
  */
-double quadraticLagrangeInterpolantLimited(IBTK::VectorNd x,
-                                           const SAMRAI::pdat::CellIndex<NDIM>& idx,
-                                           const SAMRAI::pdat::CellData<NDIM, double>& Q_data);
+double quadratic_lagrange_interpolant_limited(IBTK::VectorNd x,
+                                              const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                                              const SAMRAI::pdat::CellData<NDIM, double>& Q_data);
 
 /*!
  * Compute the divergence of a side centered velocity field using a finite difference stencil centered at idx.

--- a/include/ADS/solver_utilities.h
+++ b/include/ADS/solver_utilities.h
@@ -14,27 +14,27 @@
 
 namespace ADS
 {
-void copyDataToPetsc(Vec& petsc_vec,
-                     const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x_eul_vec,
-                     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy,
-                     const libMesh::System& x_lag_sys,
-                     int eul_map_idx,
-                     const std::map<int, int>& lag_dof_map,
-                     const std::vector<int>& dofs_per_proc);
+void copy_data_to_petsc(Vec& petsc_vec,
+                        const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x_eul_vec,
+                        SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy,
+                        const libMesh::System& x_lag_sys,
+                        int eul_map_idx,
+                        const std::map<int, int>& lag_dof_map,
+                        const std::vector<int>& dofs_per_proc);
 
-void copyDataFromPetsc(Vec& petsc_vec,
-                       const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x_eul_vec,
-                       SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy,
-                       libMesh::System& x_lag_sys,
-                       int eul_map_idx,
-                       const std::map<int, int>& lag_dof_map,
-                       const std::vector<int>& dofs_per_proc);
+void copy_data_from_petsc(Vec& petsc_vec,
+                          const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x_eul_vec,
+                          SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy,
+                          libMesh::System& x_lag_sys,
+                          int eul_map_idx,
+                          const std::map<int, int>& lag_dof_map,
+                          const std::vector<int>& dofs_per_proc);
 
-void copyDataFromPetsc(Vec& petsc_vec,
-                       const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x_eul_vec,
-                       SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy,
-                       libMesh::System& x_lag_sys,
-                       const ConditionCounter& cc);
+void copy_data_from_petsc(Vec& petsc_vec,
+                          const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x_eul_vec,
+                          SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy,
+                          libMesh::System& x_lag_sys,
+                          const ConditionCounter& cc);
 } // namespace ADS
 
 #endif // #ifndef included_ADS_solver_utilities

--- a/src/adv_ops/LagrangeReconstructions.cpp
+++ b/src/adv_ops/LagrangeReconstructions.cpp
@@ -71,7 +71,7 @@ LagrangeReconstructions::applyReconstruction(const int Q_idx, const int N_idx, c
                 const CellIndex<NDIM>& idx = ci();
                 VectorNd x_loc;
                 for (int d = 0; d < NDIM; ++d) x_loc[d] = (*xstar_data)(idx, d);
-                (*Q_new_data)(idx) = Reconstruct::quadraticLagrangeInterpolant(x_loc, idx, *Q_cur_data);
+                (*Q_new_data)(idx) = Reconstruct::quadratic_lagrange_interpolant(x_loc, idx, *Q_cur_data);
             }
         }
     }

--- a/src/adv_ops/LagrangeStructureReconstructions.cpp
+++ b/src/adv_ops/LagrangeStructureReconstructions.cpp
@@ -207,7 +207,8 @@ LagrangeStructureReconstructions::applyReconstructionLS(const int Q_idx, const i
                 {
                     if (within_lagrange_interpolant(idx, *ls_data))
                     {
-                        (*Q_new_data)(idx) = Reconstruct::quadraticLagrangeInterpolantLimited(x_loc, idx, *Q_cur_data);
+                        (*Q_new_data)(idx) =
+                            Reconstruct::quadratic_lagrange_interpolant_limited(x_loc, idx, *Q_cur_data);
                     }
                     else if (cut_cell_map.count(IndexList(patch, idx)) > 0 &&
                              (ls_val < 0.0 || !d_Q_out_sys_name.empty()))
@@ -256,7 +257,7 @@ LagrangeStructureReconstructions::applyReconstructionLS(const int Q_idx, const i
                         std::vector<CellIndex<NDIM>> idx_vec;
                         try
                         {
-                            Reconstruct::floodFillForPoints(
+                            Reconstruct::flood_fill_for_points(
                                 idx_vec, idx, *ls_data, ls_val, d_rbf_stencil_size - X_pts.size());
                         }
                         catch (const std::runtime_error& e)
@@ -275,12 +276,12 @@ LagrangeStructureReconstructions::applyReconstructionLS(const int Q_idx, const i
 
                         // Now reconstruct the function
                         (*Q_new_data)(idx) =
-                            Reconstruct::radialBasisFunctionReconstruction(x_loc, X_pts, Q_vals, d_rbf_order);
+                            Reconstruct::radial_basis_function_reconstruction(x_loc, X_pts, Q_vals, d_rbf_order);
                     }
                     else
                     {
                         // A node doesn't touch this cell. Just use normal interpolation.
-                        (*Q_new_data)(idx) = Reconstruct::radialBasisFunctionReconstruction(
+                        (*Q_new_data)(idx) = Reconstruct::radial_basis_function_reconstruction(
                             x_loc, ls_val, idx, *Q_cur_data, *ls_data, patch, d_rbf_order, d_rbf_stencil_size);
                     }
                 }

--- a/src/adv_ops/LinearReconstructions.cpp
+++ b/src/adv_ops/LinearReconstructions.cpp
@@ -87,9 +87,9 @@ LinearReconstructions::applyReconstruction(const int Q_idx, const int N_idx, con
                     std::vector<double> temp_dx = { 1.0, 1.0 };
                     if (use_bilinear)
                         (*Q_new_data)(idx) =
-                            Reconstruct::bilinearReconstruction(x_loc, x_ll, idx_ll, *Q_cur_data, temp_dx.data());
+                            Reconstruct::bilinear_reconstruction(x_loc, x_ll, idx_ll, *Q_cur_data, temp_dx.data());
                     else
-                        (*Q_new_data)(idx) = Reconstruct::radialBasisFunctionReconstruction(
+                        (*Q_new_data)(idx) = Reconstruct::radial_basis_function_reconstruction(
                             x_loc, idx, *Q_cur_data, *vol_cur_data, *ls_data, patch, d_rbf_order, d_rbf_stencil_size);
                 }
                 else

--- a/src/adv_ops/RBFDivergenceReconstructions.cpp
+++ b/src/adv_ops/RBFDivergenceReconstructions.cpp
@@ -125,7 +125,6 @@ RBFDivergenceReconstructions::applyReconstructionLS(const int u_idx, const int d
             Pointer<Patch<NDIM>> patch = level->getPatch(p());
 
             const Box<NDIM>& box = patch->getBox();
-            const hier::Index<NDIM>& idx_low = box.lower();
 
             Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
             const double* const dx = pgeom->getDx();
@@ -170,129 +169,20 @@ RBFDivergenceReconstructions::applyReconstructionLS(const int u_idx, const int d
                 if (within_regular_interpolant(idx, *ls_data, ls_val))
                 {
                     // Interpolate fd_div_data to x_loc.
-                    for (int d = 0; d < NDIM; ++d) x_loc[d] = (*xstar_data)(idx, d);
                     (*div_data)(idx) = Reconstruct::quadraticLagrangeInterpolantLimited(x_loc, idx, *fd_div_data);
                 }
                 else
                 {
-                    for (int d = 0; d < NDIM; ++d)
+                    // Use a finite difference stencil
+                    try
                     {
-                        std::vector<VectorNd> X_pts;
-                        std::vector<double> u_vals;
-                        std::vector<SideIndex<NDIM>> test_idxs = { SideIndex<NDIM>(idx, d, 0),
-                                                                   SideIndex<NDIM>(idx, d, 1) };
-                        unsigned int i = 0;
-                        while (X_pts.size() < d_rbf_stencil_size)
-                        {
-#ifndef NDEBUG
-                            if (i >= test_idxs.size())
-                            {
-                                std::ostringstream err_msg;
-                                err_msg << d_object_name
-                                        << "::applyReconstruction(): Could not find enough cells to perform "
-                                           "reconstruction.\n";
-                                err_msg << "  Reconstructing on index: " << idx << " and level " << ln
-                                        << " and patch num " << patch->getPatchNumber() << "\n";
-                                err_msg << "  Reconstructing at point: " << x_loc.transpose() << "\n";
-                                err_msg << "  ls value: " << ls_val << "\n";
-                                err_msg << "  Searched " << i << " indices and found " << test_idxs.size()
-                                        << " valid indices\n";
-                                err_msg << "  Ls neighbor values: "
-                                        << (*ls_new_data)(NodeIndex<NDIM>(idx, NodeIndex<NDIM>::LowerLeft)) << " "
-                                        << (*ls_new_data)(NodeIndex<NDIM>(idx, NodeIndex<NDIM>::LowerRight)) << " "
-                                        << (*ls_new_data)(NodeIndex<NDIM>(idx, NodeIndex<NDIM>::UpperLeft)) << " "
-                                        << (*ls_new_data)(NodeIndex<NDIM>(idx, NodeIndex<NDIM>::UpperRight)) << "\n";
-                                TBOX_ERROR(err_msg.str());
-                            }
-#endif
-                            const SideIndex<NDIM>& test_idx = test_idxs[i];
-                            if (ADS::node_to_side(test_idx, *ls_data) * ls_val > 0.0)
-                            {
-                                u_vals.push_back((*u_data)(test_idx));
-                                VectorNd xpt;
-                                for (int dd = 0; dd < NDIM; ++dd)
-                                    xpt[dd] = static_cast<double>(test_idx(dd) - idx_low(dd)) + (dd == d ? 0.0 : 0.5);
-                                X_pts.push_back(xpt);
-                            }
-
-                            // Add neighboring points to new_idxs. Prefer to add points in direction of axis.
-                            IntVector<NDIM> l(-1, 0), r(1, 0), b(0, -1), u(0, 1);
-                            SideIndex<NDIM> idx_l(test_idx + l), idx_r(test_idx + r);
-                            SideIndex<NDIM> idx_u(test_idx + u), idx_b(test_idx + b);
-                            if (d == 0)
-                            {
-                                if (ADS::node_to_side(idx_l, *ls_data) * ls_val > 0.0 &&
-                                    (std::find(test_idxs.begin(), test_idxs.end(), idx_l) == test_idxs.end()))
-                                    test_idxs.push_back(idx_l);
-                                if (ADS::node_to_side(idx_r, *ls_data) * ls_val > 0.0 &&
-                                    (std::find(test_idxs.begin(), test_idxs.end(), idx_r) == test_idxs.end()))
-                                    test_idxs.push_back(idx_r);
-
-                                if (ADS::node_to_side(idx_u, *ls_data) * ls_val > 0.0 &&
-                                    (std::find(test_idxs.begin(), test_idxs.end(), idx_u) == test_idxs.end()))
-                                    test_idxs.push_back(idx_u);
-                                if (ADS::node_to_side(idx_b, *ls_data) * ls_val > 0.0 &&
-                                    (std::find(test_idxs.begin(), test_idxs.end(), idx_b) == test_idxs.end()))
-                                    test_idxs.push_back(idx_b);
-                            }
-                            else
-                            {
-                                if (ADS::node_to_side(idx_u, *ls_data) * ls_val > 0.0 &&
-                                    (std::find(test_idxs.begin(), test_idxs.end(), idx_u) == test_idxs.end()))
-                                    test_idxs.push_back(idx_u);
-                                if (ADS::node_to_side(idx_b, *ls_data) * ls_val > 0.0 &&
-                                    (std::find(test_idxs.begin(), test_idxs.end(), idx_b) == test_idxs.end()))
-                                    test_idxs.push_back(idx_b);
-
-                                if (ADS::node_to_side(idx_l, *ls_data) * ls_val > 0.0 &&
-                                    (std::find(test_idxs.begin(), test_idxs.end(), idx_l) == test_idxs.end()))
-                                    test_idxs.push_back(idx_l);
-                                if (ADS::node_to_side(idx_r, *ls_data) * ls_val > 0.0 &&
-                                    (std::find(test_idxs.begin(), test_idxs.end(), idx_r) == test_idxs.end()))
-                                    test_idxs.push_back(idx_r);
-                            }
-                            ++i;
-                        }
-
-                        // We have all the points. Now determine weights.
-                        auto rbf = [](const double r) -> double { return r * r * r * r * r; };
-                        auto L_rbf = [](const VectorNd& xi, const VectorNd& xj, void* ctx) -> double {
-                            int d = *static_cast<int*>(ctx);
-                            double r = (xi - xj).norm();
-                            return 5.0 * (xi[d] - xj[d]) * r * r * r;
-                        };
-
-                        auto L_polys = [](const std::vector<VectorNd>& xpts,
-                                          int poly_degree,
-                                          double dx,
-                                          VectorNd base_pt,
-                                          void* ctx) -> VectorXd {
-                            int d = *static_cast<int*>(ctx);
-                            if (d == 0)
-                                return PolynomialBasis::dPdxMonomials(xpts, poly_degree, dx, base_pt).transpose();
-                            else
-                                return PolynomialBasis::dPdyMonomials(xpts, poly_degree, dx, base_pt).transpose();
-                        };
-
-                        // Need to shift x_loc by idx_low
-                        VectorNd new_x_loc;
-                        for (int d = 0; d < NDIM; ++d) new_x_loc[d] = x_loc[d] - static_cast<double>(idx_low(d));
-                        std::vector<double> wgts;
-                        std::vector<double> dummy_dx = { 1.0, 1.0 };
-                        Reconstruct::RBFFDReconstruct<VectorNd>(wgts,
-                                                                new_x_loc,
-                                                                X_pts,
-                                                                d_rbf_order == Reconstruct::RBFPolyOrder::LINEAR ? 1 :
-                                                                                                                   2,
-                                                                dummy_dx.data(),
-                                                                rbf,
-                                                                L_rbf,
-                                                                static_cast<void*>(&d),
-                                                                L_polys,
-                                                                static_cast<void*>(&d));
-                        // Now perform reconstruction.
-                        for (size_t i = 0; i < u_vals.size(); ++i)
-                            (*div_data)(idx) = (*div_data)(idx) + u_vals[i] * wgts[i] / dx[d];
+                        (*div_data)(idx) = Reconstruct::divergence(
+                            x_loc, idx, ls_val, *u_data, *ls_data, d_rbf_order, d_rbf_stencil_size, dx);
+                    }
+                    catch (const std::runtime_error& e)
+                    {
+                        pout << e.what() << "\n";
+                        TBOX_ERROR(d_object_name + "::applyReconstruction(): Could not perform reconstruction!\n");
                     }
                 }
             }

--- a/src/adv_ops/RBFDivergenceReconstructions.cpp
+++ b/src/adv_ops/RBFDivergenceReconstructions.cpp
@@ -169,7 +169,7 @@ RBFDivergenceReconstructions::applyReconstructionLS(const int u_idx, const int d
                 if (within_regular_interpolant(idx, *ls_data, ls_val))
                 {
                     // Interpolate fd_div_data to x_loc.
-                    (*div_data)(idx) = Reconstruct::quadraticLagrangeInterpolantLimited(x_loc, idx, *fd_div_data);
+                    (*div_data)(idx) = Reconstruct::quadratic_lagrange_interpolant_limited(x_loc, idx, *fd_div_data);
                 }
                 else
                 {

--- a/src/adv_ops/RBFReconstructions.cpp
+++ b/src/adv_ops/RBFReconstructions.cpp
@@ -118,7 +118,7 @@ RBFReconstructions::applyReconstructionCutCell(const int Q_idx, const int N_idx,
                 {
                     IBTK::VectorNd x_loc;
                     for (int d = 0; d < NDIM; ++d) x_loc(d) = (*xstar_data)(idx, d);
-                    (*Q_new_data)(idx) = Reconstruct::radialBasisFunctionReconstruction(
+                    (*Q_new_data)(idx) = Reconstruct::radial_basis_function_reconstruction(
                         x_loc, idx, *Q_cur_data, *vol_cur_data, *ls_data, patch, d_rbf_order, d_rbf_stencil_size);
                 }
                 else
@@ -165,14 +165,14 @@ RBFReconstructions::applyReconstructionLS(const int Q_idx, const int N_idx, cons
                     IBTK::VectorNd x_loc;
                     for (int d = 0; d < NDIM; ++d) x_loc(d) = (*xstar_data)(idx, d);
                     (*Q_new_data)(idx) =
-                        Reconstruct::radialBasisFunctionReconstruction(x_loc,
-                                                                       ADS::node_to_cell(idx, *ls_new_data),
-                                                                       idx,
-                                                                       *Q_cur_data,
-                                                                       *ls_data,
-                                                                       patch,
-                                                                       d_rbf_order,
-                                                                       d_rbf_stencil_size);
+                        Reconstruct::radial_basis_function_reconstruction(x_loc,
+                                                                          ADS::node_to_cell(idx, *ls_new_data),
+                                                                          idx,
+                                                                          *Q_cur_data,
+                                                                          *ls_data,
+                                                                          patch,
+                                                                          d_rbf_order,
+                                                                          d_rbf_stencil_size);
                 }
                 else
                 {

--- a/src/adv_ops/RBFStructureReconstructions.cpp
+++ b/src/adv_ops/RBFStructureReconstructions.cpp
@@ -242,20 +242,20 @@ RBFStructureReconstructions::applyReconstructionLS(const int Q_idx, const int N_
 
                         // Now reconstruct the function
                         (*Q_new_data)(idx) =
-                            Reconstruct::radialBasisFunctionReconstruction(x_loc, X_pts, Q_vals, d_rbf_order);
+                            Reconstruct::radial_basis_function_reconstruction(x_loc, X_pts, Q_vals, d_rbf_order);
                     }
                     else
                     {
                         // A node doesn't touch this cell. Just use normal interpolation.
                         (*Q_new_data)(idx) =
-                            Reconstruct::radialBasisFunctionReconstruction(x_loc,
-                                                                           ADS::node_to_cell(idx, *ls_new_data),
-                                                                           idx,
-                                                                           *Q_cur_data,
-                                                                           *ls_data,
-                                                                           patch,
-                                                                           d_rbf_order,
-                                                                           d_rbf_stencil_size);
+                            Reconstruct::radial_basis_function_reconstruction(x_loc,
+                                                                              ADS::node_to_cell(idx, *ls_new_data),
+                                                                              idx,
+                                                                              *Q_cur_data,
+                                                                              *ls_data,
+                                                                              patch,
+                                                                              d_rbf_order,
+                                                                              d_rbf_stencil_size);
                     }
                 }
                 else

--- a/src/adv_ops/ZSplineReconstructions.cpp
+++ b/src/adv_ops/ZSplineReconstructions.cpp
@@ -66,7 +66,7 @@ ZSplineReconstructions::applyReconstruction(const int Q_idx, const int N_idx, co
 
             Q_new_data->fillAll(0.0);
 
-            const int stencil_width = Reconstruct::getSplineWidth(d_order);
+            const int stencil_width = Reconstruct::get_spline_width(d_order);
 
             for (CellIterator<NDIM> ci(box); ci; ci++)
             {
@@ -76,10 +76,10 @@ ZSplineReconstructions::applyReconstruction(const int Q_idx, const int N_idx, co
                     IBTK::VectorNd x_loc;
                     for (int d = 0; d < NDIM; ++d) x_loc(d) = (*xstar_data)(idx, d);
                     // Check if we can use z-spline
-                    if (Reconstruct::indexWithinWidth(stencil_width, idx, *vol_cur_data))
-                        (*Q_new_data)(idx) = Reconstruct::sumOverZSplines(x_loc, idx, *Q_cur_data, d_order);
+                    if (Reconstruct::index_within_width(stencil_width, idx, *vol_cur_data))
+                        (*Q_new_data)(idx) = Reconstruct::sum_over_z_splines(x_loc, idx, *Q_cur_data, d_order);
                     else
-                        (*Q_new_data)(idx) = Reconstruct::radialBasisFunctionReconstruction(
+                        (*Q_new_data)(idx) = Reconstruct::radial_basis_function_reconstruction(
                             x_loc, idx, *Q_cur_data, *vol_cur_data, *ls_data, patch, d_rbf_order, d_rbf_stencil_size);
                 }
                 else

--- a/src/integrators/LSAdvDiffIntegrator.cpp
+++ b/src/integrators/LSAdvDiffIntegrator.cpp
@@ -1741,7 +1741,7 @@ LSAdvDiffIntegrator::evaluateMappingOnHierarchy(const int xstar_idx,
                 const CellIndex<NDIM>& idx = ci();
                 IBTK::VectorNd x_loc;
                 for (int d = 0; d < NDIM; ++d) x_loc(d) = (*xstar_data)(idx, d);
-                (*Q_new_data)(idx) = Reconstruct::sumOverZSplines(x_loc, idx, *Q_cur_data, order);
+                (*Q_new_data)(idx) = Reconstruct::sum_over_z_splines(x_loc, idx, *Q_cur_data, order);
             }
         }
     }

--- a/src/level_set/LSFromLevelSet.cpp
+++ b/src/level_set/LSFromLevelSet.cpp
@@ -89,7 +89,7 @@ LSFromLevelSet::doUpdateVolumeAreaSideLS(int vol_idx,
                 const CellIndex<NDIM>& idx = ci();
                 VectorNd x;
                 for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * static_cast<double>(idx(d) - patch_lower(d));
-                std::pair<double, double> vol_area_pair = findVolumeAndArea(x, dx, phi_data, idx);
+                std::pair<double, double> vol_area_pair = find_volume_and_area(x, dx, phi_data, idx);
                 double volume = vol_area_pair.first;
                 double area = vol_area_pair.second;
                 if (area_idx != IBTK::invalid_index)

--- a/src/level_set/LSFromMesh.cpp
+++ b/src/level_set/LSFromMesh.cpp
@@ -305,7 +305,7 @@ LSFromMesh::doUpdateVolumeAreaSideLSNode(int vol_idx,
                 const CellIndex<NDIM>& idx = ci();
                 VectorNd x;
                 for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * static_cast<double>(idx(d) - patch_lower(d));
-                std::pair<double, double> vol_area_pair = findVolumeAndArea(x, dx, phi_data, idx);
+                std::pair<double, double> vol_area_pair = find_volume_and_area(x, dx, phi_data, idx);
                 double volume = vol_area_pair.first;
                 double area = vol_area_pair.second;
                 if (area_idx != IBTK::invalid_index)

--- a/src/level_set/ls_functions.cpp
+++ b/src/level_set/ls_functions.cpp
@@ -60,10 +60,10 @@ length_fraction(const double dx, const double phi_l, const double phi_u)
 }
 
 std::pair<double, double>
-findVolumeAndArea(const VectorNd& xloc,
-                  const double* const dx,
-                  Pointer<NodeData<NDIM, double>> phi_data,
-                  const CellIndex<NDIM>& idx)
+find_volume_and_area(const VectorNd& xloc,
+                     const double* const dx,
+                     Pointer<NodeData<NDIM, double>> phi_data,
+                     const CellIndex<NDIM>& idx)
 {
     double volume = 0.0, area = 0.0;
     // Create the initial simplices.
@@ -154,14 +154,14 @@ findVolumeAndArea(const VectorNd& xloc,
     }
     else
     {
-        volume = findVolume(simplices);
-        area = findArea(simplices);
+        volume = find_volume(simplices);
+        area = find_area(simplices);
     }
     return std::make_pair(volume, area);
 }
 
 double
-findVolume(const std::vector<Simplex>& simplices)
+find_volume(const std::vector<Simplex>& simplices)
 {
     // Loop over simplices
     std::vector<std::array<VectorNd, NDIM + 1>> final_simplices;
@@ -331,7 +331,7 @@ findVolume(const std::vector<Simplex>& simplices)
 }
 
 double
-findArea(const std::vector<Simplex>& simplices)
+find_area(const std::vector<Simplex>& simplices)
 {
     // We need a lower dimensional simplex here. We're computing areas
     std::vector<std::array<VectorNd, NDIM>> final_simplices;

--- a/src/rbffd/RBFFDWeightsCache.cpp
+++ b/src/rbffd/RBFFDWeightsCache.cpp
@@ -263,7 +263,7 @@ RBFFDWeightsCache::findRBFFDWeights()
         {
             const std::vector<FDPoint>& pt_vec = d_pair_pt_map.at(patch.getPointer()).at(base_pt);
             std::vector<double> wgts;
-            Reconstruct::RBFFDReconstruct<FDPoint>(
+            Reconstruct::RBFFD_reconstruct<FDPoint>(
                 wgts, base_pt, pt_vec, d_poly_degree, dx, d_rbf_fcn, Lrbf_fcn, nullptr, Lpoly_fcn, nullptr);
             d_pt_weight_map[patch.getPointer()][base_pt] = std::move(wgts);
         }

--- a/src/reconstructions/BoundaryReconstructCache.cpp
+++ b/src/reconstructions/BoundaryReconstructCache.cpp
@@ -143,7 +143,7 @@ BoundaryReconstructCache::cacheData()
                     [](const std::vector<VectorNd>& pt_vec, int poly_degree, double ds, const VectorNd& shft, void*)
                     -> MatrixXd { return PolynomialBasis::formMonomials(pt_vec, poly_degree, ds, shft).transpose(); };
                 int poly_degree = 1;
-                Reconstruct::RBFFDReconstruct<VectorNd>(
+                Reconstruct::RBFFD_reconstruct<VectorNd>(
                     wgts, x_node, X_list, poly_degree, dx, Reconstruct::rbf, L_rbf, nullptr, L_polys, nullptr);
 
                 // Now store the weights.

--- a/src/reconstructions/reconstructions.cpp
+++ b/src/reconstructions/reconstructions.cpp
@@ -9,6 +9,8 @@
 #include "CellData.h"
 #include "NodeData.h"
 
+namespace ADS
+{
 namespace Reconstruct
 {
 double
@@ -383,3 +385,4 @@ radialBasisFunctionReconstruction(const IBTK::VectorNd& x_loc,
 }
 
 } // namespace Reconstruct
+} // namespace ADS

--- a/src/reconstructions/reconstructions.cpp
+++ b/src/reconstructions/reconstructions.cpp
@@ -14,14 +14,14 @@ namespace ADS
 namespace Reconstruct
 {
 double
-sumOverZSplines(const IBTK::VectorNd& x_loc,
-                const CellIndex<NDIM>& idx,
-                const CellData<NDIM, double>& Q_data,
-                const int order)
+sum_over_z_splines(const IBTK::VectorNd& x_loc,
+                   const CellIndex<NDIM>& idx,
+                   const CellData<NDIM, double>& Q_data,
+                   const int order)
 {
     double val = 0.0;
     Box<NDIM> box(idx, idx);
-    box.grow(getSplineWidth(order) + 1);
+    box.grow(get_spline_width(order) + 1);
     const Box<NDIM>& ghost_box = Q_data.getGhostBox();
     TBOX_ASSERT(ghost_box.contains(box));
     for (CellIterator<NDIM> ci(box); ci; ci++)
@@ -29,13 +29,13 @@ sumOverZSplines(const IBTK::VectorNd& x_loc,
         const CellIndex<NDIM>& idx_c = ci();
         VectorNd xx;
         for (int d = 0; d < NDIM; ++d) xx(d) = idx_c(d) + 0.5;
-        val += Q_data(idx_c) * evaluateZSpline(x_loc - xx, order);
+        val += Q_data(idx_c) * evaluate_z_spline(x_loc - xx, order);
     }
     return val;
 }
 
 bool
-indexWithinWidth(const int stencil_width, const CellIndex<NDIM>& idx, const CellData<NDIM, double>& vol_data)
+index_within_width(const int stencil_width, const CellIndex<NDIM>& idx, const CellData<NDIM, double>& vol_data)
 {
     bool withinWidth = true;
     Box<NDIM> check_box(idx, idx);
@@ -49,24 +49,24 @@ indexWithinWidth(const int stencil_width, const CellIndex<NDIM>& idx, const Cell
 }
 
 double
-evaluateZSpline(const VectorNd x, const int order)
+evaluate_z_spline(const VectorNd x, const int order)
 {
     double val = 1.0;
     for (int d = 0; d < NDIM; ++d)
     {
-        val *= ZSpline(x(d), order);
+        val *= z_spline(x(d), order);
     }
     return val;
 }
 
 int
-getSplineWidth(const int order)
+get_spline_width(const int order)
 {
     return order + 1;
 }
 
 double
-ZSpline(double x, const int order)
+z_spline(double x, const int order)
 {
     x = std::fabs(x);
     switch (order)
@@ -102,14 +102,14 @@ ZSpline(double x, const int order)
 }
 
 double
-radialBasisFunctionReconstruction(IBTK::VectorNd x_loc,
-                                  const CellIndex<NDIM>& idx,
-                                  const CellData<NDIM, double>& Q_data,
-                                  const CellData<NDIM, double>& vol_data,
-                                  const NodeData<NDIM, double>& ls_data,
-                                  const Pointer<Patch<NDIM>>& patch,
-                                  const RBFPolyOrder order,
-                                  const unsigned int stencil_size)
+radial_basis_function_reconstruction(IBTK::VectorNd x_loc,
+                                     const CellIndex<NDIM>& idx,
+                                     const CellData<NDIM, double>& Q_data,
+                                     const CellData<NDIM, double>& vol_data,
+                                     const NodeData<NDIM, double>& ls_data,
+                                     const Pointer<Patch<NDIM>>& patch,
+                                     const RBFPolyOrder order,
+                                     const unsigned int stencil_size)
 {
     Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
     const double* const dx = pgeom->getDx();
@@ -156,17 +156,17 @@ radialBasisFunctionReconstruction(IBTK::VectorNd x_loc,
         ++i;
     }
 
-    return radialBasisFunctionReconstruction(x_loc, X_vals, Q_vals, order);
+    return radial_basis_function_reconstruction(x_loc, X_vals, Q_vals, order);
 }
 
 double
-leastSquaresReconstruction(IBTK::VectorNd x_loc,
-                           const CellIndex<NDIM>& idx,
-                           const CellData<NDIM, double>& Q_data,
-                           const CellData<NDIM, double>& vol_data,
-                           const NodeData<NDIM, double>& ls_data,
-                           const Pointer<Patch<NDIM>>& patch,
-                           LeastSquaresOrder order)
+least_squares_reconstruction(IBTK::VectorNd x_loc,
+                             const CellIndex<NDIM>& idx,
+                             const CellData<NDIM, double>& Q_data,
+                             const CellData<NDIM, double>& vol_data,
+                             const NodeData<NDIM, double>& ls_data,
+                             const Pointer<Patch<NDIM>>& patch,
+                             LeastSquaresOrder order)
 {
 #if (NDIM == 3)
     TBOX_ERROR("MLS reconstruction not implemented for 3 spatial dimensions. Use RBF reconstruction.\n");
@@ -259,11 +259,11 @@ leastSquaresReconstruction(IBTK::VectorNd x_loc,
 }
 
 double
-bilinearReconstruction(const VectorNd& x_loc,
-                       const VectorNd& x_ll,
-                       const CellIndex<NDIM>& idx_ll,
-                       const CellData<NDIM, double>& Q_data,
-                       const double* const dx)
+bilinear_reconstruction(const VectorNd& x_loc,
+                        const VectorNd& x_ll,
+                        const CellIndex<NDIM>& idx_ll,
+                        const CellData<NDIM, double>& Q_data,
+                        const double* const dx)
 {
     double q00 = Q_data(idx_ll);
     double q01 = Q_data(idx_ll + IntVector<NDIM>(0, 1));
@@ -274,14 +274,14 @@ bilinearReconstruction(const VectorNd& x_loc,
 }
 
 double
-radialBasisFunctionReconstruction(IBTK::VectorNd x_loc,
-                                  const double ls_val,
-                                  const CellIndex<NDIM>& idx,
-                                  const CellData<NDIM, double>& Q_data,
-                                  const NodeData<NDIM, double>& ls_data,
-                                  const Pointer<Patch<NDIM>>& patch,
-                                  const RBFPolyOrder order,
-                                  const unsigned int stencil_size)
+radial_basis_function_reconstruction(IBTK::VectorNd x_loc,
+                                     const double ls_val,
+                                     const CellIndex<NDIM>& idx,
+                                     const CellData<NDIM, double>& Q_data,
+                                     const NodeData<NDIM, double>& ls_data,
+                                     const Pointer<Patch<NDIM>>& patch,
+                                     const RBFPolyOrder order,
+                                     const unsigned int stencil_size)
 {
     Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
     const double* const dx = pgeom->getDx();
@@ -298,7 +298,7 @@ radialBasisFunctionReconstruction(IBTK::VectorNd x_loc,
     std::vector<CellIndex<NDIM>> stencil_idxs;
     try
     {
-        floodFillForPoints(stencil_idxs, idx, ls_data, ls_val, stencil_size);
+        flood_fill_for_points(stencil_idxs, idx, ls_data, ls_val, stencil_size);
     }
     catch (const std::runtime_error& e)
     {
@@ -315,14 +315,14 @@ radialBasisFunctionReconstruction(IBTK::VectorNd x_loc,
         X_vals.push_back(x_cent_c);
     }
 
-    return radialBasisFunctionReconstruction(x_loc, X_vals, Q_vals, order);
+    return radial_basis_function_reconstruction(x_loc, X_vals, Q_vals, order);
 }
 
 double
-radialBasisFunctionReconstruction(const IBTK::VectorNd& x_loc,
-                                  const std::vector<IBTK::VectorNd>& X_pts,
-                                  const std::vector<double>& Q_vals,
-                                  const RBFPolyOrder order)
+radial_basis_function_reconstruction(const IBTK::VectorNd& x_loc,
+                                     const std::vector<IBTK::VectorNd>& X_pts,
+                                     const std::vector<double>& Q_vals,
+                                     const RBFPolyOrder order)
 {
     int poly_size = 0;
     switch (order)

--- a/src/utilities/solver_utilities.cpp
+++ b/src/utilities/solver_utilities.cpp
@@ -14,13 +14,13 @@
 namespace ADS
 {
 void
-copyDataToPetsc(Vec& petsc_vec,
-                const SAMRAIVectorReal<NDIM, double>& x_eul_vec,
-                Pointer<PatchHierarchy<NDIM>> hierarchy,
-                const System& x_lag_sys,
-                int eul_map_idx,
-                const std::map<int, int>& lag_dof_map,
-                const std::vector<int>& /*dofs_per_proc*/)
+copy_data_to_petsc(Vec& petsc_vec,
+                   const SAMRAIVectorReal<NDIM, double>& x_eul_vec,
+                   Pointer<PatchHierarchy<NDIM>> hierarchy,
+                   const System& x_lag_sys,
+                   int eul_map_idx,
+                   const std::map<int, int>& lag_dof_map,
+                   const std::vector<int>& /*dofs_per_proc*/)
 {
     // We are assuming the PETSc Vec has been allocated correctly.
     int ierr;
@@ -75,13 +75,13 @@ copyDataToPetsc(Vec& petsc_vec,
 }
 
 void
-copyDataFromPetsc(Vec& petsc_vec,
-                  const SAMRAIVectorReal<NDIM, double>& x_eul_vec,
-                  Pointer<PatchHierarchy<NDIM>> hierarchy,
-                  System& x_lag_sys,
-                  int eul_map_idx,
-                  const std::map<int, int>& lag_dof_map,
-                  const std::vector<int>& dofs_per_proc)
+copy_data_from_petsc(Vec& petsc_vec,
+                     const SAMRAIVectorReal<NDIM, double>& x_eul_vec,
+                     Pointer<PatchHierarchy<NDIM>> hierarchy,
+                     System& x_lag_sys,
+                     int eul_map_idx,
+                     const std::map<int, int>& lag_dof_map,
+                     const std::vector<int>& dofs_per_proc)
 {
     // We are assuming the PETSc Vec has been allocated correctly.
     int ierr;
@@ -132,11 +132,11 @@ copyDataFromPetsc(Vec& petsc_vec,
 }
 
 void
-copyDataFromPetsc(Vec& petsc_vec,
-                  const SAMRAIVectorReal<NDIM, double>& x_eul_vec,
-                  Pointer<PatchHierarchy<NDIM>> hierarchy,
-                  System& x_lag_sys,
-                  const ConditionCounter& cc)
+copy_data_from_petsc(Vec& petsc_vec,
+                     const SAMRAIVectorReal<NDIM, double>& x_eul_vec,
+                     Pointer<PatchHierarchy<NDIM>> hierarchy,
+                     System& x_lag_sys,
+                     const ConditionCounter& cc)
 {
     TBOX_ASSERT(x_eul_vec.getNumberOfComponents() == 1);
     // We are assuming the PETSc Vec has been allocated correctly.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ SETUP_2D(rbffd point_list.cpp)
 
 SETUP_3D(rbffd point_list.cpp)
 
+SETUP_2D(reconstructions divergence.cpp)
 SETUP_2D(reconstructions fd_weights.cpp)
 
 SETUP_3D(reconstructions fd_weights.cpp)

--- a/tests/operators/apply_rbf_matrix.cpp
+++ b/tests/operators/apply_rbf_matrix.cpp
@@ -310,7 +310,7 @@ main(int argc, char* argv[])
         const int eul_map = global_indexing->getEulerianMap();
         const std::map<int, int>& lag_map = global_indexing->getLagrangianMap();
         const std::vector<int> dofs_per_proc = global_indexing->getDofsPerProc();
-        copyDataToPetsc(x_vec, x_eul_vec, patch_hierarchy, x_bdry_sys, eul_map, lag_map, dofs_per_proc);
+        copy_data_to_petsc(x_vec, x_eul_vec, patch_hierarchy, x_bdry_sys, eul_map, lag_map, dofs_per_proc);
         fillGhostCells(x_vec, solver.getGhostPoints(), global_indexing);
 
         // Now we can apply the matrix
@@ -322,7 +322,7 @@ main(int argc, char* argv[])
         IBTK_CHKERRQ(ierr);
         // Now copy data back to original specifications
         pout << "Copying data from petsc representation\n";
-        copyDataFromPetsc(b_vec, b_eul_vec, patch_hierarchy, b_bdry_sys, *solver.getBulkConditionMap());
+        copy_data_from_petsc(b_vec, b_eul_vec, patch_hierarchy, b_bdry_sys, *solver.getBulkConditionMap());
 
         pout << "Checking errors\n";
         // Compute errors

--- a/tests/operators/copy_to_petsc.cpp
+++ b/tests/operators/copy_to_petsc.cpp
@@ -234,9 +234,9 @@ main(int argc, char* argv[])
             VecCreateMPI(IBTK_MPI::getCommunicator(), dofs_per_proc[IBTK_MPI::getRank()], PETSC_DETERMINE, &x_vec);
         IBTK_CHKERRQ(ierr);
         // Now copy data to x_vec
-        copyDataToPetsc(x_vec, exact_eul_vec, patch_hierarchy, exact_bdry_sys, eul_map, lag_map, dofs_per_proc);
+        copy_data_to_petsc(x_vec, exact_eul_vec, patch_hierarchy, exact_bdry_sys, eul_map, lag_map, dofs_per_proc);
         // Now copy data back
-        copyDataFromPetsc(x_vec, copied_eul_vec, patch_hierarchy, copied_bdry_sys, eul_map, lag_map, dofs_per_proc);
+        copy_data_from_petsc(x_vec, copied_eul_vec, patch_hierarchy, copied_bdry_sys, eul_map, lag_map, dofs_per_proc);
 
         pout << "Checking copied data\n";
         // Only check finest level

--- a/tests/reconstructions/divergence.cpp
+++ b/tests/reconstructions/divergence.cpp
@@ -1,0 +1,423 @@
+#include <ibamr/config.h>
+
+#include <ADS/GeneralBoundaryMeshMapping.h>
+#include <ADS/LSFromMesh.h>
+#include <ADS/PointwiseFunction.h>
+#include <ADS/RBFDivergenceReconstructions.h>
+#include <ADS/app_namespaces.h>
+
+#include "ibtk/muParserCartGridFunction.h"
+#include "ibtk/muParserRobinBcCoefs.h"
+#include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+
+#include "tbox/Pointer.h"
+
+#include <libmesh/edge_edge2.h>
+#include <libmesh/exodusII_io.h>
+#include <libmesh/explicit_system.h>
+#include <libmesh/mesh_generation.h>
+
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <LoadBalancer.h>
+#include <SAMRAI_config.h>
+#include <StandardTagAndInitialize.h>
+
+int finest_ln;
+std::array<int, NDIM> N;
+double MFAC = 0.0;
+double dx = 0.0;
+double L = 0.0;
+double ds;
+double R = 0.0;
+VectorNd cent;
+
+VectorNd
+cylinder_pt(const double s, const double t)
+{
+    VectorNd x;
+    x(0) = cent(0) + R * std::cos(2.0 * M_PI * s);
+    x(1) = cent(1) + R * std::sin(2.0 * M_PI * s);
+    return x;
+}
+
+void
+generate_structure(int& num_vertices, std::vector<IBTK::Point>& vertex_posn)
+{
+    // Generating upper level of channel.
+    // Determine lag grid spacing.
+    double circum = 2.0 * M_PI * R;
+    ds = MFAC * circum * dx;
+    num_vertices = std::ceil(L / ds);
+    vertex_posn.resize(num_vertices);
+    for (int i = 0; i < num_vertices; ++i)
+    {
+        VectorNd x = cylinder_pt(ds * (static_cast<double>(i) + 0.5), 0.0);
+        vertex_posn[i] = x;
+    }
+    return;
+}
+
+double
+u_fcn(const double /*u*/, const VectorNd& x, const double time, const int axis)
+{
+    return std::pow(std::sin(0.5 * M_PI * x[0]) * std::sin(0.5 * M_PI * x[1]), 4.0);
+}
+
+VectorNd
+u_draw_fcn(const VectorNd& /*u*/, const VectorNd& x, const double time)
+{
+    VectorNd u;
+    for (int d = 0; d < NDIM; ++d) u[d] = std::pow(std::sin(0.5 * M_PI * x[0]) * std::sin(0.5 * M_PI * x[1]), 4.0);
+    return u;
+}
+
+double
+div_fcn(const double /*div*/, const VectorNd& x, const double time)
+{
+    return 2.0 * M_PI *
+               (std::cos(0.5 * M_PI * x[1]) * std::sin(0.5 * M_PI * x[0]) *
+                std::pow(std::sin(0.5 * M_PI * x[0]) * std::sin(0.5 * M_PI * x[1]), 3.0)) +
+           2.0 * M_PI *
+               (std::cos(0.5 * M_PI * x[0]) * std::sin(0.5 * M_PI * x[1]) *
+                std::pow(std::sin(0.5 * M_PI * x[0]) * std::sin(0.5 * M_PI * x[1]), 3.0));
+}
+
+void
+compute_divergence(std::shared_ptr<GeneralBoundaryMeshMapping>& mesh_mapping,
+                   const std::string& div_sys_name,
+                   const std::string& err_sys_name,
+                   const int u_idx,
+                   const int ls_idx,
+                   Pointer<PatchHierarchy<NDIM>> hierarchy)
+{
+    const std::shared_ptr<FEMeshPartitioner>& mesh_partitioner = mesh_mapping->getMeshPartitioner();
+    EquationSystems* eq_sys = mesh_mapping->getMeshPartitioner()->getEquationSystems();
+
+    // Pull out relevant FE data
+    System& X_bdry_sys = eq_sys->get_system(mesh_partitioner->COORDINATES_SYSTEM_NAME);
+    const DofMap& X_bdry_dof_map = X_bdry_sys.get_dof_map();
+    NumericVector<double>* X_bdry_vec = X_bdry_sys.current_local_solution.get();
+
+    System& divu_sys = eq_sys->get_system(div_sys_name);
+    const DofMap& divu_dof_map = divu_sys.get_dof_map();
+    NumericVector<double>* divu_vec = divu_sys.solution.get();
+
+    System& err_sys = eq_sys->get_system(err_sys_name);
+    const DofMap& err_dof_map = err_sys.get_dof_map();
+    NumericVector<double>* err_vec = err_sys.solution.get();
+
+    // Loop through all local nodes
+    auto it = eq_sys->get_mesh().local_nodes_begin();
+    auto it_end = eq_sys->get_mesh().local_nodes_end();
+    for (; it != it_end; ++it)
+    {
+        const Node* const node = *it;
+
+        // Get the current location of the node
+        VectorNd xpt;
+        std::vector<dof_id_type> X_dofs;
+        X_bdry_dof_map.dof_indices(node, X_dofs);
+        for (int d = 0; d < NDIM; ++d) xpt[d] = (*X_bdry_vec)(X_dofs[d]);
+
+        // Compute the divergence. We first need the index of the point. Assume this point is on the specified level
+        Pointer<GridGeometry<NDIM>> grid_geom = hierarchy->getGridGeometry();
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(hierarchy->getFinestLevelNumber());
+        const CellIndex<NDIM>& idx = IndexUtilities::getCellIndex(xpt, grid_geom, level->getRatio());
+        Pointer<Patch<NDIM>> patch;
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            patch = level->getPatch(p());
+            // Is this point located on this patch?
+            if (patch->getBox().contains(idx)) continue;
+        }
+
+        // We have the patch and current index. Let's compute divergence. We are reconstruction from negative side.
+        const static double ls = -1.0;
+        Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
+        Pointer<SideData<NDIM, double>> u_data = patch->getPatchData(u_idx);
+        Pointer<NodeData<NDIM, double>> ls_data = patch->getPatchData(ls_idx);
+        const double* const dx = pgeom->getDx();
+        const double* const xlow = pgeom->getXLower();
+        const hier::Index<NDIM>& idx_low = patch->getBox().lower();
+        // Convert xpt to index space
+        VectorNd x_idx;
+        for (int d = 0; d < NDIM; ++d) x_idx[d] = (xpt[d] - xlow[d]) / dx[d] + idx_low(d);
+        double div = ADS::Reconstruct::divergence(
+            x_idx, idx, ls, *u_data, *ls_data, ADS::Reconstruct::RBFPolyOrder::QUADRATIC, 12, dx, false);
+
+        std::vector<dof_id_type> divu_dofs;
+        divu_dof_map.dof_indices(node, divu_dofs);
+        divu_vec->set(divu_dofs[0], div);
+
+        std::vector<dof_id_type> err_dofs;
+        err_dof_map.dof_indices(node, err_dofs);
+        err_vec->set(err_dofs[0], std::abs(div - div_fcn(0.0, xpt, 0.0)));
+    }
+
+    divu_vec->close();
+    divu_sys.update();
+    err_vec->close();
+    err_sys.update();
+}
+
+void
+computeSurfaceErrors(std::shared_ptr<FEMeshPartitioner> fe_data_manager, const std::string& err_name)
+{
+    EquationSystems* eq_sys = fe_data_manager->getEquationSystems();
+    const MeshBase& mesh = eq_sys->get_mesh();
+    ExplicitSystem& err_sys = eq_sys->get_system<ExplicitSystem>(err_name);
+    NumericVector<double>* err_vec = err_sys.solution.get();
+
+    const DofMap& err_dof_map = err_sys.get_dof_map();
+    const FEType& err_fe_type = err_dof_map.variable_type(0);
+
+    std::unique_ptr<FEBase> fe = FEBase::build(mesh.mesh_dimension(), err_fe_type);
+    std::unique_ptr<QBase> qrule = QBase::build(QGAUSS, mesh.mesh_dimension(), THIRD);
+    fe->attach_quadrature_rule(qrule.get());
+    const std::vector<std::vector<double>>& phi = fe->get_phi();
+    const std::vector<double>& JxW = fe->get_JxW();
+
+    auto it = mesh.local_nodes_begin();
+    const auto it_end = mesh.local_nodes_end();
+    double l1_norm = 0.0, l2_norm = 0.0, max_norm = 0.0;
+    for (; it != it_end; ++it)
+    {
+        Node* n = *it;
+        VectorNd x;
+        for (int d = 0; d < NDIM; ++d) x[d] = (*n)(d);
+        const int dof_index = n->dof_number(err_sys.number(), 0, 0);
+        max_norm = std::max(max_norm, (*err_vec)(dof_index));
+    }
+
+    auto it_e = mesh.local_elements_begin();
+    const auto& it_e_end = mesh.local_elements_end();
+    for (; it_e != it_e_end; ++it_e)
+    {
+        Elem* el = *it_e;
+        fe->reinit(el);
+        boost::multi_array<double, 1> err_node;
+        std::vector<dof_id_type> err_dof_indices;
+        err_dof_map.dof_indices(el, err_dof_indices);
+        IBTK::get_values_for_interpolation(err_node, *err_vec, err_dof_indices);
+        for (unsigned int qp = 0; qp < JxW.size(); ++qp)
+        {
+            for (unsigned int n = 0; n < phi.size(); ++n)
+            {
+                l1_norm += err_node[n] * phi[n][qp] * JxW[qp];
+                l2_norm += std::pow(err_node[n] * phi[n][qp], 2.0) * JxW[qp];
+            }
+        }
+    }
+    l2_norm = std::sqrt(l2_norm);
+
+    pout << "Error at surface\n";
+    pout << " L1-norm:  " << l1_norm << "\n";
+    pout << " L2-norm:  " << l2_norm << "\n";
+    pout << " max-norm: " << max_norm << "\n";
+
+    err_vec->close();
+}
+
+/*******************************************************************************
+ * For each run, the input filename and restart information (if needed) must   *
+ * be given on the command line.  For non-restarted case, command line is:     *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ * For restarted run, command line is:                                         *
+ *                                                                             *
+ *    executable <input file name> <restart directory> <restart number>        *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize PETSc, MPI, and SAMRAI.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+
+    // Suppress a warning
+    SAMRAI::tbox::Logger::getInstance()->setWarning(false);
+
+    { // cleanup dynamically allocated objects prior to shutdown
+
+        // Parse command line options, set some standard options from the input
+        // file, initialize the restart database (if this is a restarted run),
+        // and enable file logging.
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "adv_diff.log");
+        Pointer<Database> input_db = app_initializer->getInputDatabase();
+        Pointer<Database> main_db = app_initializer->getComponentDatabase("Main");
+        const string reaction_exodus_filename = app_initializer->getExodusIIFilename("reaction");
+
+        // Get various standard options set in the input file.
+        const bool dump_postproc_data = app_initializer->dumpPostProcessingData();
+        const std::string postproc_data_dump_dirname = app_initializer->getPostProcessingDataDumpDirectory();
+        if (dump_postproc_data && !postproc_data_dump_dirname.empty())
+        {
+            Utilities::recursiveMkdir(postproc_data_dump_dirname);
+        }
+
+        N[0] = N[1] = input_db->getInteger("NFINEST");
+        finest_ln = input_db->getInteger("MAX_LEVELS") - 1;
+        R = input_db->getDouble("R");
+        L = input_db->getDouble("L");
+        MFAC = input_db->getDouble("MFAC");
+        dx = L / N[0];
+
+        // Generate the mesh
+        libMesh::Mesh mesh(ibtk_init.getLibMeshInit().comm(), NDIM - 1);
+        {
+            int num_vertices = 0;
+            std::vector<IBTK::Point> vertex_posn;
+            generate_structure(num_vertices, vertex_posn);
+            mesh.reserve_nodes(num_vertices);
+            mesh.reserve_elem(num_vertices);
+            for (int node_num = 0; node_num < num_vertices; ++node_num)
+            {
+                mesh.add_point(libMesh::Point(vertex_posn[node_num][0], vertex_posn[node_num][1], 0.0), node_num);
+            }
+
+            // Generate elements
+            for (int i = 0; i < num_vertices - 1; ++i)
+            {
+                Elem* elem = mesh.add_elem(new libMesh::Edge2());
+                elem->set_node(0) = mesh.node_ptr(i);
+                elem->set_node(1) = mesh.node_ptr(i + 1);
+            }
+
+            // Last element is from node num_vertices to node 0
+            Elem* elem = mesh.add_elem(new libMesh::Edge2());
+            elem->set_node(0) = mesh.node_ptr(num_vertices - 1);
+            elem->set_node(1) = mesh.node_ptr(0);
+        }
+        mesh.prepare_for_use();
+
+        // Create major algorithm and data objects that comprise the
+        // application.  These objects are configured from the input database
+        // and, if this is a restarted run, from the restart database.
+        Pointer<CartesianGridGeometry<NDIM>> grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<PatchHierarchy<NDIM>> patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<BergerRigoutsos<NDIM>> box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<StandardTagAndInitialize<NDIM>> error_detector = new StandardTagAndInitialize<NDIM>(
+            "StandardTagAndInitialize", nullptr, app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<LoadBalancer<NDIM>> load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM>> gridding_algorithm =
+            new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                        app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                        error_detector,
+                                        box_generator,
+                                        load_balancer);
+
+        Pointer<NodeVariable<NDIM, double>> ls_var = new NodeVariable<NDIM, double>("ls_var");
+        Pointer<CellVariable<NDIM, double>> vol_var = new CellVariable<NDIM, double>("VOL");
+        Pointer<SideVariable<NDIM, double>> u_var = new SideVariable<NDIM, double>("u");
+        Pointer<CellVariable<NDIM, double>> u_draw_var = new CellVariable<NDIM, double>("u_draw", NDIM);
+        Pointer<CellVariable<NDIM, double>> div_var = new CellVariable<NDIM, double>("div");
+
+        auto var_db = VariableDatabase<NDIM>::getDatabase();
+        Pointer<VariableContext> ctx = var_db->getContext("CTX");
+        const int ls_idx = var_db->registerVariableAndContext(ls_var, ctx, IntVector<NDIM>(4));
+        const int vol_idx = var_db->registerVariableAndContext(vol_var, ctx, IntVector<NDIM>(4));
+        const int u_idx = var_db->registerVariableAndContext(u_var, ctx, IntVector<NDIM>(0));
+        const int u_draw_idx = var_db->registerVariableAndContext(u_draw_var, ctx);
+        const int div_idx = var_db->registerVariableAndContext(div_var, ctx);
+
+        ComponentSelector comps;
+        comps.setFlag(ls_idx);
+        comps.setFlag(vol_idx);
+        comps.setFlag(u_idx);
+        comps.setFlag(u_draw_idx);
+        comps.setFlag(div_idx);
+
+        auto mesh_mapping = std::make_shared<GeneralBoundaryMeshMapping>(
+            "MeshMapping", app_initializer->getComponentDatabase("MeshMapping"), &mesh);
+        mesh_mapping->initializeEquationSystems();
+
+        gridding_algorithm->makeCoarsestLevel(patch_hierarchy, 0.0);
+        int tag_buffer = 1;
+        int ln = 0;
+        bool done = false;
+        while (!done && (gridding_algorithm->levelCanBeRefined(ln)))
+        {
+            gridding_algorithm->makeFinerLevel(patch_hierarchy, 0.0, 0.0, tag_buffer);
+            done = !patch_hierarchy->finerLevelExists(ln);
+            ++ln;
+        }
+
+// Uncomment to draw data.
+// #define DRAW_DATA 1
+#ifdef DRAW_DATA
+        Pointer<VisItDataWriter<NDIM>> visit_data_writer = app_initializer->getVisItDataWriter();
+        visit_data_writer->registerPlotQuantity("ls", "SCALAR", ls_idx);
+        visit_data_writer->registerPlotQuantity("vol", "SCALAR", vol_idx);
+        visit_data_writer->registerPlotQuantity("u", "VECTOR", u_draw_idx);
+        visit_data_writer->registerPlotQuantity("div", "SCALAR", div_idx);
+        std::unique_ptr<ExodusII_IO> mesh_output(new ExodusII_IO(*mesh_mapping->getBoundaryMesh()));
+#endif
+
+        // Allocate data
+        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->allocatePatchData(comps);
+        }
+
+        // Set up boundary data
+        const std::string div_sys_name = "div";
+        const std::string err_sys_name = "err";
+        EquationSystems* eq_sys = mesh_mapping->getMeshPartitioner()->getEquationSystems();
+        auto& div_sys = eq_sys->add_system<ExplicitSystem>(div_sys_name);
+        div_sys.add_variable(div_sys_name);
+        div_sys.assemble_before_solve = false;
+        div_sys.assemble();
+
+        auto& err_sys = eq_sys->add_system<ExplicitSystem>(err_sys_name);
+        err_sys.add_variable(err_sys_name);
+        err_sys.assemble_before_solve = false;
+        err_sys.assemble();
+
+        mesh_mapping->initializeFEData();
+
+        mesh_mapping->getMeshPartitioner()->setPatchHierarchy(patch_hierarchy);
+        mesh_mapping->getMeshPartitioner()->reinitElementMappings();
+
+        Pointer<CutCellMeshMapping> cut_cell_mapping =
+            new CutCellVolumeMeshMapping("CutCellMapping",
+                                         app_initializer->getComponentDatabase("CutCellMapping"),
+                                         mesh_mapping->getMeshPartitioners());
+        LSFromMesh ls_vol_fcn("ls", patch_hierarchy, cut_cell_mapping, true);
+        ls_vol_fcn.registerNormalReverseDomainId(0, 0);
+        ls_vol_fcn.updateVolumeAreaSideLS(
+            vol_idx, vol_var, IBTK::invalid_index, nullptr, IBTK::invalid_index, nullptr, ls_idx, ls_var, 0.0);
+
+        PointwiseFunction<PointwiseFunctions::StaggeredFcn> u_pt_fcn("UFcn", u_fcn);
+        PointwiseFunction<PointwiseFunctions::VectorFcn> u_draw_pt_fcn("UFcn", u_draw_fcn);
+        PointwiseFunction<PointwiseFunctions::ScalarFcn> div_pt_fcn("divFcn", div_fcn);
+
+        u_pt_fcn.setDataOnPatchHierarchy(u_idx, u_var, patch_hierarchy, 0.0);
+        u_draw_pt_fcn.setDataOnPatchHierarchy(u_draw_idx, u_draw_var, patch_hierarchy, 0.0);
+        div_pt_fcn.setDataOnPatchHierarchy(div_idx, div_var, patch_hierarchy, 0.0);
+
+        compute_divergence(mesh_mapping, div_sys_name, err_sys_name, u_idx, ls_idx, patch_hierarchy);
+
+        // Compute error
+        computeSurfaceErrors(mesh_mapping->getMeshPartitioner(), err_sys_name);
+
+#ifdef DRAW_DATA
+        visit_data_writer->writePlotData(patch_hierarchy, 1, 0.0);
+        mesh_output->write_timestep("mesh.ex", *mesh_mapping->getMeshPartitioner()->getEquationSystems(), 1, 0.0);
+#endif
+
+        // Deallocate data
+        for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->deallocatePatchData(comps);
+        }
+
+    } // cleanup dynamically allocated objects prior to shutdown
+    return 0;
+} // main

--- a/tests/reconstructions/divergence_2d.input
+++ b/tests/reconstructions/divergence_2d.input
@@ -1,0 +1,93 @@
+// constants
+PI = 3.14159265358979
+
+// physical parameters
+L   = 1.0
+RHO = 1.0
+K_TETHER   = 40.0
+
+R = 0.5
+MFAC = 0.5
+
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX = L/NFINEST
+
+ls_fcn {
+  function = "0.5-sqrt(X_0*X_0 + X_1*X_1)"
+}
+
+div_ops {
+  stencil_size = 12
+  rbf_order = "QUADRATIC"
+}
+
+MeshMapping {
+  max_level = MAX_LEVELS
+}
+
+CutCellMapping {
+  perturb_nodes = FALSE
+}
+
+Main {
+
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt", "ExodusII"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "new_viz_adv_diff2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_adv_diff2d"
+
+   data_dump_interval          = 0
+   data_dump_dirname           = "hier_data_IB2d"
+
+   timer_dump_interval = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = -2,-2
+   x_up = 2,2
+   periodic_dimension = 1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.9e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.9e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+//      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,3*N/4 - 1 )]
+      level_0 = [( 2,2 ),( N - 1,N - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/reconstructions/divergence_2d.output
+++ b/tests/reconstructions/divergence_2d.output
@@ -1,0 +1,7 @@
+Minimum volume on level:     0 is: 2.43515471605e-05
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 15.219919065
+Error at surface
+ L1-norm:  0.014203
+ L2-norm:  0.00953164
+ max-norm: 0.0193177

--- a/tests/reconstructions/fd_weights.cpp
+++ b/tests/reconstructions/fd_weights.cpp
@@ -95,7 +95,7 @@ main(int argc, char* argv[])
             for (int j = 0; j < num_pts; ++j) fd_pts[j] = ADS::Point(h * (base_fd_pts[j] - base_pt) + base_pt);
 
             std::vector<double> wgts;
-            Reconstruct::RBFFDReconstruct<ADS::Point>(
+            Reconstruct::RBFFD_reconstruct<ADS::Point>(
                 wgts, ADS::Point(base_pt), fd_pts, 3, dx.data(), rbf, L_rbf, nullptr, L_poly, nullptr);
 
             double approx = 0.0;


### PR DESCRIPTION
Moves the divergence calculations to the `Reconstruct` namespace. Also makes all functions have consistent naming conventions. Adds a callback function for pre-advection steps in the semi Lagrangian integrator.