### PR TITLE
Generalize divergence calculations

### DIFF
--- a/include/ADS/InterpDivergenceReconstructions.h
+++ b/include/ADS/InterpDivergenceReconstructions.h
@@ -1,0 +1,84 @@
+#ifndef included_ADS_InterpDivergenceReconstructions
+#define included_ADS_InterpDivergenceReconstructions
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include <ibamr/config.h>
+
+#include "ADS/AdvectiveReconstructionOperator.h"
+#include "ADS/CutCellVolumeMeshMapping.h"
+#include "ADS/ls_utilities.h"
+#include "ADS/reconstructions.h"
+
+#include "CellVariable.h"
+#include "SideVariable.h"
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+namespace ADS
+{
+/*!
+ * \brief Class InterpDivergenceReconstructions is a concrete implementation of an AdvectiveReconstructionOperator that
+ * computes the divergence of the flow field along path locations.
+ *
+ * This class first uses centered differences to compute a cell centered divergence from a side centered velocity field.
+ * Then, we use quadratic interpolants in the bulk and polyharmonic splines near the boundary to interpolate the
+ * resulting divergence.
+ *
+ * This operator does not use divergences that were computed by differences across a boundary.
+ */
+class InterpDivergenceReconstructions : public AdvectiveReconstructionOperator
+{
+public:
+    /*!
+     * \brief Class constructor.
+     */
+    InterpDivergenceReconstructions(std::string object_name, SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db);
+
+    /*!
+     * \brief Destructor.
+     */
+    ~InterpDivergenceReconstructions();
+
+    /*!
+     * \brief Initialize operator. This allocates scratch data for the interpolant.
+     */
+    void allocateOperatorState(SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> hierarchy,
+                               double current_time,
+                               double new_time) override;
+
+    /*!
+     * \brief Deinitialize operator
+     */
+    void deallocateOperatorState() override;
+
+    /*!
+     * \brief Compute N = div(Q_idx) at locations stored in path_idx. Q_idx must be a side centered quantity.
+     *
+     * This first computes a centered difference approximation to the divergence, then interpolates the resulting cell
+     * centered divergence to the path locations.
+     */
+    void applyReconstruction(int Q_idx, int N_idx, int path_idx) override;
+
+private:
+    /*!
+     * \brief Compute the reconstruction using only the level set to determine sides. This method assumes ghost cells
+     * are present and filled for Q_idx.
+     */
+    void applyReconstructionLS(int Q_idx, int N_idx, int path_idx);
+
+    SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> d_hierarchy;
+    Reconstruct::RBFPolyOrder d_rbf_order = Reconstruct::RBFPolyOrder::QUADRATIC;
+    unsigned int d_rbf_stencil_size = 12;
+
+    // Scratch data
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_u_scr_var;
+    int d_u_scr_idx = IBTK::invalid_index;
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_div_var;
+    int d_div_idx = IBTK::invalid_index;
+};
+} // namespace ADS
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif // #ifndef included_LS_InterpDivergenceReconstructions

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ ENDFOREACH()
 SET(CXX_SRC
     
     adv_ops/AdvectiveReconstructionOperator.cpp
+    adv_ops/InterpDivergenceReconstructions.cpp
     adv_ops/LagrangeReconstructions.cpp
     adv_ops/LagrangeStructureReconstructions.cpp
     adv_ops/LinearReconstructions.cpp

--- a/src/adv_ops/LagrangeStructureReconstructions.cpp
+++ b/src/adv_ops/LagrangeStructureReconstructions.cpp
@@ -146,7 +146,7 @@ LagrangeStructureReconstructions::applyReconstructionLS(const int Q_idx, const i
         Q_in_vecs[part] = Q_in_sys.current_local_solution.get();
         Q_in_dof_map_vecs[part] = &Q_in_sys.get_dof_map();
 
-        if (d_reconstruct_outside)
+        if (d_reconstruct_outside && !d_Q_out_sys_name.empty())
         {
             auto& Q_out_sys = eq_sys->get_system<ExplicitSystem>(d_Q_out_sys_name);
             Q_out_vecs[part] = Q_out_sys.current_local_solution.get();

--- a/tests/adv_ops/divergence.cpp
+++ b/tests/adv_ops/divergence.cpp
@@ -1,5 +1,6 @@
 #include <ibamr/config.h>
 
+#include <ADS/InterpDivergenceReconstructions.h>
 #include <ADS/LSFromLevelSet.h>
 #include <ADS/PointwiseFunction.h>
 #include <ADS/RBFDivergenceReconstructions.h>
@@ -100,7 +101,11 @@ main(int argc, char* argv[])
         comps.setFlag(div_err_idx);
         comps.setFlag(path_idx);
 
-        RBFDivergenceReconstructions div_ops("div_ops", input_db->getDatabase("div_ops"));
+        Pointer<AdvectiveReconstructionOperator> div_ops;
+        if (input_db->getBool("USE_RBF"))
+            div_ops = new RBFDivergenceReconstructions("div_ops", input_db->getDatabase("div_ops"));
+        else
+            div_ops = new InterpDivergenceReconstructions("div_ops", input_db->getDatabase("div_ops"));
 
         gridding_algorithm->makeCoarsestLevel(patch_hierarchy, 0.0);
         int tag_buffer = 1;
@@ -161,10 +166,10 @@ main(int argc, char* argv[])
 
         u_fcn.setDataOnPatchHierarchy(u_idx, u_var, patch_hierarchy, 0.0);
 
-        div_ops.setLSData(ls_idx, vol_idx, ls_idx, vol_idx);
-        div_ops.allocateOperatorState(patch_hierarchy, 0.0, 0.0);
-        div_ops.applyReconstruction(u_idx, div_idx, path_idx);
-        div_ops.deallocateOperatorState();
+        div_ops->setLSData(ls_idx, vol_idx, ls_idx, vol_idx);
+        div_ops->allocateOperatorState(patch_hierarchy, 0.0, 0.0);
+        div_ops->applyReconstruction(u_idx, div_idx, path_idx);
+        div_ops->deallocateOperatorState();
 
         // Compute error
         div_fcn.setDataOnPatchHierarchy(div_err_idx, div_var, patch_hierarchy, 0.0);

--- a/tests/adv_ops/divergence_2d.interp.input
+++ b/tests/adv_ops/divergence_2d.interp.input
@@ -1,21 +1,22 @@
 // grid spacing parameters
-MAX_LEVELS = 2                            // maximum number of levels in locally refined grid
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
 REF_RATIO  = 4                            // refinement ratio between levels
 N = 64                                    // coarsest grid spacing
 NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
 DX = 1.0/NFINEST
+USE_RBF = FALSE
 
 ls_fcn {
   function = "0.5-sqrt(X_0*X_0 + X_1*X_1)"
 }
 
 u {
-  function_0 = "sin(2*PI*X_0)*sin(2*PI*X_1)"
-  function_1 = "cos(2*PI*X_0)*cos(2*PI*X_1)"
+   function_0 = "(sin(0.5*PI*X_0)*sin(0.5*PI*X_1))^4.0"
+   function_1 = "(sin(0.5*PI*X_0)*sin(0.5*PI*X_1))^4.0"
 }
 
 div {
-  function = "0.0"
+   function = "2.0*PI*(cos(0.5*PI*X_1)*sin(0.5*PI*X_0)*(sin(0.5*PI*X_0)*sin(0.5*PI*X_1))^3)+2.0*PI*(cos(0.5*PI*X_0)*sin(0.5*PI*X_1)*(sin(0.5*PI*X_0)*sin(0.5*PI*X_1))^3)"
 }
 
 div_ops {

--- a/tests/adv_ops/divergence_2d.interp.output
+++ b/tests/adv_ops/divergence_2d.interp.output
@@ -1,0 +1,8 @@
+Setting Level set at time 0
+Minimum volume on level:     0 is: 1.90906107369e-05
+Total area found on level:   0 is: 0
+Total volume found on level: 0 is: 15.2166879665
+Computing error in divergence interpolation:
+ L1-norm:  0.0301892
+ L2-norm:  0.0117823
+ max-norm: 0.0102796

--- a/tests/adv_ops/divergence_2d.rbffd.input
+++ b/tests/adv_ops/divergence_2d.rbffd.input
@@ -1,0 +1,84 @@
+// grid spacing parameters
+MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
+REF_RATIO  = 4                            // refinement ratio between levels
+N = 64                                    // coarsest grid spacing
+NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
+DX = 1.0/NFINEST
+USE_RBF = TRUE
+
+ls_fcn {
+  function = "0.5-sqrt(X_0*X_0 + X_1*X_1)"
+}
+
+u {
+   function_0 = "(sin(0.5*PI*X_0)*sin(0.5*PI*X_1))^4.0"
+   function_1 = "(sin(0.5*PI*X_0)*sin(0.5*PI*X_1))^4.0"
+}
+
+div {
+   function = "2.0*PI*(cos(0.5*PI*X_1)*sin(0.5*PI*X_0)*(sin(0.5*PI*X_0)*sin(0.5*PI*X_1))^3)+2.0*PI*(cos(0.5*PI*X_0)*sin(0.5*PI*X_1)*(sin(0.5*PI*X_0)*sin(0.5*PI*X_1))^3)"
+}
+
+div_ops {
+  stencil_size = 12
+  rbf_order = "QUADRATIC"
+}
+
+Main {
+
+// log file parameters
+   log_file_name               = "output"
+   log_all_nodes               = FALSE
+
+// visualization dump parameters
+   viz_writer                  = "VisIt", "ExodusII"
+   viz_dump_interval           = 0
+   viz_dump_dirname            = "new_viz_adv_diff2d"
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 0
+   restart_dump_dirname        = "restart_adv_diff2d"
+
+   data_dump_interval          = 0
+   data_dump_dirname           = "hier_data_IB2d"
+
+   timer_dump_interval = 0
+}
+
+CartesianGeometry {
+   domain_boxes = [ (0,0),(N - 1,N - 1) ]
+   x_lo = -2,-2
+   x_up = 2,2
+   periodic_dimension = 1,1
+}
+
+GriddingAlgorithm {
+   max_levels = MAX_LEVELS
+   ratio_to_coarser {
+      level_1 = REF_RATIO,REF_RATIO
+      level_2 = REF_RATIO,REF_RATIO
+      level_3 = REF_RATIO,REF_RATIO
+   }
+   largest_patch_size {
+      level_0 = 512,512  // all finer levels will use same values as level_0
+   }
+   smallest_patch_size {
+      level_0 =   4,  4  // all finer levels will use same values as level_0
+   }
+   efficiency_tolerance = 0.9e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.9e0  // chop box if sum of volumes of smaller boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+//      level_0 = [( N/4,N/4 ),( 3*N/4 - 1,3*N/4 - 1 )]
+      level_0 = [( 2,2 ),( N - 1,N - 1 )]
+   }
+}
+
+LoadBalancer {
+   bin_pack_method     = "SPATIAL"
+   max_workload_factor = 1
+}

--- a/tests/adv_ops/divergence_2d.rbffd.output
+++ b/tests/adv_ops/divergence_2d.rbffd.output
@@ -2,10 +2,7 @@ Setting Level set at time 0
 Minimum volume on level:     0 is: 1.90906107369e-05
 Total area found on level:   0 is: 0
 Total volume found on level: 0 is: 15.2166879665
-Minimum volume on level:     1 is: 6.18370098313e-08
-Total area found on level:   1 is: 0
-Total volume found on level: 1 is: 14.2303557991
 Computing error in divergence interpolation:
- L1-norm:  0.0361951
- L2-norm:  0.0471447
- max-norm: 0.0943753
+ L1-norm:  0.0307964
+ L2-norm:  0.0121132
+ max-norm: 0.0208963

--- a/tests/reconstructions/divergence.cpp
+++ b/tests/reconstructions/divergence.cpp
@@ -145,7 +145,7 @@ compute_divergence(std::shared_ptr<GeneralBoundaryMeshMapping>& mesh_mapping,
         VectorNd x_idx;
         for (int d = 0; d < NDIM; ++d) x_idx[d] = (xpt[d] - xlow[d]) / dx[d] + idx_low(d);
         double div = ADS::Reconstruct::divergence(
-            x_idx, idx, ls, *u_data, *ls_data, ADS::Reconstruct::RBFPolyOrder::QUADRATIC, 12, dx, false);
+            x_idx, idx, ls, *u_data, *ls_data, ADS::Reconstruct::RBFPolyOrder::QUADRATIC, 12, dx);
 
         std::vector<dof_id_type> divu_dofs;
         divu_dof_map.dof_indices(node, divu_dofs);


### PR DESCRIPTION
Adds a new operator that first computes a central difference of the velocity, then interpolates the resulting divergence. This makes more sense to use with the INS solver because the centered difference operator is used for divergence constraints.