### PR TITLE
Updates and warning fixes for IBAMR v0.17.

### DIFF
--- a/attest
+++ b/attest
@@ -307,7 +307,7 @@ class Test:
                     #   - [space][tab][newline]=,:;<>[](){}^ as separators
                     #     between numbers
                     numdiff_flags = ["-r", "1e-6", "-a", "1e-10", "-s",
-                                     "' \\t\\n=,:;<>[](){}^'"]
+                                     "' \\t\\n=,:;<>[](){}^'!"]
                     diff_result = subprocess.run(
                         [self._parameters.numdiff] + numdiff_flags +
                         [self.output_file, temporary_directory + os.sep

--- a/include/ADS/libmesh_utilities.h
+++ b/include/ADS/libmesh_utilities.h
@@ -89,11 +89,9 @@ collectActivePatchElements(std::vector<std::vector<libMesh::Elem*>>& active_patc
     // be a bit paranoid by computing bounding boxes for elements as the union
     // of the bounding box of the nodes and the bounding box of the quadrature
     // points:
-    const std::vector<IBTK::libMeshWrappers::BoundingBox> local_bboxes =
-        IBTK::get_local_element_bounding_boxes(mesh, X_system);
+    const std::vector<libMesh::BoundingBox> local_bboxes = IBTK::get_local_element_bounding_boxes(mesh, X_system);
 
-    const std::vector<IBTK::libMeshWrappers::BoundingBox> global_bboxes =
-        IBTK::get_global_element_bounding_boxes(mesh, local_bboxes);
+    const std::vector<libMesh::BoundingBox> global_bboxes = IBTK::get_global_element_bounding_boxes(mesh, local_bboxes);
 
     int local_patch_num = 0;
     for (SAMRAI::hier::PatchLevel<NDIM>::Iterator p(level); p; p++, ++local_patch_num)
@@ -103,7 +101,7 @@ collectActivePatchElements(std::vector<std::vector<libMesh::Elem*>>& active_patc
         const SAMRAI::tbox::Pointer<SAMRAI::geom::CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
         const double* const dx = pgeom->getDx();
         // TODO: reimplement this with an rtree description of SAMRAI's patches
-        IBTK::libMeshWrappers::BoundingBox patch_bbox;
+        libMesh::BoundingBox patch_bbox;
         for (unsigned int d = 0; d < NDIM; ++d)
         {
             patch_bbox.first(d) = pgeom->getXLower()[d] - dx[d] * ghost_width[d];
@@ -116,7 +114,7 @@ collectActivePatchElements(std::vector<std::vector<libMesh::Elem*>>& active_patc
         }
 
         auto el_it = mesh.active_elements_begin();
-        for (const IBTK::libMeshWrappers::BoundingBox& bbox : global_bboxes)
+        for (const libMesh::BoundingBox& bbox : global_bboxes)
         {
 #if LIBMESH_VERSION_LESS_THAN(1, 2, 0)
             if (bbox.intersect(patch_bbox)) elems.insert(*el_it);

--- a/src/integrators/AdvDiffImplicitIntegrator.cpp
+++ b/src/integrators/AdvDiffImplicitIntegrator.cpp
@@ -134,7 +134,7 @@ AdvDiffImplicitIntegrator::initializeHierarchyIntegrator(Pointer<PatchHierarchy<
     // Do some error checking.
     for (const auto& Q_var : d_Q_implicit_vars)
     {
-        if (d_Q_F_map.count(Q_var) > 0)
+        if (d_Q_F_map.count(Q_var) > 0 && d_Q_F_map.at(Q_var))
         {
             TBOX_WARNING("Variable " << Q_var->getName()
                                      << " had a source variable associated with it but is listed as an implicit "

--- a/src/integrators/SBIntegrator.cpp
+++ b/src/integrators/SBIntegrator.cpp
@@ -108,16 +108,16 @@ SBIntegrator::integrateHierarchy(Pointer<VariableContext> ctx, const double curr
                     std::vector<double> sf_base_cur_vals, sf_base_new_vals;
                     for (unsigned int l = 0; l < sf_names.size(); ++l)
                     {
-                        IBTK::get_nodal_dof_indices(*sf_dof_maps[l], node, 0, sf_dofs);
+                        sf_dof_maps[l]->dof_indices(node, sf_dofs, 0);
                         sf_cur_vals.push_back((*sf_cur_vecs[l])(sf_dofs[0]));
                         sf_old_vals.push_back((*sf_old_vecs[l])(sf_dofs[0]));
                     }
                     for (unsigned int l = 0; l < fl_names.size(); ++l)
                     {
-                        IBTK::get_nodal_dof_indices(*fl_dof_maps[l], node, 0, fl_dofs);
+                        fl_dof_maps[l]->dof_indices(node, fl_dofs, 0);
                         fl_vals.push_back((*fl_vecs[l])(fl_dofs[0]));
                     }
-                    IBTK::get_nodal_dof_indices(sf_base_dof_map, node, 0, sf_base_dofs);
+                    sf_base_dof_map.dof_indices(node, sf_base_dofs, 0);
                     double sf_cur_val = (*sf_base_cur_vec)(sf_base_dofs[0]);
                     sf_cur_val +=
                         dt * rcn_fcn_ctx.first(sf_cur_val, fl_vals, sf_cur_vals, current_time, rcn_fcn_ctx.second);

--- a/src/reconstructions/reconstructions.cpp
+++ b/src/reconstructions/reconstructions.cpp
@@ -203,8 +203,6 @@ least_squares_reconstruction(IBTK::VectorNd x_loc,
     TBOX_ASSERT(vol_data.getGhostBox().contains(box));
 #endif
 
-    const CellIndex<NDIM>& idx_low = patch->getBox().lower();
-
     std::vector<double> Q_vals;
     std::vector<VectorNd> X_vals;
 

--- a/src/surfaces/FEToHierarchyMapping.cpp
+++ b/src/surfaces/FEToHierarchyMapping.cpp
@@ -382,7 +382,7 @@ FEToHierarchyMapping::reinitElementMappings(const IntVector<NDIM>& ghost_width)
                     bool inside_patch = true;
                     for (unsigned int d = 0; d < NDIM; ++d)
                     {
-                        IBTK::get_nodal_dof_indices(X_dof_map, n, d, X_idxs);
+                        X_dof_map.dof_indices(n, X_idxs, d);
                         X[d] = X_local_soln[X_petsc_vec->map_global_to_local_index(X_idxs[0])];
                         // Due to how SAMRAI computes patch boundaries, even if the
                         // patch's domain is [0, 1]^2 the patches on the boundary

--- a/src/surfaces/SBSurfaceFluidCouplingManager.cpp
+++ b/src/surfaces/SBSurfaceFluidCouplingManager.cpp
@@ -311,7 +311,7 @@ SBSurfaceFluidCouplingManager::interpolateToBoundary(Pointer<CellVariable<NDIM, 
             bool inside_patch = true;
             for (unsigned int d = 0; d < NDIM; ++d)
             {
-                IBTK::get_nodal_dof_indices(X_dof_map, n, d, X_idxs);
+                X_dof_map.dof_indices(n, X_idxs, d);
                 X[d] = X_local_soln[X_petsc_vec->map_global_to_local_index(X_idxs[0])];
                 inside_patch = inside_patch && (X[d] >= patch_x_low[d]) &&
                                ((X[d] < patch_x_up[d]) || (touches_upper_regular_bdry[d] && X[d] <= patch_x_up[d]));
@@ -322,7 +322,7 @@ SBSurfaceFluidCouplingManager::interpolateToBoundary(Pointer<CellVariable<NDIM, 
                 X_node.insert(X_node.end(), &X[0], &X[0] + NDIM);
                 for (unsigned int i = 0; i < n_vars; ++i)
                 {
-                    IBTK::get_nodal_dof_indices(fl_dof_map, n, i, fl_idxs);
+                    fl_dof_map.dof_indices(n, fl_idxs, i);
                     fl_node_idxs.insert(fl_node_idxs.end(), fl_idxs.begin(), fl_idxs.end());
                 }
             }
@@ -343,7 +343,6 @@ SBSurfaceFluidCouplingManager::interpolateToBoundary(Pointer<CellVariable<NDIM, 
             // Use a MLS linear approximation to evaluate data on structure
             const CellIndex<NDIM> cell_idx =
                 IBTK::IndexUtilities::getCellIndex(&X_node[NDIM * i], pgeom, patch->getBox());
-            const CellIndex<NDIM>& idx_low = patch->getBox().lower();
             VectorNd x_loc = {
                 X_node[NDIM * i],
                 X_node[NDIM * i + 1]

--- a/tests/examples/semi_lagrangian_01.cpp
+++ b/tests/examples/semi_lagrangian_01.cpp
@@ -207,7 +207,6 @@ main(int argc, char* argv[])
         const int timer_dump_interval = app_initializer->getTimerDumpInterval();
 
         const bool dump_postproc_data = app_initializer->dumpPostProcessingData();
-        const int dump_postproc_interval = app_initializer->getPostProcessingDataDumpInterval();
         const std::string postproc_data_dump_dirname = app_initializer->getPostProcessingDataDumpDirectory();
         if (dump_postproc_data && !postproc_data_dump_dirname.empty())
         {

--- a/tests/integrators/implicit_integrator_2d.backward_euler.output
+++ b/tests/integrators/implicit_integrator_2d.backward_euler.output
@@ -1,11 +1,3 @@
-Warning in file ``/home/abarret/work/ADS/AdvDiffSolvers/src/integrators/AdvDiffImplicitIntegrator.cpp'' at line 138
-WARNING MESSAGE: 
-Variable Z had a source variable associated with it but is listed as an implicit variable. Removing the source variable!
-
-Warning in file ``/home/abarret/work/ADS/AdvDiffSolvers/src/integrators/AdvDiffImplicitIntegrator.cpp'' at line 138
-WARNING MESSAGE: 
-Variable g had a source variable associated with it but is listed as an implicit variable. Removing the source variable!
-
 AdvDiffIntegrator::initializePatchHierarchy(): tag_buffer = 0
 input_db {
    RHO                         = 1                          // input not used

--- a/tests/integrators/implicit_integrator_2d.trapezoidal_rule.output
+++ b/tests/integrators/implicit_integrator_2d.trapezoidal_rule.output
@@ -1,11 +1,3 @@
-Warning in file ``/home/abarret/work/ADS/AdvDiffSolvers/src/integrators/AdvDiffImplicitIntegrator.cpp'' at line 138
-WARNING MESSAGE: 
-Variable Z had a source variable associated with it but is listed as an implicit variable. Removing the source variable!
-
-Warning in file ``/home/abarret/work/ADS/AdvDiffSolvers/src/integrators/AdvDiffImplicitIntegrator.cpp'' at line 138
-WARNING MESSAGE: 
-Variable g had a source variable associated with it but is listed as an implicit variable. Removing the source variable!
-
 AdvDiffIntegrator::initializePatchHierarchy(): tag_buffer = 0
 input_db {
    RHO                         = 1                          // input not used

--- a/tests/utilities/pointwise_function.cpp
+++ b/tests/utilities/pointwise_function.cpp
@@ -32,7 +32,6 @@ main(int argc, char* argv[])
 {
     // Initialize PETSc, MPI, and SAMRAI.
     IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
-    const LibMeshInit& init = ibtk_init.getLibMeshInit();
 
     // Suppress a warning
     SAMRAI::tbox::Logger::getInstance()->setWarning(false);


### PR DESCRIPTION
Note that `attest` has been updated to allow for ! to be a separator for numbers.