### PR TITLE
Have InternalBdryFill fill physical cells in correctly.

### DIFF
--- a/include/ADS/ExtrapolatedAdvDiffHierarchyIntegrator.h
+++ b/include/ADS/ExtrapolatedAdvDiffHierarchyIntegrator.h
@@ -25,11 +25,16 @@ namespace ADS
 {
 /*!
  * \brief Class ExtrapolatedAdvDiffHierarchyIntegrator is a specialization of the class
- * AdvDiffSemiImplicitHierarchyIntegrator. This class extrapolates concentration fields in the normal direction across
+ * AdvDiffSemiImplicitHierarchyIntegrator.
+ *
+ * This class extrapolates concentration fields in the normal direction across
  * immersed boundaries by solving an advection equation in which the velocity is given by the normal of the signed
  * distance function. In preprocessIntegrateHierarchy(), this class computes the level set corresponding to the immersed
  * boundary, converts the level set into a signed distance, and advects concentrations using the normal field. During
  * postprocessIntegrateHierarchy(), this class zeros values that appear on the unphysical side of the boundary.
+ *
+ * \Note This class should not be used with level sets that touch the physical boundary. Ghost cells are not currently
+ * set in a consistent way at physical boundaries.
  *
  */
 class ExtrapolatedAdvDiffHierarchyIntegrator : public IBAMR::AdvDiffSemiImplicitHierarchyIntegrator

--- a/src/integrators/ExtrapolatedAdvDiffHierarchyIntegrator.cpp
+++ b/src/integrators/ExtrapolatedAdvDiffHierarchyIntegrator.cpp
@@ -127,6 +127,7 @@ ExtrapolatedAdvDiffHierarchyIntegrator::initializeHierarchyIntegrator(Pointer<Pa
         static const IntVector<NDIM> ghosts = 1;
         int ls_idx;
         registerVariable(ls_idx, ls_var, ghosts, getCurrentContext());
+        if (d_visit_writer) d_visit_writer->registerPlotQuantity(ls_var->getName(), "SCALAR", ls_idx);
 
         // For each variable restricted to this level set, create an index to hold the current state.
         for (const auto& Q_var : d_ls_Q_map[ls_var])
@@ -257,7 +258,7 @@ ExtrapolatedAdvDiffHierarchyIntegrator::preprocessIntegrateHierarchy(const doubl
                 if ((*valid_data)(idx) == 1)
                 {
                     Box<NDIM> region(idx, idx);
-                    region.grow(10);
+                    region.grow(5);
                     for (NodeIterator<NDIM> ni2(region); ni2; ni2++)
                     {
                         const NodeIndex<NDIM>& idx2 = ni2();

--- a/tests/level_set/internal_bdry_fill_2d.channel.input
+++ b/tests/level_set/internal_bdry_fill_2d.channel.input
@@ -1,10 +1,33 @@
+PI = 3.1415926535
 // grid spacing parameters
 MAX_LEVELS = 1                            // maximum number of levels in locally refined grid
 REF_RATIO  = 4                            // refinement ratio between levels
 N = 32                                    // coarsest grid spacing
 NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
 DX = 3.0/NFINEST
-INTERFACE_TYPE = "DISK"
+INTERFACE_TYPE = "CHANNEL"
+
+THETA = 0.0//PI/18.0
+YLOW = 0.0
+YUP = 0.5
+
+Q_bc {
+  acoef_function_0 = "1.0"
+  acoef_function_1 = "0.0"
+  acoef_function_2 = "0.0"
+  acoef_function_3 = "0.0"
+
+  bcoef_function_0 = "0.0"
+  bcoef_function_1 = "1.0"
+  bcoef_function_2 = "1.0"
+  bcoef_function_3 = "1.0"
+
+  gcoef_function_0 = "0.0"
+  gcoef_function_1 = "0.0"
+  gcoef_function_2 = "0.0"
+  gcoef_function_3 = "0.0"
+}
+
 
 InternalFill {
 }
@@ -33,8 +56,8 @@ Main {
 
 CartesianGeometry {
    domain_boxes = [ (0,0),(N - 1,N - 1) ]
-   x_lo = -1.5,-1.5
-   x_up = 1.5,1.5
+   x_lo = 0.0, -0.5
+   x_up = 2.0, 1.5
    periodic_dimension = 0,0
 }
 

--- a/tests/level_set/internal_bdry_fill_2d.channel.output
+++ b/tests/level_set/internal_bdry_fill_2d.channel.output
@@ -1,0 +1,1 @@
+InternalFill: After 65 iterations, the solver converged to a tolerance of 8.64754e-06!

--- a/tests/level_set/internal_bdry_fill_2d.levels=2.input
+++ b/tests/level_set/internal_bdry_fill_2d.levels=2.input
@@ -4,6 +4,7 @@ REF_RATIO  = 2                            // refinement ratio between levels
 N = 32                                    // coarsest grid spacing
 NFINEST = (REF_RATIO^(MAX_LEVELS - 1))*N  // finest   grid spacing
 DX = 3.0/NFINEST
+INTERFACE_TYPE = "DISK"
 
 InternalFill {
 }

--- a/tests/level_set/internal_bdry_fill_2d.levels=2.output
+++ b/tests/level_set/internal_bdry_fill_2d.levels=2.output
@@ -1,1 +1,1 @@
-InternalFill: After 100 iterations, the solver converged to a tolerance of 8.61502e-06!
+InternalFill: After 81 iterations, the solver converged to a tolerance of 8.0106e-06!

--- a/tests/level_set/internal_bdry_fill_2d.output
+++ b/tests/level_set/internal_bdry_fill_2d.output
@@ -1,1 +1,1 @@
-InternalFill: After 44 iterations, the solver converged to a tolerance of 8.62534e-06!
+InternalFill: After 36 iterations, the solver converged to a tolerance of 6.58135e-06!


### PR DESCRIPTION
Also fixes the advection velocity computation.

Note that `ExtrapolatedAdvDiffHierarchyIntegrator` does not work correctly when the level set abuts the physical walls. The code that fills in boundary conditions needs to be aware of the extrapolated concentration fields.